### PR TITLE
[CARD] use default layout for nested components 

### DIFF
--- a/packages/react-components/src/components/Card/Card.module.scss
+++ b/packages/react-components/src/components/Card/Card.module.scss
@@ -47,10 +47,7 @@ $base-class: card;
 
   &__content,
   &__expanded-content {
-    display: flex;
-    flex-direction: column;
     gap: 10px;
-    align-items: flex-start;
     margin: 0;
     width: 100%;
   }

--- a/packages/react-components/src/components/Card/Card.module.scss
+++ b/packages/react-components/src/components/Card/Card.module.scss
@@ -48,7 +48,7 @@ $base-class: card;
   &__content,
   &__expanded-content {
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     gap: 10px;
     align-items: flex-start;
     margin: 0;


### PR DESCRIPTION
Resolves: #421 

## Description

The previous version of the Card component had its children positioned vertically, not horizontally. This change makes sure that the current version does not introduce a regression.

## Storybook
https://feature-421--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
