### PR TITLE
AA-7719 ButtonGroup > Disable box-shadow for :focus and :active states

### DIFF
--- a/packages/design-system/src/components/ButtonGroup/style.scss
+++ b/packages/design-system/src/components/ButtonGroup/style.scss
@@ -12,7 +12,6 @@
     &.active {
       border-color: $border-primary-color;
       background-color: $ui-background-color-hover;
-      z-index: 1;
       text-shadow: 0 0 0.5px black;
 
       &:hover {
@@ -25,7 +24,7 @@
     }
 
     &:focus, &:active {
-      box-shadow: none;
+      z-index: 1;
     }
 
     &:not(:first-child) {

--- a/packages/design-system/src/components/ButtonGroup/style.scss
+++ b/packages/design-system/src/components/ButtonGroup/style.scss
@@ -8,8 +8,7 @@
   .btn {
     color: $ui-tooltip-color;
     font-weight: 400;
-    box-shadow: none;
-    
+
     &.active {
       border-color: $border-primary-color;
       background-color: $ui-background-color-hover;
@@ -23,6 +22,10 @@
 
     &:hover {
       background-color: $ui-background-color;
+    }
+
+    &:focus, &:active {
+      box-shadow: none;
     }
 
     &:not(:first-child) {


### PR DESCRIPTION
I used `ButtonGroup` in the agent app and saw that the `box-shadow` styles were placed in a different order. `.lc-btn:focus` was placed after `.lc-btn-group .lc-btn` which made the `box-shadow` of the regular button more important than disabled `box-shadow: none` for the grouped buttons. I wanted the styles of the group to be more specific.