### PR TITLE
Modals outside click fix

### DIFF
--- a/src/components/Modal/ModalBase.js
+++ b/src/components/Modal/ModalBase.js
@@ -56,7 +56,6 @@ class ModalBase extends React.Component {
   };
 
   modalRef = React.createRef();
-  overlayRef = React.createRef();
 
   render() {
     const {
@@ -74,7 +73,6 @@ class ModalBase extends React.Component {
 
     return (
       <div
-        ref={this.overlayRef}
         onClick={this.onOverlayClick}
         className={cx(
           `${baseClass}__overlay`,


### PR DESCRIPTION
In some cases listener on document click caused problems. The overlay will be always attached to Modal so we decided to use it as the onClick event target.