### PR TITLE
Add onItemFocus to DropdownListItem

### DIFF
--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -90,9 +90,18 @@ class DropdownList extends React.PureComponent {
   };
 
   changeFocusedElement = id => {
-    this.setState({
-      focusedElement: id
-    });
+    this.setState(
+      {
+        focusedElement: id
+      },
+      () => {
+        const focusedItem = this.props.items.find(item => item.itemId === id);
+
+        if (focusedItem && focusedItem.onItemFocus) {
+          focusedItem.onItemFocus(focusedItem.itemdId);
+        }
+      }
+    );
   };
 
   scrollItems = () => {
@@ -186,6 +195,7 @@ DropdownList.propTypes = {
       divider: PropTypes.bool,
       icon: PropTypes.node,
       onItemSelect: PropTypes.func,
+      onItemFocus: PropTypes.func,
       isDisabled: PropTypes.bool,
       isSelected: PropTypes.bool,
       props: PropTypes.object

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -5,21 +5,22 @@ type ItemId = string | number;
 
 interface IDropdownItemBase extends React.HTMLAttributes<HTMLLIElement> {
   icon?: React.ReactNode;
-  itemId: ItemId,
+  itemId: ItemId;
   isDisabled?: boolean;
   isSelected?: boolean;
   divider?: boolean;
+  onItemFocus?: (itemId: ItemId) => void;
   onItemSelect?: (itemId: ItemId) => void;
-} 
+}
 
 export interface IGetItemBodyPayload extends IDropdownItemBase {
   content: React.ReactNode;
   isFocused?: boolean;
   props: {
-    [key: string]: any
+    [key: string]: any;
   };
   onMouseOverItem?: (itemId: ItemId) => void;
-} 
+}
 
 export interface IDropdownProps {
   children: React.ReactNode;
@@ -33,7 +34,7 @@ export interface IDropdownProps {
   positionFixed?: boolean;
   referenceElement?: PopperJS.ReferenceObject;
   zIndex?: number;
-  triggerRenderer?: (props: {ref: React.Ref<any>}) => void;
+  triggerRenderer?: (props: { ref: React.Ref<any> }) => void;
   onClose: () => void;
 }
 
@@ -45,7 +46,8 @@ export interface IDropdownItem extends IDropdownItemBase {
   };
 }
 
-export interface IDropdownListProps extends React.HTMLAttributes<HTMLUListElement> {
+export interface IDropdownListProps
+  extends React.HTMLAttributes<HTMLUListElement> {
   className?: string;
   items: IDropdownItem[];
   getItemBody?(payload: IGetItemBodyPayload): React.ReactNode;


### PR DESCRIPTION
Currently, there is no easy possibility to get information which item is focused. I've added `onItemFocus` in a similar manner as in `onItemSelect`.