### PR TITLE
TextField labelAdornment

### DIFF
--- a/packages/design-system/src/components/InputField/InputField.js
+++ b/packages/design-system/src/components/InputField/InputField.js
@@ -39,6 +39,7 @@ const InputField = React.forwardRef((props, ref) => {
 
 InputField.propTypes = {
   labelText: PropTypes.string,
+  /**  specifies additional decorative element rendered at the end of the label */
   labelAdornment: PropTypes.node,
   id: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,

--- a/packages/design-system/src/components/InputField/InputField.js
+++ b/packages/design-system/src/components/InputField/InputField.js
@@ -9,6 +9,7 @@ const InputField = React.forwardRef((props, ref) => {
     error,
     description,
     labelText,
+    labelAdornment,
     className,
     id,
     fieldClassName,
@@ -21,6 +22,7 @@ const InputField = React.forwardRef((props, ref) => {
       error={error}
       description={description}
       labelText={labelText}
+      labelAdornment={labelAdornment}
       className={className}
       htmlFor={id}
     >
@@ -37,6 +39,7 @@ const InputField = React.forwardRef((props, ref) => {
 
 InputField.propTypes = {
   labelText: PropTypes.string,
+  labelAdornment: PropTypes.node,
   id: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   className: PropTypes.string,

--- a/packages/design-system/src/components/MultiSelectField/MultiSelectField.js
+++ b/packages/design-system/src/components/MultiSelectField/MultiSelectField.js
@@ -9,6 +9,7 @@ const MultiSelectField = props => {
     error,
     description,
     labelText,
+    labelAdornment,
     className,
     id,
     fieldClassName,
@@ -21,6 +22,7 @@ const MultiSelectField = props => {
       error={error}
       description={description}
       labelText={labelText}
+      labelAdornment={labelAdornment}
       className={className}
       htmlFor={id}
     >
@@ -36,6 +38,8 @@ const MultiSelectField = props => {
 
 MultiSelectField.propTypes = {
   labelText: PropTypes.string,
+  /**  specifies additional decorative element rendered at the end of the label */
+  labelAdornment: PropTypes.node,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
   fieldClassName: PropTypes.string,

--- a/packages/design-system/src/components/NumericInputField/NumericInputField.js
+++ b/packages/design-system/src/components/NumericInputField/NumericInputField.js
@@ -9,6 +9,7 @@ const NumericInputField = props => {
     error,
     description,
     labelText,
+    labelAdornment,
     className,
     id,
     fieldClassName,
@@ -21,6 +22,7 @@ const NumericInputField = props => {
       error={error}
       description={description}
       labelText={labelText}
+      labelAdornment={labelAdornment}
       className={className}
       htmlFor={id}
     >
@@ -36,8 +38,11 @@ const NumericInputField = props => {
 
 NumericInputField.propTypes = {
   labelText: PropTypes.string,
+  /**  specifies additional decorative element rendered at the end of the label */
+  labelAdornment: PropTypes.node,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
+  fieldClassName: PropTypes.string,
   inline: PropTypes.bool,
   error: PropTypes.string,
   description: PropTypes.node

--- a/packages/design-system/src/components/SelectField/SelectField.js
+++ b/packages/design-system/src/components/SelectField/SelectField.js
@@ -9,6 +9,7 @@ const SelectField = props => {
     error,
     description,
     labelText,
+    labelAdornment,
     className,
     id,
     fieldClassName,
@@ -21,6 +22,7 @@ const SelectField = props => {
       error={error}
       description={description}
       labelText={labelText}
+      labelAdornment={labelAdornment}
       className={className}
       htmlFor={id}
     >
@@ -31,6 +33,8 @@ const SelectField = props => {
 
 SelectField.propTypes = {
   labelText: PropTypes.string,
+  /**  specifies additional decorative element rendered at the end of the label */
+  labelAdornment: PropTypes.node,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
   fieldClassName: PropTypes.string,

--- a/packages/design-system/src/components/TextAreaField/TextAreaField.js
+++ b/packages/design-system/src/components/TextAreaField/TextAreaField.js
@@ -9,6 +9,7 @@ const TextAreaField = React.forwardRef((props, ref) => {
     error,
     description,
     labelText,
+    labelAdornment,
     className,
     id,
     fieldClassName,
@@ -21,6 +22,7 @@ const TextAreaField = React.forwardRef((props, ref) => {
       error={error}
       description={description}
       labelText={labelText}
+      labelAdornment={labelAdornment}
       className={className}
       htmlFor={id}
     >
@@ -37,6 +39,8 @@ const TextAreaField = React.forwardRef((props, ref) => {
 
 TextAreaField.propTypes = {
   labelText: PropTypes.string,
+  /**  specifies additional decorative element rendered at the end of the label */
+  labelAdornment: PropTypes.node,
   id: PropTypes.string.isRequired,
   className: PropTypes.string,
   inline: PropTypes.bool,

--- a/packages/design-system/src/components/TextField/TextField.js
+++ b/packages/design-system/src/components/TextField/TextField.js
@@ -15,6 +15,7 @@ const TextField = props => {
     error,
     description,
     labelText,
+    labelAdornment,
     className,
     htmlFor,
     children
@@ -34,10 +35,16 @@ const TextField = props => {
       {labelText && (
         <div
           className={cx({
+            [`${baseClass}__label`]: true,
             [`${baseClass}__label--inline`]: inline
           })}
         >
           <FieldLabel htmlFor={htmlFor}>{labelText}</FieldLabel>
+          {labelAdornment && (
+            <div className={cx({ [`${baseClass}__label-adornment`]: true })}>
+              {labelAdornment}
+            </div>
+          )}
         </div>
       )}
       <div>
@@ -51,6 +58,7 @@ const TextField = props => {
 
 TextField.propTypes = {
   labelText: PropTypes.string,
+  labelAdornment: PropTypes.node,
   htmlFor: PropTypes.string.isRequired,
   className: PropTypes.string,
   inline: PropTypes.bool,

--- a/packages/design-system/src/components/TextField/TextField.js
+++ b/packages/design-system/src/components/TextField/TextField.js
@@ -58,6 +58,7 @@ const TextField = props => {
 
 TextField.propTypes = {
   labelText: PropTypes.string,
+  /**  specifies additional decorative element rendered at the end of the label */
   labelAdornment: PropTypes.node,
   htmlFor: PropTypes.string.isRequired,
   className: PropTypes.string,

--- a/packages/design-system/src/components/TextField/style.scss
+++ b/packages/design-system/src/components/TextField/style.scss
@@ -30,10 +30,12 @@ $base-class: 'text-field';
   &__label-adornment {
     width: 20px;
     height: 20px;
+    margin-left: 4px;
     line-height: 20px;
     overflow: hidden;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-start;
   }
 }

--- a/packages/design-system/src/components/TextField/style.scss
+++ b/packages/design-system/src/components/TextField/style.scss
@@ -8,11 +8,32 @@ $base-class: 'text-field';
     flex-direction: row;
   }
 
-  &__label--inline {
+  &__label {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    margin-bottom: 4px;
+
+    label {
+      margin-bottom: 0;
+    }
+  }
+
+  &__label--inline {
     justify-content: center;
+    align-items: center;
     height: 38px;
     margin-right: 10px;
+  }
+
+  &__label-adornment {
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/packages/design-system/src/interfaces/buttonGroup.d.ts
+++ b/packages/design-system/src/interfaces/buttonGroup.d.ts
@@ -1,12 +1,12 @@
 // <reference types="react" />
-import { ButtonSize } from "./buttons";
+import { ButtonSize } from './buttons';
 
 export interface IButtonGroupProps
   extends React.HTMLAttributes<HTMLDivElement> {
   fullWidth?: boolean;
   className?: string;
   currentIndex?: number;
-  size: ButtonSize;
+  size?: ButtonSize;
   children: React.ReactNode;
   onIndexChange?: (
     index: number,

--- a/packages/design-system/src/interfaces/forms.d.ts
+++ b/packages/design-system/src/interfaces/forms.d.ts
@@ -102,6 +102,7 @@ export interface IInputProps
 
 export interface IInputFieldProps extends IInputProps {
   labelText?: string;
+  labelAdornment?: React.ReactNode;
   id: string;
   inline?: boolean;
   description?: React.ReactNode;
@@ -110,6 +111,7 @@ export interface IInputFieldProps extends IInputProps {
 
 export interface ITextFieldProps {
   labelText?: string;
+  labelAdornment?: React.ReactNode;
   htmlFor: string;
   className?: string;
   inline?: boolean;
@@ -122,8 +124,8 @@ export interface ITextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   error?: string;
   ref?:
-    | React.Ref<HTMLTextAreaElement>
-    | React.Ref<React.Component<ITextAreaProps>>;
+  | React.Ref<HTMLTextAreaElement>
+  | React.Ref<React.Component<ITextAreaProps>>;
 }
 
 export interface ITextAreaFieldProps extends ITextAreaProps {

--- a/packages/design-system/src/interfaces/forms.d.ts
+++ b/packages/design-system/src/interfaces/forms.d.ts
@@ -8,6 +8,15 @@ export interface IFormProps extends React.HTMLAttributes<HTMLFormElement> {
   formFooter?: React.ReactNode;
 }
 
+export interface IWithTextFieldProps {
+  labelText?: string;
+  inline?: boolean;
+  description?: React.ReactNode;
+  error?: string;
+  labelAdornment?: React.ReactNode;
+  fieldClassName?: string;
+}
+
 export interface IFormGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   labelText?: string;
@@ -43,14 +52,9 @@ export interface ISelectProps {
   selectHeader?: string;
 }
 
-export interface ISelectFieldProps extends ISelectProps {
-  labelText?: string;
+export interface ISelectFieldProps extends ISelectProps, IWithTextFieldProps {
   id: string;
   className?: string;
-  inline?: boolean;
-  fieldClassName?: string;
-  error?: string;
-  description?: React.ReactNode;
 }
 
 export interface IMultiSelectProps {
@@ -84,14 +88,11 @@ export interface IMultiSelectProps {
   onItemRemove(itemKey: string | number): any;
 }
 
-export interface IMultiSelectFieldProps extends IMultiSelectProps {
-  labelText?: string;
+export interface IMultiSelectFieldProps
+  extends IMultiSelectProps,
+  IWithTextFieldProps {
   id: string;
   className?: string;
-  fieldClassName?: string;
-  inline?: boolean;
-  error?: string;
-  description?: React.ReactNode;
 }
 
 export interface IInputProps
@@ -100,24 +101,12 @@ export interface IInputProps
   ref?: React.Ref<HTMLInputElement> | React.Ref<React.Component<IInputProps>>;
 }
 
-export interface IInputFieldProps extends IInputProps {
-  labelText?: string;
-  labelAdornment?: React.ReactNode;
+export interface IInputFieldProps extends IInputProps, IWithTextFieldProps {
   id: string;
-  inline?: boolean;
-  description?: React.ReactNode;
-  fieldClassName?: string;
 }
 
-export interface ITextFieldProps {
-  labelText?: string;
-  labelAdornment?: React.ReactNode;
-  htmlFor: string;
+export interface ITextFieldProps extends IWithTextFieldProps {
   className?: string;
-  inline?: boolean;
-  error?: string;
-  description?: React.ReactNode;
-  children?: React.ReactNode;
 }
 
 export interface ITextAreaProps
@@ -128,12 +117,10 @@ export interface ITextAreaProps
   | React.Ref<React.Component<ITextAreaProps>>;
 }
 
-export interface ITextAreaFieldProps extends ITextAreaProps {
-  labelText?: string;
+export interface ITextAreaFieldProps
+  extends ITextAreaProps,
+  IWithTextFieldProps {
   id: string;
-  inline?: boolean;
-  description?: React.ReactNode;
-  fieldClassName?: string;
 }
 
 export interface INumericInputProps {
@@ -149,11 +136,10 @@ export interface INumericInputProps {
   onChange(value: string): void;
 }
 
-export interface INumericInputFieldProps extends INumericInputProps {
+export interface INumericInputFieldProps
+  extends INumericInputProps,
+  IWithTextFieldProps {
   id: string;
-  labelText?: string;
-  inline?: boolean;
-  description?: React.ReactNode;
 }
 
 export interface ICheckboxFieldProps


### PR DESCRIPTION
TextField labelAdornment property allows displaying a React node next to the label as a way to decorate the whole input element with an additional element like icon or tooltip trigger and etc.

The main motivation for adding this prop is to allow extending already existing text explanation for input with some possible interactive decoration elements. The label adornment is treated generically it only restricts the dimensions and layout but is more like a "render spot" for the consumer content rather than the actual element.