### PR TITLE
Fix modal footer shrinking

### DIFF
--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -92,7 +92,7 @@
     justify-content: flex-end;
     padding: 16px 20px;
     box-sizing: border-box;
-    flex-grow: 0;
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
Fix modal footer shrinking when modal body had lots of content.
![image (2)](https://user-images.githubusercontent.com/24607370/54916830-b1020180-4efa-11e9-83e3-ddda5ae1fa8a.png)
![Pasted_image_at_2019-03-25__11_23_AM](https://user-images.githubusercontent.com/24607370/54916857-bd865a00-4efa-11e9-9fe1-15b1be0632b9.png)
