### PR TITLE
Add onFocus and onBlur handlers to NumericInput

### DIFF
--- a/packages/design-system/CHANGELOG.md
+++ b/packages/design-system/CHANGELOG.md
@@ -1,5 +1,13 @@
 All notable changes to this project will be documented in this file.
 
+## v0.13.2
+
+_Release: 2022-04-21_
+
+##### New features
+
+- adding support for onFocus and onBlur properties to NumericInput component (#314)
+
 ## v0.13.1
 
 _Release: 2021-06-23_

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/design-system/src/components/NumericInputField/NumericInput.js
+++ b/packages/design-system/src/components/NumericInputField/NumericInput.js
@@ -121,12 +121,18 @@ class NumericInput extends React.PureComponent {
     this.changeValue(-1);
   };
 
-  handleFocus = () => {
+  handleFocus = event => {
     this.addKeyboardEventListeners();
+    if (this.props.onFocus) {
+      this.props.onFocus(event);
+    }
   };
 
-  handleBlur = () => {
+  handleBlur = event => {
     this.removeKeyboardEventListeners();
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
   };
 
   render() {
@@ -217,7 +223,9 @@ NumericInput.propTypes = {
   /**
    * It's called with string value: '', '-' or '{number}'
    */
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func
 };
 
 export default NumericInput;


### PR DESCRIPTION
As title says, allow onFocus and onBlur handlers passed in props to execute