### PR TITLE
Add line-height to TooltipContent

### DIFF
--- a/src/components/Tooltip/style.scss
+++ b/src/components/Tooltip/style.scss
@@ -17,6 +17,7 @@
     background-color: $ui-tooltip-color;
     border-color: $ui-tooltip-color;
     color: #fff;
+    line-height: 18px;
   }
 
   &__arrow {


### PR DESCRIPTION
Multiline tooltip content looked bad on IE, so I checked in Zeplin and it appears that the TooltipContent misses the `line-height` declaration from the design. This PR fixes that.