### PR TITLE
Handling Dropdown content resize

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
     "react-day-picker": "^7.2.4",
     "react-material-icon-svg": "1.7.0",
     "react-popper": "^1.3.3",
-    "react-transition-group": "^2.4.0"
+    "react-transition-group": "^2.4.0",
+    "resize-observer-polyfill": "^1.5.1"
   },
   "postcss": {},
   "jest": {

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -15,7 +15,8 @@ class Dropdown extends React.PureComponent {
     modifiers: {},
     zIndex: 20,
     closeOnEscPress: true,
-    closeOnEnterPress: false
+    closeOnEnterPress: false,
+    shouldUpdateOnResize: false
   };
 
   static buildPopperModifiers(modifiers) {

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -86,15 +86,26 @@ class Dropdown extends React.PureComponent {
   };
 
   handleKeyDown = event => {
-    if (this.props.onClose) {
-      const isEscKeyPressed = event.keyCode === KeyCodes.esc;
-      const isEnterKeyPressed = event.keyCode === KeyCodes.enter;
+    const { keyCode } = event;
+    const {
+      closeKeyCodes,
+      closeOnEnterPress,
+      closeOnEscPress,
+      onClose
+    } = this.props;
+
+    if (onClose) {
+      const isEscKeyPressed = keyCode === KeyCodes.esc;
+      const isEnterKeyPressed = keyCode === KeyCodes.enter;
+      const isCustomCloseKeyPressed =
+        closeKeyCodes && closeKeyCodes.includes(keyCode);
 
       if (
-        (this.props.closeOnEscPress && isEscKeyPressed) ||
-        (this.props.closeOnEnterPress && isEnterKeyPressed)
+        (closeOnEscPress && isEscKeyPressed) ||
+        (closeOnEnterPress && isEnterKeyPressed) ||
+        isCustomCloseKeyPressed
       ) {
-        this.props.onClose();
+        onClose();
         if (this.triggerRef) {
           this.triggerRef.focus();
         }
@@ -211,6 +222,10 @@ Dropdown.propTypes = {
   className: PropTypes.string,
   closeOnEscPress: PropTypes.bool,
   closeOnEnterPress: PropTypes.bool,
+  /**
+   * you can specify which key press should trigger Dropdown close
+   */
+  closeKeyCodes: PropTypes.arrayOf(PropTypes.number),
   eventsEnabled: PropTypes.bool,
   isVisible: PropTypes.bool.isRequired,
   modifiers: PropTypes.object,

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -203,7 +203,7 @@ class Dropdown extends React.PureComponent {
         {isVisible && (
           <Popper
             innerRef={this.setPopupRef}
-            placement={placement || 'bottom-start'}
+            placement={placement}
             modifiers={computedModifiers}
             eventsEnabled={eventsEnabled}
             positionFixed={positionFixed}
@@ -266,6 +266,7 @@ Dropdown.defaultProps = {
   zIndex: 20,
   closeOnEscPress: true,
   closeOnEnterPress: false,
+  placement: 'bottom-start',
   shouldUpdateOnResize: false
 };
 

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -104,6 +104,10 @@ class Dropdown extends React.PureComponent {
     }
   };
 
+  handleComponentForcedUpdate() {
+    this.forceUpdate();
+  }
+
   addEventHandlers = () => {
     document.addEventListener('keydown', this.handleKeyDown, true);
     document.addEventListener('click', this.handleDocumentClick);
@@ -115,7 +119,13 @@ class Dropdown extends React.PureComponent {
   };
 
   render() {
-    const { children, className, triggerRenderer, isVisible } = this.props;
+    const {
+      children,
+      className,
+      triggerRenderer,
+      isVisible,
+      contentRenderer
+    } = this.props;
 
     const mergedClassNames = getMergedClassNames(
       cx({
@@ -149,7 +159,10 @@ class Dropdown extends React.PureComponent {
                 data-placement={placement}
                 className={mergedClassNames}
               >
-                {children}
+                {children ||
+                  contentRenderer({
+                    forceUpdate: this.handleComponentForcedUpdate
+                  })}
                 {modifiers.arrow.enabled && (
                   <div
                     ref={arrowProps.ref}
@@ -168,13 +181,15 @@ class Dropdown extends React.PureComponent {
 }
 
 Dropdown.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  contentRenderer: PropTypes.func,
   className: PropTypes.string,
   closeOnEscPress: PropTypes.bool,
   closeOnEnterPress: PropTypes.bool,
   eventsEnabled: PropTypes.bool,
   isVisible: PropTypes.bool.isRequired,
   modifiers: PropTypes.object,
+  dropdownItemsCount: PropTypes.number,
   placement: PropTypes.oneOf([
     'auto',
     'auto-end',

--- a/src/components/Dropdown/Dropdown.js
+++ b/src/components/Dropdown/Dropdown.js
@@ -11,14 +11,6 @@ import { KeyCodes } from '../../constants/keyCodes';
 const cx = cssClassNames.bind(styles);
 
 class Dropdown extends React.PureComponent {
-  static defaultProps = {
-    modifiers: {},
-    zIndex: 20,
-    closeOnEscPress: true,
-    closeOnEnterPress: false,
-    shouldUpdateOnResize: false
-  };
-
   static buildPopperModifiers(modifiers) {
     const { offset, flip, hide, preventOverflow, arrow, ...rest } = modifiers;
     return {
@@ -245,13 +237,21 @@ Dropdown.propTypes = {
     clientHeight: PropTypes.number.isRequired
   }),
   /**
-   * Set `true` when it's possible that dropdown content will resize
+   * Pass `true` when it's possible that content of your dropdown will resize
    * (e.g removing list items on select)
    */
   shouldUpdateOnResize: PropTypes.bool,
   triggerRenderer: PropTypes.func,
   zIndex: PropTypes.number,
   onClose: PropTypes.func
+};
+
+Dropdown.defaultProps = {
+  modifiers: {},
+  zIndex: 20,
+  closeOnEscPress: true,
+  closeOnEnterPress: false,
+  shouldUpdateOnResize: false
 };
 
 export default Dropdown;

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -9,9 +9,13 @@ import findNextFocusableItem from '../../helpers/find-next-focusable-item';
 const baseClass = 'dropdown';
 
 class DropdownList extends React.PureComponent {
-  state = {
-    focusedElement: null
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      focusedElement: props.defaultFocusedItemId
+    };
+  }
 
   componentDidMount() {
     document.addEventListener('keydown', this.onKeydown);
@@ -31,8 +35,8 @@ class DropdownList extends React.PureComponent {
       this.handleArrowKeyUse(event);
     }
 
-    if (keyCode === KeyCodes.enter) {
-      this.handleEnterKeyUse();
+    if (this.isItemSelectKeyCode(keyCode)) {
+      this.handleSelectKeyUse();
     }
   };
 
@@ -48,7 +52,7 @@ class DropdownList extends React.PureComponent {
     return this.hoverCallbacks[itemKey];
   };
 
-  handleEnterKeyUse = () => {
+  handleSelectKeyUse = () => {
     const { focusedElement } = this.state;
 
     if (focusedElement !== null) {
@@ -102,6 +106,16 @@ class DropdownList extends React.PureComponent {
         }
       }
     );
+  };
+
+  isItemSelectKeyCode = keyCode => {
+    const { itemSelectKeyCodes } = this.props;
+
+    if (itemSelectKeyCodes && itemSelectKeyCodes.includes(keyCode)) {
+      return true;
+    }
+
+    return false;
   };
 
   scrollItems = () => {
@@ -189,6 +203,10 @@ class DropdownList extends React.PureComponent {
 
 DropdownList.propTypes = {
   className: PropTypes.string,
+  defaultFocusedItemId: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
   items: PropTypes.arrayOf(
     PropTypes.shape({
       className: PropTypes.string,
@@ -205,7 +223,15 @@ DropdownList.propTypes = {
     })
   ).isRequired,
   getItemBody: PropTypes.func,
-  onScroll: PropTypes.func
+  onScroll: PropTypes.func,
+  /**
+   * you can specify which key press should trigger list item select
+   */
+  itemSelectKeyCodes: PropTypes.arrayOf(PropTypes.number)
+};
+
+DropdownList.defaultProps = {
+  itemSelectKeyCodes: [KeyCodes.enter]
 };
 
 export default DropdownList;

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -36,6 +36,7 @@ class DropdownList extends React.PureComponent {
     }
 
     if (this.isItemSelectKeyCode(keyCode)) {
+      event.preventDefault();
       this.handleSelectKeyUse();
     }
   };
@@ -156,7 +157,13 @@ class DropdownList extends React.PureComponent {
   listRef = React.createRef();
 
   render() {
-    const { className, items, getItemBody, ...restProps } = this.props;
+    const {
+      className,
+      items,
+      getItemBody,
+      itemSelectKeyCodes,
+      ...restProps
+    } = this.props;
 
     const mergedClassNames = getMergedClassNames(
       styles[`${baseClass}__list`],

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -13,7 +13,7 @@ class DropdownList extends React.PureComponent {
     super(props);
 
     this.state = {
-      focusedElement: (props.items[0] && props.items[0].itemId) || null,
+      focusedElement: this.getFirstFocusableItemId(),
       itemsCount: props.items.length
     };
   }
@@ -24,7 +24,7 @@ class DropdownList extends React.PureComponent {
       props.items.length !== state.itemsCount
     ) {
       return {
-        focusedElement: (props.items[0] && props.items[0].itemId) || null,
+        focusedElement: this.getFirstFocusableItemId(),
         itemsCount: props.items.length
       };
     }
@@ -65,6 +65,15 @@ class DropdownList extends React.PureComponent {
     }
 
     return this.hoverCallbacks[itemKey];
+  };
+
+  getFirstFocusableItemId = () => {
+    const focusableItem = this.props.items.find(item => !item.isDisabled);
+
+    if (!focusableItem) {
+      return null;
+    }
+    return focusableItem.itemId;
   };
 
   handleSelectKeyUse = () => {

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -13,8 +13,22 @@ class DropdownList extends React.PureComponent {
     super(props);
 
     this.state = {
-      focusedElement: props.defaultFocusedItemId
+      focusedElement: (props.items[0] && props.items[0].itemId) || null,
+      itemsCount: props.items.length
     };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (
+      props.autoFocusOnItemsCountChange &&
+      props.items.length !== state.itemsCount
+    ) {
+      return {
+        focusedElement: (props.items[0] && props.items[0].itemId) || null,
+        itemsCount: props.items.length
+      };
+    }
+    return null;
   }
 
   componentDidMount() {
@@ -162,6 +176,7 @@ class DropdownList extends React.PureComponent {
       items,
       getItemBody,
       itemSelectKeyCodes,
+      autoFocusOnItemsCountChange,
       ...restProps
     } = this.props;
 
@@ -209,6 +224,7 @@ class DropdownList extends React.PureComponent {
 }
 
 DropdownList.propTypes = {
+  autoFocusOnItemsCountChange: PropTypes.bool,
   className: PropTypes.string,
   defaultFocusedItemId: PropTypes.oneOfType([
     PropTypes.string,

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -235,10 +235,6 @@ class DropdownList extends React.PureComponent {
 DropdownList.propTypes = {
   autoFocusOnItemsCountChange: PropTypes.bool,
   className: PropTypes.string,
-  defaultFocusedItemId: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number
-  ]),
   items: PropTypes.arrayOf(
     PropTypes.shape({
       className: PropTypes.string,

--- a/src/components/Dropdown/DropdownList.test.js
+++ b/src/components/Dropdown/DropdownList.test.js
@@ -14,14 +14,14 @@ const generateItems = (length = 10) =>
     onItemSelect: jest.fn()
   }));
 
-describe('Archives | Components | FiltersMenu', () => {
+describe('Components | DropdownList', () => {
   let items;
 
   beforeEach(() => {
     items = generateItems(4);
   });
 
-  it('renders correctly', () => {
+  it('renders correctly four items with autofocused second item', () => {
     const renderer = new ShallowRenderer();
     const component = renderer.render(<DropdownList items={items} />);
 

--- a/src/components/Dropdown/DropdownListItem.js
+++ b/src/components/Dropdown/DropdownListItem.js
@@ -12,6 +12,7 @@ const baseClass = 'dropdown__list-item';
 class DropdownListItem extends React.PureComponent {
   handleClick = e => {
     if (!this.props.isDisabled && this.props.onItemSelect) {
+      e.nativeEvent.stopImmediatePropagation();
       this.props.onItemSelect(this.props.itemId);
     }
     if (this.props.onClick) {

--- a/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
@@ -3,11 +3,6 @@
 exports[`Archives | Components | FiltersMenu renders correctly 1`] = `
 <ul
   className="dropdown__list"
-  itemSelectKeyCodes={
-    Array [
-      13,
-    ]
-  }
   onScroll={[Function]}
   tabIndex={0}
 >
@@ -21,7 +16,7 @@ exports[`Archives | Components | FiltersMenu renders correctly 1`] = `
       />
     }
     isDisabled={true}
-    isFocused={false}
+    isFocused={true}
     isSelected={false}
     itemId={1}
     onItemSelect={[MockFunction]}

--- a/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Archives | Components | FiltersMenu renders correctly 1`] = `
+exports[`Components | DropdownList renders correctly four items with autofocused second item 1`] = `
 <ul
   className="dropdown__list"
   onScroll={[Function]}

--- a/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
@@ -3,6 +3,11 @@
 exports[`Archives | Components | FiltersMenu renders correctly 1`] = `
 <ul
   className="dropdown__list"
+  itemSelectKeyCodes={
+    Array [
+      13,
+    ]
+  }
   onScroll={[Function]}
   tabIndex={0}
 >

--- a/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
@@ -16,7 +16,7 @@ exports[`Archives | Components | FiltersMenu renders correctly 1`] = `
       />
     }
     isDisabled={true}
-    isFocused={true}
+    isFocused={false}
     isSelected={false}
     itemId={1}
     onItemSelect={[MockFunction]}
@@ -34,7 +34,7 @@ exports[`Archives | Components | FiltersMenu renders correctly 1`] = `
       />
     }
     isDisabled={false}
-    isFocused={false}
+    isFocused={true}
     isSelected={false}
     itemId={2}
     onItemSelect={[MockFunction]}

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -9,24 +9,7 @@ const baseClass = 'switch';
 const cx = classNames.bind(styles);
 const noop = () => {};
 
-class Switch extends React.PureComponent {
-  static propTypes = {
-    className: PropTypes.string,
-    defaultOn: PropTypes.bool,
-    innerRef: PropTypes.instanceOf(Element),
-    name: PropTypes.string,
-    on: PropTypes.bool,
-    onChange: PropTypes.func,
-    size: PropTypes.oneOf(acceptedSizes)
-  };
-
-  static defaultProps = {
-    defaultOn: false,
-    onChange: noop,
-    size: 'basic',
-    name: baseClass
-  };
-
+class SwitchComponent extends React.PureComponent {
   state = {
     enabled: this.isControlledByProps() ? this.props.on : this.props.defaultOn,
     prevPropsOn: this.props.on // eslint-disable-line react/no-unused-state
@@ -111,6 +94,38 @@ class Switch extends React.PureComponent {
   }
 }
 
-export default React.forwardRef((props, ref) => (
-  <Switch innerRef={ref} {...props} />
+const basePropTypes = {
+  className: PropTypes.string,
+  defaultOn: PropTypes.bool,
+  name: PropTypes.string,
+  on: PropTypes.bool,
+  onChange: PropTypes.func,
+  size: PropTypes.oneOf(acceptedSizes)
+};
+
+/* eslint-disable react/default-props-match-prop-types */
+const baseDefaultProps = {
+  defaultOn: false,
+  onChange: noop,
+  size: 'basic',
+  name: baseClass
+};
+
+SwitchComponent.propTypes = {
+  ...basePropTypes,
+  innerRef: PropTypes.instanceOf(
+    typeof Element === 'undefined' ? () => {} : Element
+  )
+};
+
+SwitchComponent.defaultProps = baseDefaultProps;
+
+const Switch = React.forwardRef((props, ref) => (
+  <SwitchComponent innerRef={ref} {...props} />
 ));
+
+Switch.propTypes = basePropTypes;
+
+Switch.defaultProps = baseDefaultProps;
+
+export default Switch;

--- a/src/components/Switch/__snapshots__/Switch.test.js.snap
+++ b/src/components/Switch/__snapshots__/Switch.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch should render basic Switch 1`] = `
-<Switch
+<SwitchComponent
   defaultOn={false}
   innerRef={null}
   name="switch"

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -22,12 +22,8 @@ export interface IGetItemBodyPayload extends IDropdownItemBase {
   onMouseOverItem?: (itemId: ItemId) => void;
 }
 
-export interface IContentRendererPayload {
-  forceUpdate: () => void;
-}
-
 export interface IDropdownProps {
-  children?: React.ReactNode;
+  children: React.ReactNode;
   className?: string;
   closeOnEscPress?: boolean;
   closeOnEnterPress?: boolean;

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -51,6 +51,7 @@ export interface IDropdownItem extends IDropdownItemBase {
 
 export interface IDropdownListProps
   extends React.HTMLAttributes<HTMLUListElement> {
+  autoFocusOnItemsCountChange?: boolean;
   className?: string;
   items: IDropdownItem[];
   defaultFocusedItemId?: ItemId;

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -27,6 +27,7 @@ export interface IDropdownProps {
   className?: string;
   closeOnEscPress?: boolean;
   closeOnEnterPress?: boolean;
+  closeKeyCodes?: number[];
   eventsEnabled?: boolean;
   isVisible: boolean;
   modifiers?: PopperJS.Modifiers;
@@ -52,6 +53,8 @@ export interface IDropdownListProps
   extends React.HTMLAttributes<HTMLUListElement> {
   className?: string;
   items: IDropdownItem[];
+  defaultFocusedItemId?: ItemId;
+  itemSelectKeyCodes?: number[];
   getItemBody?(payload: IGetItemBodyPayload): React.ReactNode;
 }
 

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -54,7 +54,6 @@ export interface IDropdownListProps
   autoFocusOnItemsCountChange?: boolean;
   className?: string;
   items: IDropdownItem[];
-  defaultFocusedItemId?: ItemId;
   itemSelectKeyCodes?: number[];
   getItemBody?(payload: IGetItemBodyPayload): React.ReactNode;
 }

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -22,15 +22,21 @@ export interface IGetItemBodyPayload extends IDropdownItemBase {
   onMouseOverItem?: (itemId: ItemId) => void;
 }
 
+export interface IContentRendererPayload {
+  forceUpdate: () => void;
+}
+
 export interface IDropdownProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   closeOnEscPress?: boolean;
   closeOnEnterPress?: boolean;
+  contentRenderer?: (payload: IContentRendererPayload) => void;
   eventsEnabled?: boolean;
   isVisible: boolean;
   modifiers?: PopperJS.Modifiers;
   placement?: PopperJS.Placement;
+  dropdownItemsCount?: number;
   positionFixed?: boolean;
   referenceElement?: PopperJS.ReferenceObject;
   zIndex?: number;

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -31,14 +31,13 @@ export interface IDropdownProps {
   className?: string;
   closeOnEscPress?: boolean;
   closeOnEnterPress?: boolean;
-  contentRenderer?: (payload: IContentRendererPayload) => void;
   eventsEnabled?: boolean;
   isVisible: boolean;
   modifiers?: PopperJS.Modifiers;
   placement?: PopperJS.Placement;
-  dropdownItemsCount?: number;
   positionFixed?: boolean;
   referenceElement?: PopperJS.ReferenceObject;
+  shouldUpdateOnResize?: boolean;
   zIndex?: number;
   triggerRenderer?: (props: { ref: React.Ref<any> }) => void;
   onClose: () => void;


### PR DESCRIPTION
![dropdown-resize](https://user-images.githubusercontent.com/24607370/58133323-e5a4e780-7c23-11e9-9270-beb90b6b94c2.gif)

We noticed the issue in Dropdown component. When the number of dropdown list items changes or items are removed on click (screen) Dropdown is not updating its position. Dynamic content of dropdown could also trigger this bug.
We decided to listen on Dropdown content wrapper resize to properly handle those cases. 

References:
- similar issue solution in the other library: https://github.com/palantir/blueprint/pull/2718
- ResizeObserver polyfill: https://github.com/que-etc/resize-observer-polyfill
- popper issue (closed): https://github.com/FezVrasta/popper.js/issues/85 

Also I added props for custom keycodes setup and autofocus first item on creating component and list items count change (filtering)