### PR TITLE
#418 Add closeOnOverlayPress prop to Modal

### DIFF
--- a/packages/react-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-components/src/components/Modal/Modal.stories.tsx
@@ -30,6 +30,7 @@ Modal.args = {
   heading: 'Modal',
   children: 'Modal content',
   closeOnEscPress: true,
+  closeOnOverlayPress: true,
   style: { width: '600px', height: '400px' },
   footer: (
     <React.Fragment>

--- a/packages/react-components/src/components/Modal/ModalBase.spec.tsx
+++ b/packages/react-components/src/components/Modal/ModalBase.spec.tsx
@@ -55,4 +55,16 @@ describe('<ModalBase /> component', () => {
     userEvent.keyboard('[Escape]');
     expect(onClose).not.toBeCalled();
   });
+
+  it('should not call onClose on overlay pressed when closeOnOverlayPress is disabled', () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <ModalBase onClose={onClose} closeOnOverlayPress={false}>
+        test
+      </ModalBase>
+    );
+
+    userEvent.click(getByTestId('lc-modal-overlay'));
+    expect(onClose).not.toBeCalled();
+  });
 });

--- a/packages/react-components/src/components/Modal/ModalBase.tsx
+++ b/packages/react-components/src/components/Modal/ModalBase.tsx
@@ -8,6 +8,7 @@ import styles from './Modal.module.scss';
 export interface ModalBaseProps extends React.HTMLAttributes<HTMLDivElement> {
   onClose(): void;
   closeOnEscPress?: boolean;
+  closeOnOverlayPress?: boolean;
 }
 
 const baseClass = 'modal-base';
@@ -17,6 +18,7 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
   className = '',
   onClose,
   closeOnEscPress = true,
+  closeOnOverlayPress = true,
   ...props
 }) => {
   const mergedClassNames = cx(styles[baseClass], className);
@@ -37,7 +39,7 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
   }, [closeOnEscPress]);
 
   const onOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
+    if (closeOnOverlayPress && event.target === event.currentTarget) {
       onClose();
     }
   };


### PR DESCRIPTION
Resolves: #418 
## Description
Adding a new property to the Modal component to allow not to close modal on overlay click.

## Storybook
https://feature-418--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
