### PR TITLE
#440 Change on focus property from box shadow to filter

### DIFF
--- a/packages/react-components/src/components/Button/Button.module.scss
+++ b/packages/react-components/src/components/Button/Button.module.scss
@@ -28,7 +28,7 @@ $base-class: 'btn';
   }
 
   &:focus {
-    box-shadow: 0 0 1px 2px rgb(var(--color-action-default-rgb) 0.7);
+    filter: drop-shadow(0 0 1px 2px rgb(var(--color-action-default-rgb) 0.7));
   }
 
   &--disabled {


### PR DESCRIPTION
Resolves: #440 and https://livechatinc.atlassian.net/browse/AA-13976

## Description
When we use buttons and add the margin, the button's highlights are not in the right place. I changed from `box-shadow` to the `filter: drop-shadow` property. 

## Design
Before: 
<img width="300" alt="Screenshot 2022-10-03 at 10 21 30" src="https://user-images.githubusercontent.com/50942512/193533176-761984b1-c8da-4853-86b5-124e58e10b82.png">

After: 
<img width="247" alt="Screenshot 2022-10-03 at 10 26 32" src="https://user-images.githubusercontent.com/50942512/193533185-fb5e3e3b-f526-4551-b9b6-e3edaf9b1f5e.png">

## Storybook
https://feature-AA-13976--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
