### PR TITLE
Unlocking html `type` prop in the Button component

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -22,11 +22,12 @@ const Button = React.forwardRef((props, ref) => {
     ariaControls,
     ariaExpanded,
     className,
+    type: htmlType,
     ...buttonProps
   } = props;
 
   const isDisabled = disabled || loading;
-  const type = submit ? 'submit' : 'button';
+  const type = submit ? 'submit' : htmlType || 'button';
   let buttonType = null;
 
   if (primary) {
@@ -92,6 +93,7 @@ Button.propTypes = {
   /**
    * Sets button width to max-width=320px
    */
+  type: PropTypes.string,
   fullWidth: PropTypes.bool,
   onClick: PropTypes.func,
   onFocus: PropTypes.func,


### PR DESCRIPTION
It's pretty easy to use HTML prop `type`. Unfortunately, we are ignoring it completely in the Button component. It caused some problems today: https://github.com/livechat/my.livechatinc.com/pull/10696 

We should support `type` and `submit` props. 
