### PR TITLE
#423 Provide way of passing flip parameters to Popover component

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -32,7 +32,7 @@ const placements = [
 ];
 
 const provideFallbackPlacement = (flipOptions: Placement) => {
-  const hasNoFallback = (flipOptions as string) === 'none';
+  const hasNoFallback = (flipOptions as string) === 'default';
   const hasNotChosen = Object.keys(flipOptions).length === 0;
 
   return hasNoFallback || hasNotChosen
@@ -40,7 +40,7 @@ const provideFallbackPlacement = (flipOptions: Placement) => {
     : { fallbackPlacements: [flipOptions] };
 };
 
-const placementsWithUnselect = ['none', ...placements];
+const placementsWithUnselect = ['default', ...placements];
 
 const OpenChat = () => {
   return (

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { Placement } from '@floating-ui/react-dom';
-
 import { Button } from '../Button';
 import { Popover as PopoverComponent } from './Popover';
 
@@ -31,6 +30,8 @@ const placements = [
   'bottom-end',
   'left-end',
 ];
+
+const placementsWithUnselect = ['none', ...placements];
 
 const OpenChat = () => {
   return (
@@ -67,14 +68,21 @@ const BanCustomer = () => {
 export const Popover = ({
   placement,
   isVisible,
+  flipOptions,
 }: {
   placement: Placement;
   isVisible: boolean;
+  flipOptions: Placement;
 }): React.ReactElement => (
   <div className="wrap">
     <PopoverComponent
       placement={placement}
       isVisible={isVisible}
+      flipOptions={
+        (flipOptions as string) === 'none'
+          ? undefined
+          : { fallbackPlacements: [flipOptions] }
+      }
       triggerRenderer={() => (
         <Button icon={<Icon source={DropDown}></Icon>} iconPosition={'right'}>
           Open Popover
@@ -112,20 +120,28 @@ export const Popover = ({
 
 Popover.args = {
   placement: 'bottom-start',
+  flipOptions: {},
   isVisible: true,
 };
 
 export const Actions = ({
   placement,
   isVisible,
+  flipOptions,
 }: {
   placement: Placement;
   isVisible: boolean;
+  flipOptions: Placement;
 }): React.ReactElement => (
   <div style={{ minHeight: '200px' }}>
     <PopoverComponent
       placement={placement}
       isVisible={isVisible}
+      flipOptions={
+        (flipOptions as string) === 'none'
+          ? undefined
+          : { fallbackPlacements: [flipOptions] }
+      }
       triggerRenderer={() => (
         <Button icon={<Icon source={DropDown}></Icon>} iconPosition={'right'}>
           Actions
@@ -149,6 +165,7 @@ export const Actions = ({
 Actions.args = {
   placement: 'bottom-start',
   isVisible: true,
+  flipOptions: {},
 };
 
 export default {
@@ -160,6 +177,13 @@ export default {
       control: {
         type: 'select',
         labels: placements,
+      },
+    },
+    flipOptions: {
+      options: placementsWithUnselect,
+      control: {
+        type: 'select',
+        labels: placementsWithUnselect,
       },
     },
   },

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -185,6 +185,7 @@ export default {
         type: 'select',
         labels: placementsWithUnselect,
       },
+      name: 'flipOptions.fallbackPlacements',
     },
   },
 } as ComponentMeta<typeof Popover>;

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -31,6 +31,15 @@ const placements = [
   'left-end',
 ];
 
+const provideFallbackPlacement = (flipOptions: Placement) => {
+  const hasNoFallback = (flipOptions as string) === 'none';
+  const hasNotChosen = Object.keys(flipOptions).length === 0;
+
+  return hasNoFallback || hasNotChosen
+    ? undefined
+    : { fallbackPlacements: [flipOptions] };
+};
+
 const placementsWithUnselect = ['none', ...placements];
 
 const OpenChat = () => {
@@ -78,11 +87,7 @@ export const Popover = ({
     <PopoverComponent
       placement={placement}
       isVisible={isVisible}
-      flipOptions={
-        (flipOptions as string) === 'none'
-          ? undefined
-          : { fallbackPlacements: [flipOptions] }
-      }
+      flipOptions={provideFallbackPlacement(flipOptions)}
       triggerRenderer={() => (
         <Button icon={<Icon source={DropDown}></Icon>} iconPosition={'right'}>
           Open Popover
@@ -132,35 +137,33 @@ export const Actions = ({
   placement: Placement;
   isVisible: boolean;
   flipOptions: Placement;
-}): React.ReactElement => (
-  <div style={{ minHeight: '200px' }}>
-    <PopoverComponent
-      placement={placement}
-      isVisible={isVisible}
-      flipOptions={
-        (flipOptions as string) === 'none'
-          ? undefined
-          : { fallbackPlacements: [flipOptions] }
-      }
-      triggerRenderer={() => (
-        <Button icon={<Icon source={DropDown}></Icon>} iconPosition={'right'}>
-          Actions
-        </Button>
-      )}
-    >
-      <div
-        style={{
-          minWidth: '200px',
-        }}
+}): React.ReactElement => {
+  return (
+    <div style={{ minHeight: '200px' }}>
+      <PopoverComponent
+        placement={placement}
+        isVisible={isVisible}
+        flipOptions={provideFallbackPlacement(flipOptions)}
+        triggerRenderer={() => (
+          <Button icon={<Icon source={DropDown}></Icon>} iconPosition={'right'}>
+            Actions
+          </Button>
+        )}
       >
-        <OpenChat />
-        <CreateTicket />
-        <SendTranscript />
-        <BanCustomer />
-      </div>
-    </PopoverComponent>
-  </div>
-);
+        <div
+          style={{
+            minWidth: '200px',
+          }}
+        >
+          <OpenChat />
+          <CreateTicket />
+          <SendTranscript />
+          <BanCustomer />
+        </div>
+      </PopoverComponent>
+    </div>
+  );
+};
 
 Actions.args = {
   placement: 'bottom-start',

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -6,7 +6,9 @@ import {
   flip,
   offset,
   autoUpdate,
+  DetectOverflowOptions,
 } from '@floating-ui/react-dom';
+import type { Options as FlipOptions } from '@floating-ui/core/src/middleware/flip';
 
 import cssStyles from './Popover.module.scss';
 
@@ -15,6 +17,7 @@ export interface IPopoverProps {
   className?: string;
   placement?: Placement;
   isVisible?: boolean;
+  flipOptions?: Partial<FlipOptions & DetectOverflowOptions>;
   triggerRenderer: () => React.ReactNode;
 }
 
@@ -24,6 +27,7 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
     children,
     className,
     placement,
+    flipOptions,
     isVisible = false,
   } = props;
   const [visible, setVisibility] = React.useState(false);
@@ -38,7 +42,7 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
     update,
     placement: updatedPlacement,
   } = useFloating({
-    middleware: [offset(4), flip()],
+    middleware: [offset(4), flip(flipOptions)],
     placement: placement,
   });
 

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -6,9 +6,7 @@ import {
   flip,
   offset,
   autoUpdate,
-  DetectOverflowOptions,
 } from '@floating-ui/react-dom';
-import type { Options as FlipOptions } from '@floating-ui/core/src/middleware/flip';
 
 import cssStyles from './Popover.module.scss';
 
@@ -17,7 +15,7 @@ export interface IPopoverProps {
   className?: string;
   placement?: Placement;
   isVisible?: boolean;
-  flipOptions?: Partial<FlipOptions & DetectOverflowOptions>;
+  flipOptions?: Parameters<typeof flip>[0];
   triggerRenderer: () => React.ReactNode;
 }
 


### PR DESCRIPTION
Resolves #423

## Description
One of the teams has reported that the Popover component lacks options when it comes to placement.
This PR provides a way of passing options for flip() method available in floatingUI library
https://floating-ui.com/docs/flip

## Storybook
https://popover-more-options--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [x] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
