### PR TITLE
#385 Change CloseIcon size and background colour for 'info' variant

### DIFF
--- a/packages/react-components/.storybook/preview.js
+++ b/packages/react-components/.storybook/preview.js
@@ -2,6 +2,7 @@ import '../src/themes/legacy.scss';
 import '../src/themes/light.scss';
 import '../src/themes/dark.scss';
 import '../src/foundations/spacing.css';
+import '../src/foundations/shadow.css';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -21,7 +21,7 @@
     "dev:styles": "npm run build:styles -- --watch",
     "build": "run-s build:*",
     "build:lib": "tsc && vite build",
-    "build:styles": "sass src/themes:dist/themes; sass src/foundations:dist/spacing",
+    "build:styles": "sass src/themes:dist/themes; sass src/foundations:dist/spacing; sass src/foundations:dist/shadow",
     "build-storybook": "build-storybook",
     "chromatic": "dotenv -e ../../.env chromatic -- --exit-zero-on-changes",
     "lint": "eslint src --ext js,jsx,ts,tsx",

--- a/packages/react-components/src/components/Toast/Toast.module.scss
+++ b/packages/react-components/src/components/Toast/Toast.module.scss
@@ -3,86 +3,46 @@ $toast-exit-animation-timeout: 200ms;
 
 .toast {
   align-items: center;
-  background: #fff;
   border-radius: 4px;
-  box-shadow: 0 6px 30px -10px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-pop-over);
   box-sizing: border-box;
   display: inline-flex;
-  flex: 0 1 auto;
+  flex-direction: row;
   font-size: 15px;
-  font-stretch: normal;
-  font-style: normal;
-  font-weight: 600;
+  gap: 8px;
   justify-content: flex-start;
-  letter-spacing: normal;
-  line-height: 20px;
+  line-height: 22px;
   max-width: 500px;
   min-width: 300px;
   padding: 10px 12px;
 
   &__content {
     color: var(--content-default);
+    font-weight: 600;
+    min-width: 192px;
     width: 100%;
-  }
-
-  &__icon,
-  &__close {
-    align-self: baseline;
-    height: 20px;
-    padding-right: 12px;
-  }
-
-  &__icon svg {
-    display: flex;
-    fill: var(--color-action-default);
-    height: 20px;
-    width: 20px;
   }
 
   &__actions {
     align-items: center;
-    align-self: flex-start;
     display: inline-flex;
-    flex: 1 0 auto;
     flex-wrap: nowrap;
-    height: 20px;
-    margin-bottom: auto;
-    margin-left: auto;
+    gap: 8px;
 
-    &-close {
-      align-items: center;
-      display: flex;
-      flex: 0 1 auto;
-      height: 100%;
-      margin-left: 16px;
-      width: 100%;
-
-      svg {
-        cursor: pointer;
-        display: flex;
-        fill: var(--content-subtle);
-        height: 16px;
-        width: 16px;
-      }
+    &--close svg {
+      cursor: pointer;
+      fill: var(--content-subtle);
     }
 
-    &-custom {
-      background-color: transparent;
-      border: 0;
+    &--custom {
       color: var(--content-default);
-      cursor: pointer;
-      font-weight: 600;
-      line-height: 20px;
-      margin-left: 16px;
-      outline: 0;
-      padding: 0;
       text-decoration: underline;
       white-space: nowrap;
     }
-  }
 
-  &--notification {
-    background: #fff;
+    button {
+      font-weight: 400;
+    }
   }
 
   &--success {
@@ -102,14 +62,14 @@ $toast-exit-animation-timeout: 200ms;
   }
 
   &--info {
-    background: var(--color-action-default);
+    background: var(--surface-invert-default);
   }
 
   &--success,
   &--error,
   &--info {
     .toast__content,
-    .toast__actions-custom {
+    .toast__actions--custom {
       color: var(--content-invert-default);
     }
   }

--- a/packages/react-components/src/components/Toast/Toast.spec.tsx
+++ b/packages/react-components/src/components/Toast/Toast.spec.tsx
@@ -43,42 +43,34 @@ describe('<Toast> component', () => {
     expect(container.firstChild).toHaveClass(styles['toast--error']);
   });
 
-  it('should render as notification', () => {
-    const { container } = renderComponent({
-      kind: 'notification',
-    });
-
-    expect(container.firstChild).toHaveClass(styles['toast--notification']);
-  });
-
   it('should render with action button and call action function', () => {
-    const handler = vi.fn();
+    const onClick = vi.fn();
     const { getByText } = renderComponent({
       action: {
         label: 'Example action',
-        handler,
+        onClick,
       },
     });
 
     expect(getByText('Example action')).toBeVisible();
     fireEvent.click(getByText('Example action'));
-    expect(handler).toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalled();
   });
 
   it('should call action function with onClose function', () => {
-    const handler = vi.fn();
+    const onClick = vi.fn();
     const onClose = vi.fn();
     const { getByText } = renderComponent({
       action: {
         label: 'Example action',
-        handler,
-        closeOnClick: true,
+        onClick,
+        closesOnClick: true,
       },
       onClose,
     });
 
     fireEvent.click(getByText('Example action'));
-    expect(handler).toHaveBeenCalled();
+    expect(onClick).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/packages/react-components/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-components/src/components/Toast/Toast.stories.tsx
@@ -16,7 +16,6 @@ export default {
     It disappears on its own after a few seconds. It provides a feedback about an operation 
     for user.
     `,
-    exclude: { controls: { exclude: ['action'] } },
   },
   argTypes: {
     onClose: { action: 'closed' },

--- a/packages/react-components/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-components/src/components/Toast/Toast.stories.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
-import { ToastProps, Toast as ToastComponent } from './Toast';
+import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
+import { ToastProps, Toast } from './Toast';
 
 export default {
   title: 'Components/Toast',
-  component: ToastComponent,
+  component: Toast,
   parameters: {
     componentSubtitle: `
     Toast is a small message that by default shows up in the top middle of the screen. 
@@ -13,52 +14,80 @@ export default {
     for user.
     `,
   },
-} as ComponentMeta<typeof ToastComponent>;
+} as ComponentMeta<typeof Toast>;
 
-interface IToastArgs extends ToastProps {
-  label: string;
-}
+export const Default: Story<ToastProps> = (args: ToastProps) => (
+  <Toast {...args}>All systems running</Toast>
+);
+Default.storyName = 'Toast';
+Default.args = {};
 
-const StoryTemplate: Story<IToastArgs> = (args: IToastArgs) => (
-  <div>
-    <ToastComponent {...args}>Example text</ToastComponent>
-  </div>
+export const Kinds = (): JSX.Element => (
+  <>
+    <StoryDescriptor title="Success">
+      <Toast kind="success">Saved successfully</Toast>
+    </StoryDescriptor>
+    <StoryDescriptor title="Error">
+      <Toast kind="error">System error</Toast>
+    </StoryDescriptor>
+    <StoryDescriptor title="Warning">
+      <Toast kind="warning">Check your system</Toast>
+    </StoryDescriptor>
+    <StoryDescriptor title="Info">
+      <Toast kind="info">All systems running</Toast>
+    </StoryDescriptor>
+  </>
 );
 
-export const Toast = StoryTemplate.bind({});
-Toast.args = {};
+export const WithCloseIcon = (): JSX.Element => (
+  <Toast
+    kind="success"
+    removable={true}
+    onClose={() => alert('Close icon clicked')}
+  >
+    Saved successfully
+  </Toast>
+);
 
-export const SuccessToast = StoryTemplate.bind({});
-SuccessToast.args = {
-  kind: 'success',
-};
-
-export const WarningToast = StoryTemplate.bind({});
-WarningToast.args = {
-  kind: 'warning',
-};
-
-export const ErrorToast = StoryTemplate.bind({});
-ErrorToast.args = {
-  kind: 'error',
-};
-
-export const InfoToast = StoryTemplate.bind({});
-InfoToast.args = {
-  kind: 'info',
-};
-
-export const NotificationToast = StoryTemplate.bind({});
-NotificationToast.args = {
-  kind: 'notification',
-};
-
-export const ToastWithActionAndRemovable = StoryTemplate.bind({});
-ToastWithActionAndRemovable.args = {
-  action: {
-    label: 'Action',
-    handler: () => alert('onAction click'),
-  },
-  removable: true,
-  onClose: () => alert('onClose click'),
-};
+export const WithCustomAction = (): JSX.Element => (
+  <>
+    <StoryDescriptor title="Without close icon">
+      <Toast
+        kind="success"
+        action={{
+          label: 'Show details',
+          onClick: () => alert('Custom action button clicked'),
+        }}
+      >
+        Saved successfully
+      </Toast>
+    </StoryDescriptor>
+    <StoryDescriptor title="With close icon">
+      <Toast
+        kind="success"
+        removable={true}
+        action={{
+          label: 'Show details',
+          onClick: () => alert('Custom action button clicked'),
+        }}
+        onClose={() => alert('Close icon clicked')}
+      >
+        Saved successfully
+      </Toast>
+    </StoryDescriptor>
+    <StoryDescriptor title="Closing on action click">
+      <Toast
+        kind="success"
+        removable={true}
+        action={{
+          label: 'Show details',
+          onClick: () => alert('Custom action button clicked'),
+          closesOnClick: true,
+        }}
+        onClose={() => alert('Close icon clicked')}
+      >
+        Saved successfully
+      </Toast>
+    </StoryDescriptor>
+  </>
+);

--- a/packages/react-components/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-components/src/components/Toast/Toast.stories.tsx
@@ -40,12 +40,8 @@ export const Kinds = (): JSX.Element => (
 );
 
 export const WithCloseIcon = (): JSX.Element => (
-  <Toast
-    kind="success"
-    removable={true}
-    onClose={() => alert('Close icon clicked')}
-  >
-    Saved successfully
+  <Toast removable={true} onClose={() => alert('Close icon clicked')}>
+    All systems running
   </Toast>
 );
 
@@ -53,18 +49,16 @@ export const WithCustomAction = (): JSX.Element => (
   <>
     <StoryDescriptor title="Without close icon">
       <Toast
-        kind="success"
         action={{
           label: 'Show details',
           onClick: () => alert('Custom action button clicked'),
         }}
       >
-        Saved successfully
+        All systems running
       </Toast>
     </StoryDescriptor>
     <StoryDescriptor title="With close icon">
       <Toast
-        kind="success"
         removable={true}
         action={{
           label: 'Show details',
@@ -72,12 +66,11 @@ export const WithCustomAction = (): JSX.Element => (
         }}
         onClose={() => alert('Close icon clicked')}
       >
-        Saved successfully
+        All systems running
       </Toast>
     </StoryDescriptor>
     <StoryDescriptor title="Closing on action click">
       <Toast
-        kind="success"
         removable={true}
         action={{
           label: 'Show details',
@@ -86,7 +79,7 @@ export const WithCustomAction = (): JSX.Element => (
         }}
         onClose={() => alert('Close icon clicked')}
       >
-        Saved successfully
+        All systems running
       </Toast>
     </StoryDescriptor>
   </>

--- a/packages/react-components/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-components/src/components/Toast/Toast.stories.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
+import { DISABLED_CONTROLS } from '../../utils/story-parameters';
+
 import { ToastProps, Toast } from './Toast';
 
 export default {
@@ -13,6 +16,11 @@ export default {
     It disappears on its own after a few seconds. It provides a feedback about an operation 
     for user.
     `,
+    exclude: { controls: { exclude: ['action'] } },
+  },
+  argTypes: {
+    onClose: { action: 'closed' },
+    action: { control: false },
   },
 } as ComponentMeta<typeof Toast>;
 
@@ -22,7 +30,7 @@ export const Default: Story<ToastProps> = (args: ToastProps) => (
 Default.storyName = 'Toast';
 Default.args = {};
 
-export const Kinds = (): JSX.Element => (
+export const Kinds: Story = (): JSX.Element => (
   <>
     <StoryDescriptor title="Success">
       <Toast kind="success">Saved successfully</Toast>
@@ -38,12 +46,14 @@ export const Kinds = (): JSX.Element => (
     </StoryDescriptor>
   </>
 );
+Kinds.parameters = DISABLED_CONTROLS;
 
-export const WithCloseIcon = (): JSX.Element => (
-  <Toast removable={true} onClose={() => alert('Close icon clicked')}>
+export const WithCloseIcon: Story = (): JSX.Element => (
+  <Toast removable={true} onClose={action('closed')}>
     All systems running
   </Toast>
 );
+WithCloseIcon.parameters = DISABLED_CONTROLS;
 
 export const WithCustomAction = (): JSX.Element => (
   <>
@@ -51,7 +61,7 @@ export const WithCustomAction = (): JSX.Element => (
       <Toast
         action={{
           label: 'Show details',
-          onClick: () => alert('Custom action button clicked'),
+          onClick: action('closed'),
         }}
       >
         All systems running
@@ -62,9 +72,9 @@ export const WithCustomAction = (): JSX.Element => (
         removable={true}
         action={{
           label: 'Show details',
-          onClick: () => alert('Custom action button clicked'),
+          onClick: action('action-clicked'),
         }}
-        onClose={() => alert('Close icon clicked')}
+        onClose={action('closed')}
       >
         All systems running
       </Toast>
@@ -74,13 +84,14 @@ export const WithCustomAction = (): JSX.Element => (
         removable={true}
         action={{
           label: 'Show details',
-          onClick: () => alert('Custom action button clicked'),
+          onClick: action('action-clicked'),
           closesOnClick: true,
         }}
-        onClose={() => alert('Close icon clicked')}
+        onClose={action('closed')}
       >
         All systems running
       </Toast>
     </StoryDescriptor>
   </>
 );
+WithCustomAction.parameters = DISABLED_CONTROLS;

--- a/packages/react-components/src/components/Toast/Toast.tsx
+++ b/packages/react-components/src/components/Toast/Toast.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import cx from 'clsx';
-
 import {
   Close,
   Info,
@@ -8,26 +6,22 @@ import {
   CheckCircleSolid,
   Error,
 } from '@livechat/design-system-icons/react/material';
+import cx from 'clsx';
+
+import { Button } from '../Button';
 import { Icon, IconKind, IconSource } from '../Icon';
 
 import styles from './Toast.module.scss';
 
-const baseClass = 'toast';
+type ToastKind = 'success' | 'warning' | 'error' | 'info';
 
-export type ToastKind =
-  | 'success'
-  | 'warning'
-  | 'error'
-  | 'info'
-  | 'notification';
-
-interface ToastAction {
-  handler: () => void;
+type ToastAction = {
+  onClick: () => void;
   label: string;
-  closeOnClick?: boolean;
-}
+  closesOnClick?: boolean;
+};
 
-export interface ToastProps {
+export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   action?: ToastAction;
   className?: string;
   removable?: boolean;
@@ -35,7 +29,7 @@ export interface ToastProps {
   onClose?: () => void;
 }
 
-const IconConfig: Record<ToastKind, { source: IconSource; kind?: IconKind }> = {
+const iconConfig: Record<ToastKind, { source: IconSource; kind?: IconKind }> = {
   success: {
     source: CheckCircleSolid,
     kind: 'inverted',
@@ -51,11 +45,9 @@ const IconConfig: Record<ToastKind, { source: IconSource; kind?: IconKind }> = {
     source: Info,
     kind: 'inverted',
   },
-  notification: {
-    source: Info,
-    kind: 'link',
-  },
 };
+
+const baseClass = 'toast';
 
 export const Toast: React.FC<ToastProps> = ({
   action,
@@ -64,6 +56,7 @@ export const Toast: React.FC<ToastProps> = ({
   removable,
   kind = 'info',
   onClose,
+  ...divProps
 }) => {
   const mergedClassNames = cx(
     styles[baseClass],
@@ -72,44 +65,41 @@ export const Toast: React.FC<ToastProps> = ({
   );
 
   const onActionClick = (action: ToastAction) => {
-    if (action && action.closeOnClick && onClose) {
-      action.handler();
+    if (action && action.closesOnClick && onClose) {
+      action.onClick();
       return onClose();
     }
 
-    return action.handler();
+    return action.onClick();
   };
 
   return (
-    <div className={mergedClassNames}>
+    <div className={mergedClassNames} {...divProps}>
       <div className={styles[`${baseClass}__icon`]}>
-        <Icon {...IconConfig[kind]} />
+        <Icon {...iconConfig[kind]} size="medium" />
       </div>
       <div className={styles[`${baseClass}__content`]}>{children}</div>
       {(action || removable) && (
         <div className={styles[`${baseClass}__actions`]}>
           {action && (
-            <button
-              className={styles[`${baseClass}__actions-custom`]}
+            <Button
+              className={styles[`${baseClass}__actions--custom`]}
+              kind="plain"
               onClick={() => onActionClick(action)}
             >
               {action.label}
-            </button>
+            </Button>
           )}
           {removable && (
             <div
-              className={styles[`${baseClass}__actions-close`]}
+              className={styles[`${baseClass}__actions--close`]}
               aria-label="Close toast"
               onClick={onClose}
             >
               <Icon
                 source={Close}
-                size="small"
-                kind={
-                  ['warning', 'notification'].includes(kind)
-                    ? 'primary'
-                    : 'inverted'
-                }
+                size="medium"
+                kind={['warning'].includes(kind) ? 'primary' : 'inverted'}
               />
             </div>
           )}

--- a/packages/react-components/src/foundations/shadow-token.ts
+++ b/packages/react-components/src/foundations/shadow-token.ts
@@ -1,0 +1,5 @@
+export const ShadowToken = {
+  Float: '--shadow-float',
+  PopOver: '--shadow-pop-over',
+  Modal: '--shadow-modal',
+};

--- a/packages/react-components/src/foundations/shadow.css
+++ b/packages/react-components/src/foundations/shadow.css
@@ -1,0 +1,5 @@
+:root {
+  --shadow-float: 0 2px 6px rgba(66, 77, 87, 0.4);
+  --shadow-pop-over: 0 6px 20px rgba(66, 77, 87, 0.4);
+  --shadow-modal: 0 10px 50px rgba(66, 77, 87, 0.4);
+}

--- a/packages/react-components/src/index.scss
+++ b/packages/react-components/src/index.scss
@@ -2,6 +2,7 @@
 @use './themes/light';
 @use './themes/dark';
 @use './foundations/spacing';
+@use './foundations/shadow';
 
 *[class^='lc-'] {
   box-sizing: border-box;

--- a/packages/react-components/src/index.ts
+++ b/packages/react-components/src/index.ts
@@ -2,8 +2,10 @@ import './index.scss';
 
 export { DesignToken } from './themes/design-token';
 export { SpacingToken } from './foundations/spacing-token';
+export { ShadowToken } from './foundations/shadow-token';
 
 export * from './components/Alert';
+export * from './components/Avatar';
 export * from './components/Badge';
 export * from './components/Button';
 export * from './components/ButtonGroup';

--- a/packages/react-components/src/utils/story-parameters.ts
+++ b/packages/react-components/src/utils/story-parameters.ts
@@ -1,0 +1,5 @@
+import { Parameters } from '@storybook/react';
+
+export const DISABLED_CONTROLS: Parameters = {
+  controls: { disable: true },
+};


### PR DESCRIPTION
Resolves: #385

## Description
* Added basic `shadow` tokens
* Reorganized `Toast` styles (mostly simplified)
* Removed `notification` kind, fixed color tokens for `info` kind
* Added more advanced stories for `Toast`
* Added missing export of `Avatar`
* Renamed some `Toast` props to follow convention

## Storybook
https://feature-385--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [x] Design review
- [x] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
