### PR TITLE
Remove max-width on buttons

### DIFF
--- a/src/components/Button/style.scss
+++ b/src/components/Button/style.scss
@@ -1,7 +1,6 @@
 @import '../../scss/variables/colors';
 
 .btn {
-  max-width: 320px;
   position: relative;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
I wanted to use the design system button in my components, but since button has max-width, it breaks with `fullWidth` property.


Example:
<img width="927" alt="image" src="https://user-images.githubusercontent.com/1757436/53630833-546c3900-3c11-11e9-818a-70126538ff25.png">


I'm suggesting removing this whatsoever and adding this only when necessary.

