### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 All notable changes to this project will be documented in this file.
 
+## v0.4.2
+
+_Release: 2019-06-19_
+
+##### New Features
+
+- adding optional `onOpen` property to `PopperTooltip` - for tooltips with `click` and `hover` trigger action types
+- extending `Dropdown` and `DropdownList` components:
+  - adding dropdown content resize observer
+  - custom key codes for Dropdown close and DropdownList select events
+  - prevent default on item select with the keydown event
+  - adding autofocus first item to DropdownList component
+  - adding a new property to control dropdown keyboard events
+  - passing event as argument of `onItemSelect` property (optional)
+
+##### Refactors
+
+- refactoring Dropdown and Switch prop types and default props - it was not visible in the docs
+
+##### Bug Fixes
+
+- `Toast` component styles fix - elements inside of `Toast` were positioned incorectly (ie11, firefox, safari)
+
+---
+
 ## v0.4.1
 
 _Release: 2019-06-11_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## v0.4.2

 _Release: 2019-06-19_

 ##### New Features

 - adding optional `onOpen` property to `PopperTooltip` - for tooltips with `click` and `hover` trigger action types
- extending `Dropdown` and `DropdownList` components:
  - adding dropdown content resize observer
  - custom key codes for Dropdown close and DropdownList select events
  - prevent default on item select with the keydown event
  - adding autofocus first item to DropdownList component
  - adding a new property to control dropdown keyboard events
  - passing event as argument of `onItemSelect` property (optional)

 ##### Refactors

 - refactoring Dropdown and Switch prop types and default props - it was not visible in the docs

 ##### Bug Fixes

 - `Toast` component styles fix - elements inside of `Toast` were positioned incorectly (ie11, firefox, safari)

 ---