### PR TITLE
DS-121 Improve search bar close icon

### DIFF
--- a/packages/design-system/src/components/SearchBar/SearchBar.js
+++ b/packages/design-system/src/components/SearchBar/SearchBar.js
@@ -194,7 +194,7 @@ export class SearchBar extends React.PureComponent {
     const closeIconClassName = cx(
       [`lc-${baseClass}__icon`, `lc-${baseClass}__clear-icon`],
       {
-        [`lc-${baseClass}__clear-icon--disable`]: !shouldDisplayClearButton
+        [`lc-${baseClass}__clear-icon--hidden`]: !shouldDisplayClearButton
       }
     );
 
@@ -225,7 +225,7 @@ export class SearchBar extends React.PureComponent {
             onBlur={this.handleBlur}
             onKeyDown={this.handleKeyPress}
             className={inputClassName}
-            data-element="search-input"
+            data-testId="search-input"
           />
           <CloseIcon
             width="18px"
@@ -236,7 +236,7 @@ export class SearchBar extends React.PureComponent {
             }
             className={closeIconClassName}
             tabIndex="0"
-            data-element="close-icon"
+            data-testId="close-button"
           />
         </div>
         {error && <FieldError>{error}</FieldError>}
@@ -281,7 +281,7 @@ SearchBar.propTypes = {
   onExpand: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  forwardedRef: PropTypes.func
+  forwardedRef: React.RefObject
 };
 
 SearchBar.defaultProps = {
@@ -289,6 +289,7 @@ SearchBar.defaultProps = {
   debounceTime: 0
 };
 
-export default React.forwardRef((props, ref) => (
-  <SearchBar {...props} forwardedRef={ref} />
-));
+/* eslint prefer-arrow-callback: ["error", { "allowNamedFunctions": true }] */
+export default React.forwardRef(function SearchBarWithRef(props, ref) {
+  return <SearchBar {...props} forwardedRef={ref} />;
+});

--- a/packages/design-system/src/components/SearchBar/SearchBar.js
+++ b/packages/design-system/src/components/SearchBar/SearchBar.js
@@ -25,7 +25,7 @@ export class SearchBar extends React.PureComponent {
     }
 
     this.state = {
-      searchTerm: '',
+      searchTerm: props.value || '',
       isCollapsed: props.collapsable
     };
   }
@@ -219,7 +219,7 @@ export class SearchBar extends React.PureComponent {
           <Input
             placeholder={placeholder}
             ref={this.inputRef}
-            value={value || this.state.searchTerm}
+            value={value || value === '' ? value : this.state.searchTerm}
             onChange={this.handleChange}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}

--- a/packages/design-system/src/components/SearchBar/SearchBar.js
+++ b/packages/design-system/src/components/SearchBar/SearchBar.js
@@ -219,13 +219,13 @@ export class SearchBar extends React.PureComponent {
           <Input
             placeholder={placeholder}
             ref={this.inputRef}
-            value={value || value === '' ? value : this.state.searchTerm}
+            value={value != null ? value : this.state.searchTerm}
             onChange={this.handleChange}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
             onKeyDown={this.handleKeyPress}
             className={inputClassName}
-            data-testId="search-input"
+            data-testid="search-input"
           />
           <CloseIcon
             width="18px"
@@ -236,7 +236,7 @@ export class SearchBar extends React.PureComponent {
             }
             className={closeIconClassName}
             tabIndex="0"
-            data-testId="close-button"
+            data-testid="close-button"
           />
         </div>
         {error && <FieldError>{error}</FieldError>}
@@ -281,7 +281,10 @@ SearchBar.propTypes = {
   onExpand: PropTypes.func,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
-  forwardedRef: React.RefObject
+  forwardedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any })
+  ])
 };
 
 SearchBar.defaultProps = {

--- a/packages/design-system/src/components/SearchBar/SearchBar.js
+++ b/packages/design-system/src/components/SearchBar/SearchBar.js
@@ -93,37 +93,43 @@ export class SearchBar extends React.PureComponent {
     if (this.props.onBlur) {
       this.props.onBlur(event);
     }
-    
+
     if (this.props.collapseOnBlur) {
-      this.setState({
-        isCollapsed: true
-      }, () => {
-        if (this.props.onCollapse) {
-          this.props.onCollapse();
+      this.setState(
+        {
+          isCollapsed: true
+        },
+        () => {
+          if (this.props.onCollapse) {
+            this.props.onCollapse();
+          }
         }
-      })
+      );
     }
-  }
+  };
 
   handleFocus = event => {
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
-    
-    if (this.props.expandOnFocus) {
-      this.setState({
-        isCollapsed: false
-      }, () => {
-        if (this.inputRef.current) {
-          this.inputRef.current.focus();
-        }
 
-        if (this.props.onExpand) {
-          this.props.onExpand();
+    if (this.props.expandOnFocus) {
+      this.setState(
+        {
+          isCollapsed: false
+        },
+        () => {
+          if (this.inputRef.current) {
+            this.inputRef.current.focus();
+          }
+
+          if (this.props.onExpand) {
+            this.props.onExpand();
+          }
         }
-      })
+      );
     }
-  }
+  };
 
   toggleSearchBarMode = () => {
     this.setState(
@@ -185,6 +191,13 @@ export class SearchBar extends React.PureComponent {
       [`lc-${baseClass}__input--collapsed`]: isCollapsed
     });
 
+    const closeIconClassName = cx(
+      [`lc-${baseClass}__icon`, `lc-${baseClass}__clear-icon`],
+      {
+        [`lc-${baseClass}__clear-icon--disable`]: !shouldDisplayClearButton
+      }
+    );
+
     return (
       <div className={className} ref={forwardedRef} {...restProps}>
         <div className={styles[`${baseClass}__container`]}>
@@ -212,20 +225,19 @@ export class SearchBar extends React.PureComponent {
             onBlur={this.handleBlur}
             onKeyDown={this.handleKeyPress}
             className={inputClassName}
+            data-element="search-input"
           />
-          {shouldDisplayClearButton && (
-            <CloseIcon
-              width="18px"
-              height="18px"
-              onClick={this.handleClear}
-              onKeyDown={this.handleClearButtonKeyDown}
-              className={cx([
-                `lc-${baseClass}__icon`,
-                `lc-${baseClass}__clear-icon`
-              ])}
-              tabIndex="0"
-            />
-          )}
+          <CloseIcon
+            width="18px"
+            height="18px"
+            onClick={shouldDisplayClearButton ? this.handleClear : null}
+            onKeyDown={
+              shouldDisplayClearButton ? this.handleClearButtonKeyDown : null
+            }
+            className={closeIconClassName}
+            tabIndex="0"
+            data-element="close-icon"
+          />
         </div>
         {error && <FieldError>{error}</FieldError>}
       </div>
@@ -268,7 +280,8 @@ SearchBar.propTypes = {
   onCollapse: PropTypes.func,
   onExpand: PropTypes.func,
   onFocus: PropTypes.func,
-  onBlur: PropTypes.func
+  onBlur: PropTypes.func,
+  forwardedRef: PropTypes.func
 };
 
 SearchBar.defaultProps = {
@@ -276,6 +289,6 @@ SearchBar.defaultProps = {
   debounceTime: 0
 };
 
-export default React.forwardRef(function SearchBarWithRef(props, ref) {
-  return <SearchBar {...props} forwardedRef={ref} />;
-});
+export default React.forwardRef((props, ref) => (
+  <SearchBar {...props} forwardedRef={ref} />
+));

--- a/packages/design-system/src/components/SearchBar/style.scss
+++ b/packages/design-system/src/components/SearchBar/style.scss
@@ -52,7 +52,7 @@ $base-class: "search-bar";
       border: 1px solid #8db4ee;
     }
 
-    &--disable {
+    &--hidden {
       display: none;
     }
   }

--- a/packages/design-system/src/components/SearchBar/style.scss
+++ b/packages/design-system/src/components/SearchBar/style.scss
@@ -29,7 +29,7 @@ $base-class: "search-bar";
   }
 
   &__clear-icon {
-    opacity: 1;
+    display: block;
     right: 13px;
     cursor: pointer;
     fill: $icon-primary-color;
@@ -53,7 +53,7 @@ $base-class: "search-bar";
     }
 
     &--disable {
-      opacity: 0;
+      display: none;
     }
   }
 

--- a/packages/design-system/src/components/SearchBar/style.scss
+++ b/packages/design-system/src/components/SearchBar/style.scss
@@ -29,6 +29,7 @@ $base-class: "search-bar";
   }
 
   &__clear-icon {
+    opacity: 1;
     right: 13px;
     cursor: pointer;
     fill: $icon-primary-color;
@@ -49,6 +50,10 @@ $base-class: "search-bar";
       border-radius: 3px;
       box-sizing: border-box;
       border: 1px solid #8db4ee;
+    }
+
+    &--disable {
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
Jira: https://livechatinc.atlassian.net/browse/DS-121

Hey, according to the above task the close icon in search bar is disappearing quicker from the DOM than some helper function/hook a developer wants to use and it is causing problems. I've prepared a fix that icon is always visible in the DOM (`display: none/block`) and even if user will turn this icon on through dev console then nothing will happen (blocked handlers on this icon).

Moreover I'm trying new concept of `data-element` attributes to help user find elements inside given component. WDYT about this approach?

PS: In the code there are some prettier code formatting changes