### PR TITLE
DS-118 - Add tabindex 0 to dropdown list item to make it visible for screen readers

### DIFF
--- a/packages/design-system/src/components/Dropdown/DropdownListItem.js
+++ b/packages/design-system/src/components/Dropdown/DropdownListItem.js
@@ -70,6 +70,7 @@ class DropdownListItem extends React.PureComponent {
         onClick={this.handleClick}
         onMouseOver={this.handleMouseOver}
         onMouseDown={this.handleMouseDown}
+        tabIndex={0}
       >
         <div className={styles[`${baseClass}__content`]}>
           {icon && <div className={styles[`${baseClass}__icon`]}>{icon}</div>}


### PR DESCRIPTION
Jira: https://livechatinc.atlassian.net/browse/DS-118

Description:
Adding tabindex=0 makes list item visible for screen reader when hovering mouse over the item or by using touch screen by sliding the finger on it.