### PR TITLE
Adding Omit type to support AA typescript version

### DIFF
--- a/src/interfaces/switch.d.ts
+++ b/src/interfaces/switch.d.ts
@@ -1,5 +1,6 @@
 export type SwitchSize = "basic" | "compact";
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type HTMLInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">;
 
 export interface ISwitchProps extends HTMLInputProps {


### PR DESCRIPTION
https://github.com/livechat/design-system/pull/136/files#diff-480884be778ca4f56fa81be6ae696310R3 - This change caused an error in AA because global Omit type was introduced in Typescript 3.5 (AA is on ts 3.1.6)