### PR TITLE
[Switch] Allow accessible name for switch input element

### DIFF
--- a/packages/react-components/src/components/Switch/Switch.spec.tsx
+++ b/packages/react-components/src/components/Switch/Switch.spec.tsx
@@ -62,4 +62,12 @@ describe('Switch', () => {
     expect(checkbox.disabled).toEqual(true);
     expect(lockIcon).toBeVisible();
   });
+
+  it('should allow setting accessible name for input element', () => {
+    const label = 'Hello world';
+    const { getByRole } = render(<Switch on={true} ariaLabel={label} />);
+
+    const checkbox = getByRole('checkbox', { name: label });
+    expect(checkbox).toHaveAccessibleName(label);
+  });
 });

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -14,6 +14,7 @@ export type SwitchSize = 'compact' | 'medium' | 'large';
 export type SwitchState = 'regular' | 'loading' | 'locked';
 
 export interface SwitchProps {
+  ariaLabel?: string;
   className?: string;
   defaultOn?: boolean;
   disabled?: boolean;
@@ -23,7 +24,6 @@ export interface SwitchProps {
   onChange?(e: React.FormEvent, value: boolean): void;
   size?: SwitchSize;
   state?: SwitchState;
-  ariaLabel?: string;
 }
 
 export const Switch: React.FC<SwitchProps> = ({
@@ -35,8 +35,8 @@ export const Switch: React.FC<SwitchProps> = ({
   onChange = noop,
   size = 'large',
   state = 'regular',
-  ariaLabel,
   innerRef,
+  ariaLabel,
   ...props
 }) => {
   const [checked, setChecked] = React.useState(() =>

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -23,6 +23,7 @@ export interface SwitchProps {
   onChange?(e: React.FormEvent, value: boolean): void;
   size?: SwitchSize;
   state?: SwitchState;
+  ariaLabel?: string;
 }
 
 export const Switch: React.FC<SwitchProps> = ({
@@ -34,6 +35,7 @@ export const Switch: React.FC<SwitchProps> = ({
   onChange = noop,
   size = 'large',
   state = 'regular',
+  ariaLabel,
   innerRef,
   ...props
 }) => {
@@ -82,7 +84,7 @@ export const Switch: React.FC<SwitchProps> = ({
         name={name}
         ref={innerRef}
         disabled={shouldBehaveAsDisabled}
-        test-id="foo"
+        aria-label={ariaLabel}
         {...props}
       />
       <span className={styles[`${baseClass}__container`]}>


### PR DESCRIPTION
Resolves: #444

## Description
At the moment looks like there is no way to set either `aria-label` or `aria-labelledby` for checkbox input element inside the switch. 
I propose to add new optional property for Switch interface to allow setting accessible name (one of several ways to achieve it). 
I also removed test-id that seems to be some kind of leftover after moving components to new DS setup. I didn't find any usage of this `foo` test id in the repository. I think leaving it there was not intentional.

<img width="1320" alt="Screenshot 2022-10-17 at 08 27 49" src="https://user-images.githubusercontent.com/58426925/196105472-fcbf6265-c2ae-49bf-8da5-ee8d5fdb709c.png">


## Storybook
https://feature-v1-switch-accessibility-props--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [x] Accessibility cases (keyboard control, correct HTML markup, etc.)
