### PR TITLE
#386 Separate disabled and locked states in Switch component

### DIFF
--- a/packages/react-components/src/components/Switch/Switch.spec.tsx
+++ b/packages/react-components/src/components/Switch/Switch.spec.tsx
@@ -39,14 +39,13 @@ describe('Switch', () => {
   });
 
   it('should be disabled if disabled is set to true', () => {
-    const { getByRole, queryByTestId } = render(<Switch disabled={true} />);
+    const { getByRole } = render(<Switch disabled={true} />);
     const checkbox = getByRole('checkbox') as HTMLInputElement;
     expect(checkbox.disabled).toEqual(true);
-    expect(queryByTestId('disabled-icon')).toBeVisible();
   });
 
-  it('should have loader icon visible if loading is set to true', () => {
-    const { container, getByRole } = render(<Switch loading={true} />);
+  it('should display loader icon if in loading state and behave as disabled', () => {
+    const { container, getByRole } = render(<Switch state="loading" />);
     const checkbox = getByRole('checkbox') as HTMLInputElement;
     const loader = container.querySelector(
       `.${loaderStyles['loader__spinner']}`
@@ -55,16 +54,12 @@ describe('Switch', () => {
     expect(loader).toBeVisible();
   });
 
-  it('should always show loader icon on top if there are other icons to be displayed', () => {
-    const { container, getByRole, queryByTestId } = render(
-      <Switch loading={true} disabled={true} />
-    );
+  it('should display lock icon if in locked state and behave as disabled', () => {
+    const { getByTestId, getByRole } = render(<Switch state="locked" />);
     const checkbox = getByRole('checkbox') as HTMLInputElement;
-    const loader = container.querySelector(
-      `.${loaderStyles['loader__spinner']}`
-    );
-    expect(loader).toBeVisible();
+    const lockIcon = getByTestId('lock-icon');
+
     expect(checkbox.disabled).toEqual(true);
-    expect(queryByTestId('disabled-icon')).not.toBeInTheDocument();
+    expect(lockIcon).toBeVisible();
   });
 });

--- a/packages/react-components/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-components/src/components/Switch/Switch.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
+import { DISABLED_CONTROLS } from '../../utils/story-parameters';
 
 import { Switch, SwitchProps } from './Switch';
 
@@ -15,7 +16,25 @@ export const Default: Story<SwitchProps> = (args: SwitchProps) => (
 );
 Default.storyName = 'Switch';
 
-export const States = (): JSX.Element => (
+export const States: Story = (): JSX.Element => (
+  <>
+    <StoryDescriptor title="Regular">
+      <Switch on={true} state="regular" />
+      <Switch on={false} state="regular" />
+    </StoryDescriptor>
+    <StoryDescriptor title="Loading">
+      <Switch on={true} state="loading" />
+      <Switch on={false} state="loading" />
+    </StoryDescriptor>
+    <StoryDescriptor title="Locked">
+      <Switch on={true} state="locked" />
+      <Switch on={false} state="locked" />
+    </StoryDescriptor>
+  </>
+);
+States.parameters = DISABLED_CONTROLS;
+
+export const Availability: Story = (): JSX.Element => (
   <>
     <StoryDescriptor title="Enabled">
       <Switch on={true} />
@@ -25,14 +44,11 @@ export const States = (): JSX.Element => (
       <Switch on={true} disabled={true} />
       <Switch on={false} disabled={true} />
     </StoryDescriptor>
-    <StoryDescriptor title="Loading">
-      <Switch on={true} loading={true} />
-      <Switch on={false} loading={true} />
-    </StoryDescriptor>
   </>
 );
+Availability.parameters = DISABLED_CONTROLS;
 
-export const Sizes = (): JSX.Element => (
+export const Sizes: Story = (): JSX.Element => (
   <>
     <StoryDescriptor title="Compact">
       <Switch size="compact" />
@@ -45,3 +61,4 @@ export const Sizes = (): JSX.Element => (
     </StoryDescriptor>
   </>
 );
+Sizes.parameters = DISABLED_CONTROLS;

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -11,27 +11,29 @@ import { Loader } from '../Loader';
 export const baseClass = 'switch';
 
 export type SwitchSize = 'compact' | 'medium' | 'large';
+export type SwitchState = 'regular' | 'loading' | 'locked';
+
 export interface SwitchProps {
   className?: string;
   defaultOn?: boolean;
   disabled?: boolean;
-  loading?: boolean;
   innerRef?: React.LegacyRef<HTMLInputElement> | undefined;
   name?: string;
   on?: boolean;
   onChange?(e: React.FormEvent, value: boolean): void;
   size?: SwitchSize;
+  state?: SwitchState;
 }
 
 export const Switch: React.FC<SwitchProps> = ({
   className = '',
   defaultOn = false,
   disabled = false,
-  loading = false,
   name = baseClass,
   on,
   onChange = noop,
   size = 'large',
+  state = 'regular',
   innerRef,
   ...props
 }) => {
@@ -45,16 +47,17 @@ export const Switch: React.FC<SwitchProps> = ({
     }
   }, [on]);
 
+  const isLoading = state === 'loading';
+  const isLocked = state === 'locked';
   const iconSize: IconSize = size === 'large' ? 'small' : 'xsmall';
   const toggleStyles = checked ? 'on' : 'off';
-  const shouldBehaveAsDisabled = disabled || loading;
+  const shouldBehaveAsDisabled = disabled || isLoading || isLocked;
   const availabilityStyles = shouldBehaveAsDisabled ? 'disabled' : 'enabled';
   const mergedClassNames = cx(
     styles[baseClass],
     styles[`${baseClass}--${size}`],
     className
   );
-  const shouldShowDisabledIcon = disabled && !loading;
 
   const handleChange = (e: React.FormEvent) => {
     const hasOnChangePassed = onChange !== noop;
@@ -97,7 +100,7 @@ export const Switch: React.FC<SwitchProps> = ({
             styles[`${baseClass}__slider--${size}--${toggleStyles}`]
           )}
         >
-          {loading && (
+          {isLoading && (
             <Loader
               className={cx(
                 styles[`${baseClass}__loader`],
@@ -105,9 +108,9 @@ export const Switch: React.FC<SwitchProps> = ({
               )}
             />
           )}
-          {shouldShowDisabledIcon && (
+          {isLocked && (
             <Icon
-              data-testid="disabled-icon"
+              data-testid="lock-icon"
               size={iconSize}
               source={LockIcon}
               kind="primary"


### PR DESCRIPTION
Resolves: #386

## Description
- Introduced `state` prop with values of `regular`, `locked`, and `loading`.
- Removed `loading` boolean prop.
- `locked` and `loading` variants behave as disabled.
- In the `regular` state `disabled` availability has no icons.

## Storybook
https://feature-386--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [x] Design review
- [x] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
