### PR TITLE
Fix inner-shadow appearing on Safari mobile

### DIFF
--- a/packages/design-system/src/components/InputField/style.scss
+++ b/packages/design-system/src/components/InputField/style.scss
@@ -10,7 +10,8 @@
   box-sizing: border-box;
   transition: border 0.25s ease-in-out;
   will-change: border-color;
-
+  background-clip: padding-box;
+ 
   &::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: $font-primary-color;
     opacity: 0.4; /* Firefox */

--- a/packages/design-system/src/components/NumericInputField/__snapshots__/NumericInput.test.js.snap
+++ b/packages/design-system/src/components/NumericInputField/__snapshots__/NumericInput.test.js.snap
@@ -7,6 +7,8 @@ exports[`NumericInput should render NumericInput with all available props 1`] = 
 >
   <input
     disabled={true}
+    max={100}
+    min={1}
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
@@ -47,6 +49,7 @@ exports[`NumericInput should render NumericInput with required props 1`] = `
   <button
     aria-label="Increment value"
     className="numeric-input__increment"
+    disabled={false}
     onClick={[Function]}
     tabIndex="-1"
     type="button"
@@ -54,6 +57,7 @@ exports[`NumericInput should render NumericInput with required props 1`] = `
   <button
     aria-label="Decrement value"
     className="numeric-input__decrement"
+    disabled={false}
     onClick={[Function]}
     tabIndex="-1"
     type="button"

--- a/packages/design-system/src/components/NumericInputField/style.scss
+++ b/packages/design-system/src/components/NumericInputField/style.scss
@@ -31,6 +31,7 @@ $base-class: 'numeric-input';
     width: 100%;
     box-sizing: border-box;
     -moz-appearance: textfield;
+    background-clip: padding-box;
 
     &:hover {
       border-color: $field-hover-border-color;

--- a/packages/design-system/src/components/TextAreaField/style.scss
+++ b/packages/design-system/src/components/TextAreaField/style.scss
@@ -11,6 +11,7 @@
   box-sizing: border-box;
   transition: border 0.25s ease-in-out;
   will-change: border-color;
+  background-clip: padding-box;
 
   &::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
     color: $font-primary-color;


### PR DESCRIPTION
It appears that the native behavior of Safari related to the `-webkit-appearance` has caused the inner shadows to be displayed inside of the `InputField`, `NumericInputField` and `TextAreaField `:

![image](https://user-images.githubusercontent.com/47242672/73871572-60637080-484e-11ea-92e0-6be557934f0f.png)

Using `-webkit-appearance: none;` might be an overkill, but after digging a bit it seems that `background-clip: padding-box;` does the trick.

I have also updated the snapshots for the NumericInput, as they seemed not to be up-to-date.