### PR TITLE
#346 Make mdx docs readable for dark theme by applying styles on Canvas wrapper

### DIFF
--- a/packages/react-components/src/stories/ColorTokens.stories.mdx
+++ b/packages/react-components/src/stories/ColorTokens.stories.mdx
@@ -7,4 +7,11 @@ import { ColorTokensPallete } from './components/ColorTokens';
 
 List of available color tokens. Click on token to copy it's value to clipboard.
 
-<ColorTokensPallete />
+<Canvas
+  style={{
+    color: 'var(--content-default)',
+    backgroundColor: 'var(--background)',
+  }}
+>
+  <ColorTokensPallete />
+</Canvas>

--- a/packages/react-components/src/stories/Icons.stories.mdx
+++ b/packages/react-components/src/stories/Icons.stories.mdx
@@ -9,4 +9,11 @@ import { IconsShowcase } from './components/IconsShowcase';
 
 List of the icons available in the design system.
 
-<IconsShowcase />
+<Canvas
+  style={{
+    color: 'var(--content-default)',
+    backgroundColor: 'var(--background)',
+  }}
+>
+  <IconsShowcase />
+</Canvas>

--- a/packages/react-components/src/stories/Typography.stories.mdx
+++ b/packages/react-components/src/stories/Typography.stories.mdx
@@ -1,6 +1,6 @@
-import { Meta, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Canvas, ArgsTable } from '@storybook/addon-docs';
 
-import { Heading, Text } from "../components/Typography";
+import { Heading, Text } from '../components/Typography';
 
 <Meta title="Foundations/Typography" />
 
@@ -22,7 +22,12 @@ You can modify the output element via `as` prop. For example if you want to rend
 
 <ArgsTable of={Heading} />
 
-<Canvas style={{ color: "var(--content-default)" }}>
+<Canvas
+  style={{
+    color: 'var(--content-default)',
+    backgroundColor: 'var(--background)',
+  }}
+>
   <Heading size="xl">Heading XLarge</Heading>
   <Heading size="lg">Heading Large</Heading>
   <Heading size="md">Heading Medium</Heading>
@@ -42,7 +47,12 @@ You can modify the output element via `as` prop. For example if you want to rend
 
 <ArgsTable of={Text} />
 
-<Canvas style={{ color: "var(--content-default)" }}>
+<Canvas
+  style={{
+    color: 'var(--content-default)',
+    backgroundColor: 'var(--background)',
+  }}
+>
   <Text>Paragraph Medium</Text>
   <Text bold>Paragraph Medium Bold</Text>
   <Text underline>Paragraph Medium Underline</Text>

--- a/packages/react-components/src/stories/components/ColorTokens.tsx
+++ b/packages/react-components/src/stories/components/ColorTokens.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Canvas } from '@storybook/addon-docs';
 import { DesignTokens } from '../../themes/designTokens';
 import { Text } from '../../components/Typography';
 
@@ -63,7 +64,7 @@ const CONTENT = {
 };
 
 export const ColorTokensPallete: React.FC = () => (
-  <div style={{ color: 'var(--content-default)' }}>
+  <React.Fragment>
     {Object.entries(CONTENT).map(([section, { heading, content }]) => (
       <React.Fragment key={section}>
         <h2>{heading}</h2>
@@ -95,5 +96,5 @@ export const ColorTokensPallete: React.FC = () => (
         </ul>
       </React.Fragment>
     ))}
-  </div>
+  </React.Fragment>
 );

--- a/packages/react-components/src/stories/components/ColorTokens.tsx
+++ b/packages/react-components/src/stories/components/ColorTokens.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Canvas } from '@storybook/addon-docs';
 import { DesignTokens } from '../../themes/designTokens';
 import { Text } from '../../components/Typography';
 

--- a/packages/react-components/src/stories/components/iconsShowcase.css
+++ b/packages/react-components/src/stories/components/iconsShowcase.css
@@ -9,5 +9,5 @@
   display: grid;
   gap: 10px;
   grid-auto-rows: minmax(100px, auto);
-  grid-template-columns: repeat(8, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }


### PR DESCRIPTION
Resolves #346

Based on the following threads/issues I ended up applying themes in docs using the Canvas wrapper, so only a part of the documentation reflects theme tokens, and only for font and background color. This should be enough for showing `Foundations` docs.

Proof:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/8076673/179793062-ded5c1b8-cbce-4be7-a4d4-7891741e49f2.png">
<img width="665" alt="image" src="https://user-images.githubusercontent.com/8076673/179793127-bff7ade0-4662-4148-9a71-ed0a1680dffb.png">
<img width="680" alt="image" src="https://user-images.githubusercontent.com/8076673/179793238-64ea0f0a-e17e-4b8a-b01c-40c21cd4f558.png">

References:
https://github.com/storybookjs/storybook/issues/10054
https://github.com/storybookjs/storybook/issues/12817