### PR TITLE
#382 Handle only numeric values as Badge content. Support custom limit.

### DIFF
--- a/packages/react-components/src/components/Badge/Badge.helpers.ts
+++ b/packages/react-components/src/components/Badge/Badge.helpers.ts
@@ -1,0 +1,3 @@
+export function formatCount(count: number, limit: number): string {
+  return count > limit ? `${limit}+` : `${count}`;
+}

--- a/packages/react-components/src/components/Badge/Badge.helpers.ts
+++ b/packages/react-components/src/components/Badge/Badge.helpers.ts
@@ -1,3 +1,3 @@
-export function formatCount(count: number, limit: number): string {
-  return count > limit ? `${limit}+` : `${count}`;
+export function formatCount(count: number, max: number): string {
+  return count > max ? `${max}+` : `${count}`;
 }

--- a/packages/react-components/src/components/Badge/Badge.spec.tsx
+++ b/packages/react-components/src/components/Badge/Badge.spec.tsx
@@ -11,11 +11,26 @@ describe('Badge', () => {
     expect(container.firstChild).toHaveClass('my-custom-class');
   });
 
-  it('should display content passed as children by default', () => {
-    const content = '3 steps left';
-    const { container } = render(<Badge>{content}</Badge>);
+  it('should display number passed as count', () => {
+    const count = 1;
+    const { container } = render(<Badge count={count} />);
 
-    expect(container).toHaveTextContent(content);
+    expect(container).toHaveTextContent(`${count}`);
+  });
+
+  it('should display number shortened to default limit', () => {
+    const count = 100;
+    const { container } = render(<Badge count={count} />);
+
+    expect(container).toHaveTextContent('99+');
+  });
+
+  it('should display number shortened to passed limit', () => {
+    const count = 10;
+    const limit = 9;
+    const { container } = render(<Badge count={count} limit={limit} />);
+
+    expect(container).toHaveTextContent(`${limit}+`);
   });
 
   it('should display exclamation mark for alert type', () => {

--- a/packages/react-components/src/components/Badge/Badge.spec.tsx
+++ b/packages/react-components/src/components/Badge/Badge.spec.tsx
@@ -18,19 +18,19 @@ describe('Badge', () => {
     expect(container).toHaveTextContent(`${count}`);
   });
 
-  it('should display number shortened to default limit', () => {
+  it('should display number shortened to default max limit', () => {
     const count = 100;
     const { container } = render(<Badge count={count} />);
 
     expect(container).toHaveTextContent('99+');
   });
 
-  it('should display number shortened to passed limit', () => {
+  it('should display number shortened to passed max limit', () => {
     const count = 10;
-    const limit = 9;
-    const { container } = render(<Badge count={count} limit={limit} />);
+    const max = 9;
+    const { container } = render(<Badge count={count} max={max} />);
 
-    expect(container).toHaveTextContent(`${limit}+`);
+    expect(container).toHaveTextContent(`${max}+`);
   });
 
   it('should display exclamation mark for alert type', () => {

--- a/packages/react-components/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-components/src/components/Badge/Badge.stories.tsx
@@ -52,11 +52,11 @@ export const Types = (): JSX.Element => (
     <StoryDescriptor title="Count">
       <Badge type="counter" count={1} />
     </StoryDescriptor>
-    <StoryDescriptor title="Count with default limit">
+    <StoryDescriptor title="Count with default max limit">
       <Badge type="counter" count={100} />
     </StoryDescriptor>
-    <StoryDescriptor title="Count with custom limit">
-      <Badge type="counter" count={6} limit={5} />
+    <StoryDescriptor title="Count with custom max limit">
+      <Badge type="counter" count={6} max={5} />
     </StoryDescriptor>
     <StoryDescriptor title="Alert">
       <Badge type="alert" />

--- a/packages/react-components/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-components/src/components/Badge/Badge.stories.tsx
@@ -16,19 +16,19 @@ export const Default: Story<BadgeProps> = (
 
 Default.storyName = 'Badge';
 Default.args = {
-  children: '1',
+  count: 1,
 };
 
 export const Sizes = (): JSX.Element => (
   <>
     <StoryDescriptor title="Compact">
-      <Badge size="compact">1</Badge>
+      <Badge size="compact" count={1} />
     </StoryDescriptor>
     <StoryDescriptor title="Medium">
-      <Badge size="medium">1</Badge>
+      <Badge size="medium" count={1} />
     </StoryDescriptor>
     <StoryDescriptor title="Large">
-      <Badge size="large">1</Badge>
+      <Badge size="large" count={1} />
     </StoryDescriptor>
   </>
 );
@@ -36,21 +36,27 @@ export const Sizes = (): JSX.Element => (
 export const Kinds = (): JSX.Element => (
   <>
     <StoryDescriptor title="Primary">
-      <Badge kind="primary">1</Badge>
+      <Badge kind="primary" count={1} />
     </StoryDescriptor>
     <StoryDescriptor title="Secondary">
-      <Badge kind="secondary">1</Badge>
+      <Badge kind="secondary" count={1} />
     </StoryDescriptor>
     <StoryDescriptor title="Tertiary">
-      <Badge kind="tertiary">1</Badge>
+      <Badge kind="tertiary" count={1} />
     </StoryDescriptor>
   </>
 );
 
 export const Types = (): JSX.Element => (
   <>
-    <StoryDescriptor title="Content">
-      <Badge type="content">3 steps left</Badge>
+    <StoryDescriptor title="Count">
+      <Badge type="counter" count={1} />
+    </StoryDescriptor>
+    <StoryDescriptor title="Count with default limit">
+      <Badge type="counter" count={100} />
+    </StoryDescriptor>
+    <StoryDescriptor title="Count with custom limit">
+      <Badge type="counter" count={6} limit={5} />
     </StoryDescriptor>
     <StoryDescriptor title="Alert">
       <Badge type="alert" />

--- a/packages/react-components/src/components/Badge/Badge.tsx
+++ b/packages/react-components/src/components/Badge/Badge.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react';
+import cx from 'clsx';
 
 import styles from './Badge.module.scss';
-import cx from 'clsx';
+import { formatCount } from './Badge.helpers';
 
 const baseClass = 'badge';
 
-export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  count?: number;
+  limit?: number;
   kind?: 'primary' | 'secondary' | 'tertiary';
   size?: 'large' | 'medium' | 'compact';
-  type?: 'content' | 'alert' | 'dot';
+  type?: 'counter' | 'alert' | 'dot';
 }
 
 export const Badge: React.FC<BadgeProps> = ({
-  children,
   className,
+  count = 0,
+  limit = 99,
   kind = 'primary',
   size = 'medium',
-  type = 'content',
+  type = 'counter',
+  ...spanProps
 }) => {
   const mergedClassNames = cx(
     className,
@@ -26,10 +31,14 @@ export const Badge: React.FC<BadgeProps> = ({
   );
 
   const content = {
-    ['content']: children,
+    ['counter']: formatCount(count, limit),
     ['alert']: '!',
     ['dot']: <span className={styles[`${baseClass}__dot`]} />,
   }[type];
 
-  return <span className={mergedClassNames}>{content}</span>;
+  return (
+    <span className={mergedClassNames} {...spanProps}>
+      {content}
+    </span>
+  );
 };

--- a/packages/react-components/src/components/Badge/Badge.tsx
+++ b/packages/react-components/src/components/Badge/Badge.tsx
@@ -8,8 +8,8 @@ const baseClass = 'badge';
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   count?: number;
-  limit?: number;
   kind?: 'primary' | 'secondary' | 'tertiary';
+  max?: number;
   size?: 'large' | 'medium' | 'compact';
   type?: 'counter' | 'alert' | 'dot';
 }
@@ -17,7 +17,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 export const Badge: React.FC<BadgeProps> = ({
   className,
   count = 0,
-  limit = 99,
+  max = 99,
   kind = 'primary',
   size = 'medium',
   type = 'counter',
@@ -31,7 +31,7 @@ export const Badge: React.FC<BadgeProps> = ({
   );
 
   const content = {
-    ['counter']: formatCount(count, limit),
+    ['counter']: formatCount(count, max),
     ['alert']: '!',
     ['dot']: <span className={styles[`${baseClass}__dot`]} />,
   }[type];


### PR DESCRIPTION
Resolves: #382

## Description
* `Badge` has two new props: `count` and `max` with defaults set to `0` and `99`.
* `children` prop is no longer supported as only numeric values are allowed.
* `React.HTMLAttributes<HTMLSpanElement>` are now supported as additional props.

## Storybook
* https://feature-382--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [x] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
