### PR TITLE
Release 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 All notable changes to this project will be documented in this file.
 
+## v0.5.4
+
+_Release: 2019-10-09_
+
+##### Bug Fixes
+
+- Adding `Omit` type to support typescript in version 3.1 (#138)
+
+---
+
 ## v0.5.3
 
 _Release: 2019-10-09_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "publishConfig": {
     "access": "public"
   },

--- a/src/interfaces/switch.d.ts
+++ b/src/interfaces/switch.d.ts
@@ -1,5 +1,6 @@
 export type SwitchSize = "basic" | "compact";
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 type HTMLInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">;
 
 export interface ISwitchProps extends HTMLInputProps {


### PR DESCRIPTION
## v0.5.4

_Release: 2019-10-09_

##### Bug Fixes

- Adding `Omit` type to support typescript in version 3.1 (#138)

---