### PR TITLE
#377 Alert now uses 'large' size for Icon

### DIFF
--- a/packages/react-components/src/components/Alert/Alert.tsx
+++ b/packages/react-components/src/components/Alert/Alert.tsx
@@ -77,6 +77,7 @@ export const Alert: React.FC<AlertProps> = ({
       <div className={styles[`${baseClass}__content`]}>
         <Icon
           {...IconConfig[kind]}
+          size="large"
           className={styles[`${baseClass}__content-icon`]}
         />
         <Text


### PR DESCRIPTION
Resolves: #377

## Description
* `Alert` now uses `large` size for `Icon` 

## Storybook
https://feature-377--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
