### PR TITLE
#343 Extend the Picker options interface and logic to enable passing the component as list item

### DIFF
--- a/packages/react-components/src/components/Picker/Picker.stories.css
+++ b/packages/react-components/src/components/Picker/Picker.stories.css
@@ -1,0 +1,12 @@
+.custom-picker-option {
+  align-items: center;
+  display: flex;
+  flex-flow: row;
+}
+
+.image {
+  border-radius: 50%;
+  height: auto;
+  margin-right: 15px;
+  width: 24px;
+}

--- a/packages/react-components/src/components/Picker/Picker.stories.tsx
+++ b/packages/react-components/src/components/Picker/Picker.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentMeta, Story } from '@storybook/react';
 
 import { IPickerProps, Picker as PickerComponent } from './Picker';
 
+import './Picker.stories.css';
+
 export default {
   title: 'Components/Picker',
   component: PickerComponent,
@@ -127,6 +129,43 @@ PickerWithSelectedOption.args = {
     { key: 'five', name: 'Option five' },
     { key: 'six', name: 'Option six', disabled: true },
     { key: 'seven', name: 'Option seven', disabled: true },
+  ],
+  onSelect: (item) => console.log(item),
+};
+
+const CustomPickerOption: React.FC = ({ children }) => (
+  <div className="custom-picker-option">{children}</div>
+);
+
+export const PickerWithOptionsAsCustomElements = StoryTemplate.bind({});
+PickerWithOptionsAsCustomElements.args = {
+  options: [
+    {
+      key: 'one',
+      name: 'Option one',
+      customElement: (
+        <CustomPickerOption>
+          <img
+            className="image"
+            src="https://avatars2.githubusercontent.com/u/29309941?s=88&v=4"
+          />
+          <div>Custom element 1</div>
+        </CustomPickerOption>
+      ),
+    },
+    {
+      key: 'two',
+      name: 'Option two',
+      customElement: (
+        <CustomPickerOption>
+          <img
+            className="image"
+            src="https://avatars2.githubusercontent.com/u/29309941?s=88&v=4"
+          />
+          <div>Custom element 2</div>
+        </CustomPickerOption>
+      ),
+    },
   ],
   onSelect: (item) => console.log(item),
 };

--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -112,6 +112,9 @@ export const Picker: React.FC<IPickerProps> = ({
     });
   }, [searchPhrase]);
 
+  const getSelectedItem = (item: IPickerListItem) =>
+    item?.customElement || item.name;
+
   return (
     <div ref={triggerRef} className={styles[baseClass]}>
       {label && (
@@ -136,7 +139,7 @@ export const Picker: React.FC<IPickerProps> = ({
           onClearClick={handleOnClearClick}
           onFilter={handleOnFilter}
         >
-          {selectedItem ? selectedItem.name : placeholder}
+          {selectedItem ? getSelectedItem(selectedItem) : placeholder}
         </Trigger>
         <PickerList
           selectedItem={selectedItem}

--- a/packages/react-components/src/components/Picker/PickerList.module.scss
+++ b/packages/react-components/src/components/Picker/PickerList.module.scss
@@ -40,10 +40,12 @@ $base-class: 'picker-list';
   &__item {
     align-items: center;
     border: 1px solid transparent;
+    box-sizing: border-box;
     cursor: pointer;
     display: flex;
     height: 36px;
     justify-content: space-between;
+    overflow: hidden;
     padding: 6px 11px;
 
     &:hover,
@@ -75,6 +77,10 @@ $base-class: 'picker-list';
       justify-content: space-between;
       padding: 7px 12px;
       text-transform: uppercase;
+    }
+
+    &__custom {
+      width: 100%;
     }
   }
 }

--- a/packages/react-components/src/components/Picker/PickerList.tsx
+++ b/packages/react-components/src/components/Picker/PickerList.tsx
@@ -12,6 +12,7 @@ const itemClassName = `${baseClass}__item`;
 export interface IPickerListItem {
   key: string;
   name: string;
+  customElement?: React.ReactElement;
   groupHeader?: boolean;
   disabled?: boolean;
 }
@@ -143,6 +144,18 @@ export const PickerList: React.FC<IPickerListProps> = ({
   const isItemSelected = (key: string): boolean =>
     !!selectedItem && key === selectedItem.key;
 
+  const getOptionContent = (item: IPickerListItem) => {
+    if (item.customElement) {
+      return (
+        <div className={styles[`${itemClassName}__custom`]}>
+          {item.customElement}
+        </div>
+      );
+    }
+
+    return item.name;
+  };
+
   if (!isOpen) {
     return null;
   }
@@ -182,7 +195,7 @@ export const PickerList: React.FC<IPickerListProps> = ({
             className={styles[itemClassName]}
             onClick={() => !item.disabled && handleOnClick(item)}
           >
-            {item.name}
+            {getOptionContent(item)}
             {isItemSelected(item.key) && <Icon kind="link" source={Check} />}
           </li>
         );

--- a/packages/react-components/src/components/Picker/Trigger.module.scss
+++ b/packages/react-components/src/components/Picker/Trigger.module.scss
@@ -32,7 +32,7 @@ $base-class: 'picker-trigger';
     cursor: pointer;
   }
 
-  &__text {
+  &__content {
     flex-grow: 2;
   }
 

--- a/packages/react-components/src/components/Picker/Trigger.tsx
+++ b/packages/react-components/src/components/Picker/Trigger.tsx
@@ -96,7 +96,7 @@ export const Trigger: React.FC<ITriggerProps> = ({
           autoFocus
         />
       ) : (
-        <div className={styles[`${baseClass}__text`]}>{children}</div>
+        <div className={styles[`${baseClass}__content`]}>{children}</div>
       )}
       {isItemSelected && !isDisabled && !isRequired && (
         <div


### PR DESCRIPTION
Resolves: #343 

## Description
Some changes related to the interface and logic of `Trigger` and `PickerList`, enabling the possibility to pass the own component as list item.

## Storybook

## Checklist

**Obligatory:**

- [ ] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
