### PR TITLE
#332 z-index for Popover component

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.module.scss
+++ b/packages/react-components/src/components/Popover/Popover.module.scss
@@ -5,7 +5,7 @@
   display: none;
   max-width: 336px;
   min-width: 168px;
-  z-index: 1000;
+  z-index: $stacking-context-level-popover;
 
   &:focus {
     outline: none;

--- a/packages/react-components/src/components/Popover/Popover.module.scss
+++ b/packages/react-components/src/components/Popover/Popover.module.scss
@@ -5,6 +5,7 @@
   display: none;
   max-width: 336px;
   min-width: 168px;
+  z-index: 1000;
 
   &:focus {
     outline: none;

--- a/packages/react-components/src/components/Popover/Popover.module.scss
+++ b/packages/react-components/src/components/Popover/Popover.module.scss
@@ -1,3 +1,5 @@
+@import '../../utils/StackingContextLevel';
+
 .popover {
   background-color: var(--surface-basic-default);
   border-radius: 4px;

--- a/packages/react-components/src/utils/StackingContextLevel.scss
+++ b/packages/react-components/src/utils/StackingContextLevel.scss
@@ -2,5 +2,5 @@
  * Definition of z-index values to be used across application.
  */
 
-$stacking-context-level-dropdown: 10000;
-$stacking-context-level-popover: 11000;
+$stacking-context-level-dropdown: 2000;
+$stacking-context-level-popover: 1000;

--- a/packages/react-components/src/utils/StackingContextLevel.scss
+++ b/packages/react-components/src/utils/StackingContextLevel.scss
@@ -3,3 +3,4 @@
  */
 
 $stacking-context-level-dropdown: 10000;
+$stacking-context-level-popover: 11000;


### PR DESCRIPTION
Resolves: #[332](https://github.com/livechat/design-system/issues/332)

## Description
It seems to be enough to fix stuff like:
https://monosnap.com/file/agb5EyL9CrbJqO8E0vNQhtUAo6BYOo

## Storybook
https://613a8e945a5665003a05113b-iaeypnmfan.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [x] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
