### PR TITLE
#437: Add class name prop to `SearchInput` 

### DIFF
--- a/packages/react-components/src/components/Search/Search.spec.tsx
+++ b/packages/react-components/src/components/Search/Search.spec.tsx
@@ -125,4 +125,13 @@ describe('<Search> component', () => {
     fireEvent.click(getByTestId(`${baseClass}-clear-icon`));
     expect(getByRole('textbox')).toHaveValue('');
   });
+
+  it('should apply className prop', () => {
+    const { getByRole } = renderComponent({
+      ...defaultProps,
+      className: 'test-class',
+    });
+
+    expect(getByRole('textbox')).toHaveClass('test-class');
+  });
 });

--- a/packages/react-components/src/components/Search/Search.tsx
+++ b/packages/react-components/src/components/Search/Search.tsx
@@ -26,6 +26,7 @@ export interface ISearchInputProps {
   placeholder?: string;
   size?: SearchSize;
   value?: string;
+  className?: string;
   onChange: (value: string) => void;
 }
 
@@ -36,6 +37,7 @@ export const SearchInput: React.FC<ISearchInputProps> = ({
   placeholder = 'Search ...',
   size = SearchSize.Medium,
   value,
+  className,
   onChange,
 }) => {
   const [searchValue, setSearchValue] = React.useState<string>(value || '');
@@ -44,6 +46,7 @@ export const SearchInput: React.FC<ISearchInputProps> = ({
   const isCloseIconVisible = !!searchValue && !isDisabled && !isLoading;
 
   const mergedClassNames = cx(
+    className,
     styles[`${inputBaseClass}`],
     styles[`${inputBaseClass}--${size}`],
     (isDisabled || isLoading) && styles[`${inputBaseClass}--disabled`],


### PR DESCRIPTION
Resolves: #437

## Description
Add class name prop to `SearchInput` component

## Storybook
https://searchInput-add-classname--613a8e945a5665003a05113b.chromatic.com/

## Checklist

- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [x] Design review
- [x] Functional (QA) review


