### PR TITLE
[AA-7213] Allow autofocusedItemId prop

### DIFF
--- a/packages/design-system/src/components/Dropdown/DropdownList.js
+++ b/packages/design-system/src/components/Dropdown/DropdownList.js
@@ -14,7 +14,8 @@ class DropdownList extends React.PureComponent {
     super(props);
 
     this.state = {
-      focusedElement: getFirstFocusableItemId(props.items),
+      focusedElement:
+        this.props.autoFocusedItemId || getFirstFocusableItemId(props.items),
       itemsCount: props.items.length
     };
   }
@@ -52,8 +53,8 @@ class DropdownList extends React.PureComponent {
   }
 
   componentWillUnmount() {
-    if (this.timeout) {
-      clearTimeout(this.timeout);
+    if (this.hoverEnablerTimeout) {
+      clearTimeout(this.hoverEnablerTimeout);
     }
     document.removeEventListener('keydown', this.onKeydown);
   }
@@ -74,6 +75,7 @@ class DropdownList extends React.PureComponent {
   getFocusedItemCallback = itemKey => {
     if (!this.hoverCallbacks[itemKey]) {
       this.hoverCallbacks[itemKey] = () => {
+        debugger; // eslint-disable-line
         if (!this.isHoverDisabled) {
           this.changeFocusedElement(itemKey);
         }
@@ -119,9 +121,7 @@ class DropdownList extends React.PureComponent {
     if (this.props.onScroll) {
       this.props.onScroll(event);
     }
-    this.timeout = setTimeout(() => {
-      this.isHoverDisabled = false;
-    }, 150);
+    this.enableHoverOnItems(150);
   };
 
   changeFocusedElement = id => {
@@ -177,10 +177,24 @@ class DropdownList extends React.PureComponent {
           itemOfsetTop - (itemOfsetTop % itemHeigth);
       }
     }
+
+    this.enableHoverOnItems(150);
   };
 
+  enableHoverOnItems(delayInMs) {
+    if (this.hoverEnablerTimeout) clearTimeout(this.hoverEnablerTimeout);
+
+    if (delayInMs) {
+      this.hoverEnablerTimeout = setTimeout(() => {
+        this.isHoverDisabled = false;
+      }, delayInMs);
+    } else {
+      this.isHoverDisabled = false;
+    }
+  }
+
   isHoverDisabled = false;
-  timeout = null;
+  hoverEnablerTimeout = null;
 
   hoverCallbacks = [];
 
@@ -241,6 +255,7 @@ class DropdownList extends React.PureComponent {
 }
 
 DropdownList.propTypes = {
+  autoFocusedItemId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   autoFocusOnItemsCountChange: PropTypes.bool,
   className: PropTypes.string,
   /**

--- a/packages/design-system/src/components/Dropdown/DropdownList.js
+++ b/packages/design-system/src/components/Dropdown/DropdownList.js
@@ -75,7 +75,6 @@ class DropdownList extends React.PureComponent {
   getFocusedItemCallback = itemKey => {
     if (!this.hoverCallbacks[itemKey]) {
       this.hoverCallbacks[itemKey] = () => {
-        debugger; // eslint-disable-line
         if (!this.isHoverDisabled) {
           this.changeFocusedElement(itemKey);
         }
@@ -182,7 +181,9 @@ class DropdownList extends React.PureComponent {
   };
 
   enableHoverOnItems(delayInMs) {
-    if (this.hoverEnablerTimeout) clearTimeout(this.hoverEnablerTimeout);
+    if (this.hoverEnablerTimeout) {
+      clearTimeout(this.hoverEnablerTimeout);
+    }
 
     if (delayInMs) {
       this.hoverEnablerTimeout = setTimeout(() => {

--- a/packages/design-system/src/components/Dropdown/DropdownList.js
+++ b/packages/design-system/src/components/Dropdown/DropdownList.js
@@ -255,6 +255,9 @@ class DropdownList extends React.PureComponent {
 }
 
 DropdownList.propTypes = {
+  /**
+   * Specify which item should be focused after dropdown open
+   */
   autoFocusedItemId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   autoFocusOnItemsCountChange: PropTypes.bool,
   className: PropTypes.string,

--- a/packages/design-system/src/components/Dropdown/DropdownList.js
+++ b/packages/design-system/src/components/Dropdown/DropdownList.js
@@ -37,6 +37,10 @@ class DropdownList extends React.PureComponent {
     if (this.props.keyboardEventsEnabled) {
       document.addEventListener('keydown', this.onKeydown);
     }
+
+    if (this.props.autoFocusedItemId) {
+      this.scrollItems();
+    }
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/design-system/src/interfaces/dropdowns.d.ts
+++ b/packages/design-system/src/interfaces/dropdowns.d.ts
@@ -54,6 +54,7 @@ export interface IDropdownItem extends IDropdownItemBase {
 
 export interface IDropdownListProps
   extends React.HTMLAttributes<HTMLUListElement> {
+  autoFocusedItemId?: string;
   autoFocusOnItemsCountChange?: boolean;
   className?: string;
   items: IDropdownItem[];


### PR DESCRIPTION
Focus can’t be controlled at the moment, but in some cases, it could be helpful - Jakub Sikora, from the Developer Platform team, needs to automatically focus the current version of docs on dropdown open.

Take a look at the comment:
https://livechatinc.atlassian.net/browse/DPS-1258?focusedCommentId=63598&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-63598

Done in PR:
- fixing keydown and hover handlers - items hover handlers were disabled after keyboard keys use when there was no list scroll
- allow autofocusedItemId prop