### PR TITLE
added Element shims for SSR

### DIFF
--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -172,7 +172,7 @@ Dropdown.propTypes = {
     'top-start'
   ]),
   positionFixed: PropTypes.bool,
-  referenceElement: PropTypes.instanceOf(Element),
+  referenceElement: PropTypes.instanceOf(typeof Element === "undefined" ? function () { } : Element),
   triggerRenderer: PropTypes.func.isRequired,
   zIndex: PropTypes.number,
   onClose: PropTypes.func

--- a/src/components/MultiSelectField/MultiSelectList.js
+++ b/src/components/MultiSelectField/MultiSelectList.js
@@ -222,7 +222,7 @@ MultiSelectList.propTypes = {
   onEnterKey: PropTypes.func,
   focusedItemKey: PropTypes.string,
   onFocusedItemChange: PropTypes.func,
-  listRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  listRef: PropTypes.shape({ current: PropTypes.instanceOf(typeof Element === "undefined" ? function () { } : Element) }),
   toggleAllOptions: PropTypes.shape({
     onToggleAll: PropTypes.func.isRequired,
     selectLabel: PropTypes.string,

--- a/src/components/MultiSelectField/Search.js
+++ b/src/components/MultiSelectField/Search.js
@@ -45,7 +45,7 @@ const Search = props => {
 };
 
 Search.propTypes = {
-  inputRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  inputRef: PropTypes.shape({ current: PropTypes.instanceOf(typeof Element === "undefined" ? function () { } : Element) }),
   placeholder: PropTypes.string,
   value: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/components/SelectField/Search.js
+++ b/src/components/SelectField/Search.js
@@ -39,7 +39,7 @@ const Search = props => {
 };
 
 Search.propTypes = {
-  inputRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  inputRef: PropTypes.shape({ current: PropTypes.instanceOf(typeof Element === "undefined" ? function () { } : Element) }),
   isVisible: PropTypes.bool,
   placeholder: PropTypes.string,
   value: PropTypes.string,

--- a/src/components/SelectField/SelectList.js
+++ b/src/components/SelectField/SelectList.js
@@ -173,7 +173,7 @@ SelectList.propTypes = {
   onEnterKey: PropTypes.func,
   focusedItemKey: PropTypes.string,
   onFocusedItemChange: PropTypes.func,
-  listRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  listRef: PropTypes.shape({ current: PropTypes.instanceOf(typeof Element === "undefined" ? function () { } : Element) })
 };
 
 export default SelectList;


### PR DESCRIPTION
Using `Element` breaks SSR (e.g. with Gatsby). We can simply shim `Element` to fix this.

Wasn't sure if we should move the shim to a separate file and import something like `SSRSafeElement` or leave it inline. 

I stuck with inline as it's a bit more straightforward. @kamilmateusiak what's your preference on this?