### PR TITLE
Passing event as argument of `onItemSelect` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system",
-  "version": "0.3.2-beta.3",
+  "version": "0.3.2-beta.4",
   "publishConfig": {
     "access": "public"
   },

--- a/src/components/Dropdown/DropdownList.js
+++ b/src/components/Dropdown/DropdownList.js
@@ -67,7 +67,7 @@ class DropdownList extends React.PureComponent {
 
     if (this.isItemSelectKeyCode(keyCode)) {
       event.preventDefault();
-      this.handleSelectKeyUse();
+      this.handleSelectKeyUse(event);
     }
   };
 
@@ -83,7 +83,7 @@ class DropdownList extends React.PureComponent {
     return this.hoverCallbacks[itemKey];
   };
 
-  handleSelectKeyUse = () => {
+  handleSelectKeyUse = event => {
     const { focusedElement } = this.state;
 
     if (focusedElement !== null) {
@@ -92,7 +92,7 @@ class DropdownList extends React.PureComponent {
       );
 
       if (selectedItem && selectedItem.onItemSelect) {
-        selectedItem.onItemSelect(selectedItem.itemId);
+        selectedItem.onItemSelect(selectedItem.itemId, event);
       }
     }
   };

--- a/src/components/Dropdown/DropdownListItem.js
+++ b/src/components/Dropdown/DropdownListItem.js
@@ -10,29 +10,29 @@ const cx = cssClassNames.bind(styles);
 const baseClass = 'dropdown__list-item';
 
 class DropdownListItem extends React.PureComponent {
-  handleClick = e => {
+  handleClick = event => {
     if (!this.props.isDisabled && this.props.onItemSelect) {
-      e.nativeEvent.stopImmediatePropagation();
-      this.props.onItemSelect(this.props.itemId, e);
+      event.nativeEvent.stopImmediatePropagation();
+      this.props.onItemSelect(this.props.itemId, event);
     }
     if (this.props.onClick) {
-      this.props.onClick(e);
+      this.props.onClick(event);
     }
   };
 
-  handleMouseOver = e => {
+  handleMouseOver = event => {
     if (!this.props.isDisabled && this.props.onMouseOverItem) {
       this.props.onMouseOverItem(this.props.itemId);
     }
     if (this.props.onMouseOver) {
-      this.props.onMouseOver(e);
+      this.props.onMouseOver(event);
     }
   };
 
-  handleMouseDown = e => {
-    e.preventDefault();
+  handleMouseDown = event => {
+    event.preventDefault();
     if (this.props.onMouseDown) {
-      this.props.onMouseDown(e);
+      this.props.onMouseDown(event);
     }
     return false;
   };

--- a/src/components/Dropdown/DropdownListItem.js
+++ b/src/components/Dropdown/DropdownListItem.js
@@ -13,7 +13,7 @@ class DropdownListItem extends React.PureComponent {
   handleClick = e => {
     if (!this.props.isDisabled && this.props.onItemSelect) {
       e.nativeEvent.stopImmediatePropagation();
-      this.props.onItemSelect(this.props.itemId);
+      this.props.onItemSelect(this.props.itemId, e);
     }
     if (this.props.onClick) {
       this.props.onClick(e);

--- a/src/interfaces/dropdowns.d.ts
+++ b/src/interfaces/dropdowns.d.ts
@@ -9,7 +9,10 @@ interface IDropdownItemBase extends React.HTMLAttributes<HTMLLIElement> {
   isDisabled?: boolean;
   isSelected?: boolean;
   divider?: boolean;
-  onItemSelect?: (itemId: ItemId) => void;
+  onItemSelect?: (
+    itemId: ItemId,
+    event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
+  ) => void;
 }
 
 export interface IGetItemBodyPayload extends IDropdownItemBase {


### PR DESCRIPTION
- we should always pass `event` as argument of event handlers in component API 
- in this case, the event helps with recognizing of keyboard or mouse usage (we need to add different amplitude event in AA for keyboard and mouse)