### PR TITLE
Adding new property to control dropdown keyboard events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system",
-  "version": "0.3.2-beta.1",
+  "version": "0.3.2-beta.2",
   "publishConfig": {
     "access": "public"
   },

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -193,6 +193,7 @@ class DropdownList extends React.PureComponent {
       getItemBody,
       itemSelectKeyCodes,
       autoFocusOnItemsCountChange,
+      keyboardEventsEnabled,
       ...restProps
     } = this.props;
 

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -33,7 +33,22 @@ class DropdownList extends React.PureComponent {
   }
 
   componentDidMount() {
-    document.addEventListener('keydown', this.onKeydown);
+    if (this.props.keyboardEventsEnabled) {
+      document.addEventListener('keydown', this.onKeydown);
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const eventsEnabled =
+      !prevProps.keyboardEventsEnabled && this.props.keyboardEventsEnabled;
+    const eventsDisabled =
+      prevProps.keyboardEventsEnabled && !this.props.keyboardEventsEnabled;
+
+    if (eventsEnabled) {
+      document.addEventListener('keydown', this.onKeydown);
+    } else if (eventsDisabled) {
+      document.removeEventListener('keydown', this.onKeydown);
+    }
   }
 
   componentWillUnmount() {
@@ -227,6 +242,10 @@ class DropdownList extends React.PureComponent {
 DropdownList.propTypes = {
   autoFocusOnItemsCountChange: PropTypes.bool,
   className: PropTypes.string,
+  /**
+   * use this property to enable/disable keyboard events of DropdownList
+   */
+  keyboardEventsEnabled: PropTypes.bool,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       className: PropTypes.string,
@@ -251,6 +270,7 @@ DropdownList.propTypes = {
 };
 
 DropdownList.defaultProps = {
+  keyboardEventsEnabled: true,
   itemSelectKeyCodes: [KeyCodes.enter]
 };
 

--- a/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Components | DropdownList renders correctly four items with autofocused second item 1`] = `
 <ul
   className="dropdown__list"
+  keyboardEventsEnabled={true}
   onScroll={[Function]}
   tabIndex={0}
 >

--- a/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
+++ b/src/components/Dropdown/__snapshots__/DropdownList.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Components | DropdownList renders correctly four items with autofocused second item 1`] = `
 <ul
   className="dropdown__list"
-  keyboardEventsEnabled={true}
   onScroll={[Function]}
   tabIndex={0}
 >

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -55,6 +55,7 @@ export interface IDropdownListProps
   className?: string;
   items: IDropdownItem[];
   itemSelectKeyCodes?: number[];
+  keyboardEventsEnabled?: boolean;
   getItemBody?(payload: IGetItemBodyPayload): React.ReactNode;
 }
 


### PR DESCRIPTION
Building list with sublist using DropdownList component can be a bit problematic. @sgraczyk encountered one more issue when building canned responses dropdown - while hiding one of 2 lists its events are still attached and using keyboard arrows change a focused item in 2 lists. 