### PR TITLE
#399 [Tab] Improvements

### DIFF
--- a/packages/react-components/src/components/Tab/Tab.module.scss
+++ b/packages/react-components/src/components/Tab/Tab.module.scss
@@ -1,56 +1,88 @@
 .tab {
-  align-items: center;
-  background: none;
-  border: 0;
-  color: var(--content-default);
-  cursor: pointer;
   display: flex;
-  flex-direction: row;
-  margin: 0 8px 11px;
-  outline: none;
-  overflow: visible;
-  padding: 0 12px 1px;
   position: relative;
+  flex-direction: row;
+  align-items: center;
   transition: color 0.25s;
-
-  &__description {
-    color: var(--content-subtle);
-    display: inline-block;
-    padding-left: 3px;
-    transition: color 0.25s;
-  }
+  margin: 0 8px;
+  outline: none;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  padding: 0 12px 1px;
+  overflow: visible;
+  color: var(--content-default);
 
   &::before {
-    background-color: var(--color-action-default);
-    bottom: 0;
-    content: '';
     display: block;
-    height: 0;
-    left: 0;
     position: absolute;
     right: 0;
+    bottom: 0;
+    left: 0;
     z-index: 1;
+    background-color: var(--color-action-default);
+    height: 0;
+    content: '';
+  }
+
+  &:hover {
+    text-decoration: none;
+    color: var(--color-action-default);
+
+    .tab__count {
+      color: var(--color-action-default);
+    }
+  }
+
+  &--compact {
+    height: 32px;
+  }
+
+  &--medium {
+    height: 40px;
+  }
+
+  &--large {
+    height: 48px;
+  }
+
+  &__count {
+    display: inline-block;
+    transition: color 0.25s;
+    padding-left: 3px;
+    color: var(--content-subtle);
+  }
+
+  &__badge {
+    margin-left: 4px;
   }
 
   &--selected {
     color: var(--color-action-default);
 
-    .tab__description {
-      color: var(--color-action-default);
+    &::before {
+      height: 3px;
     }
 
-    &::before {
-      bottom: -12px;
-      height: 3px;
+    .tab__count {
+      color: var(--color-action-default);
     }
   }
 
-  &:hover {
-    color: var(--color-action-default);
-    text-decoration: none;
+  &--disabled {
+    cursor: not-allowed;
+    color: var(--content-disabled);
 
-    .tab__description {
-      color: var(--color-action-default);
+    &:hover {
+      color: var(--content-disabled);
+
+      .tab__count {
+        color: var(--content-disabled);
+      }
+    }
+
+    .tab__count {
+      color: var(--content-disabled);
     }
   }
 }

--- a/packages/react-components/src/components/Tab/Tab.spec.tsx
+++ b/packages/react-components/src/components/Tab/Tab.spec.tsx
@@ -15,9 +15,37 @@ describe('<Tab /> component', () => {
     expect(getByText('Hello')).toHaveClass(styles['tab--selected']);
   });
 
-  it('should render properly formatted description', () => {
-    const { getByText } = render(<Tab description="1">Hello</Tab>);
+  it("should render disabled Tab if 'disabled' is provided", () => {
+    const { getByText } = render(<Tab disabled>Hello</Tab>);
+    expect(getByText('Hello')).toHaveClass(styles['tab--disabled']);
+  });
+
+  it('should render Tab with medium size by default', () => {
+    const { getByText } = render(<Tab>Hello</Tab>);
+    expect(getByText('Hello')).toHaveClass(styles['tab--medium']);
+  });
+
+  it('should render Tab with compact size', () => {
+    const { getByText } = render(<Tab size="compact">Hello</Tab>);
+    expect(getByText('Hello')).toHaveClass(styles['tab--compact']);
+  });
+
+  it('should render Tab with large size', () => {
+    const { getByText } = render(<Tab size="large">Hello</Tab>);
+    expect(getByText('Hello')).toHaveClass(styles['tab--large']);
+  });
+
+  it('should render properly formatted counter', () => {
+    const { getByText } = render(<Tab count={1}>Hello</Tab>);
     expect(getByText('(1)')).toBeVisible();
+  });
+  it('should render properly formatted counter as a badge', () => {
+    const { getByTestId } = render(
+      <Tab count={1} asBadge>
+        Hello
+      </Tab>
+    );
+    expect(getByTestId('tab-badge')).toBeVisible();
   });
 
   it('should render with button element by default', () => {

--- a/packages/react-components/src/components/Tab/Tab.stories.tsx
+++ b/packages/react-components/src/components/Tab/Tab.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { Tab as TabComponent, TabProps } from './Tab';
+import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
 
 export default {
   title: 'Components/Tabs',
@@ -15,6 +16,70 @@ export const Tab = (args: ITabArgs): React.ReactElement => {
 };
 
 Tab.args = {
-  children: 'Lorem ipsum',
-  description: '1',
+  children: 'Tab',
+  count: 1,
 } as ITabArgs;
+
+export const StatesAndVariants = (): JSX.Element => (
+  <>
+    <StoryDescriptor title="Basic">
+      <Tab>Tab</Tab>
+      <Tab isSelected>Tab selected</Tab>
+      <Tab disabled>Tab disabled</Tab>
+    </StoryDescriptor>
+    <StoryDescriptor title="With counter">
+      <Tab count={3}>Tab</Tab>
+      <Tab count={3} isSelected>
+        Tab selected
+      </Tab>
+      <Tab count={3} disabled>
+        Tab disabled
+      </Tab>
+    </StoryDescriptor>
+    <StoryDescriptor title="With counter as badge">
+      <Tab count={3} asBadge>
+        Tab
+      </Tab>
+      <Tab count={3} asBadge isSelected>
+        Tab selected
+      </Tab>
+      <Tab count={3} asBadge disabled>
+        Tab disabled
+      </Tab>
+    </StoryDescriptor>
+  </>
+);
+
+export const Sizes = (): JSX.Element => (
+  <>
+    <StoryDescriptor title="Compact">
+      <Tab size="compact">Tab</Tab>
+      <Tab size="compact" isSelected>
+        Tab selected
+      </Tab>
+      <Tab size="compact" disabled>
+        Tab disabled
+      </Tab>
+    </StoryDescriptor>
+    <StoryDescriptor title="Medium">
+      <Tab size="medium">Tab</Tab>
+      <Tab size="medium" isSelected>
+        Tab selected
+      </Tab>
+      <Tab size="medium" disabled>
+        Tab disabled
+      </Tab>
+    </StoryDescriptor>
+    <StoryDescriptor title="Large">
+      <Tab size="large" asBadge>
+        Tab
+      </Tab>
+      <Tab size="large" asBadge isSelected>
+        Tab selected
+      </Tab>
+      <Tab size="large" asBadge disabled>
+        Tab disabled
+      </Tab>
+    </StoryDescriptor>
+  </>
+);

--- a/packages/react-components/src/components/Tab/Tab.tsx
+++ b/packages/react-components/src/components/Tab/Tab.tsx
@@ -30,6 +30,8 @@ export const Tab: React.FC<TabProps> = ({
 }) => {
   const { disabled } =
     restProps as React.ButtonHTMLAttributes<HTMLButtonElement>;
+  const shouldDisplayAsCounter = count && !asBadge;
+  const shouldDisplayAsBadge = count && asBadge;
 
   return (
     <Text
@@ -46,12 +48,12 @@ export const Tab: React.FC<TabProps> = ({
       )}
     >
       {children}
-      {count && !asBadge && (
+      {shouldDisplayAsCounter && (
         <Text as="span" size="md" className={styles[`${baseClass}__count`]}>
           ({count})
         </Text>
       )}
-      {count && asBadge && (
+      {shouldDisplayAsBadge && (
         <Badge
           data-testid="tab-badge"
           count={count}

--- a/packages/react-components/src/components/Tab/Tab.tsx
+++ b/packages/react-components/src/components/Tab/Tab.tsx
@@ -3,14 +3,18 @@ import cx from 'clsx';
 import { Text } from '../Typography';
 
 import styles from './Tab.module.scss';
+import { Badge } from '../Badge';
+import { Size } from 'utils';
 
 type HTMLProps =
   | (React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string })
   | (React.ButtonHTMLAttributes<HTMLButtonElement> & { href?: never });
 
 export type TabProps = HTMLProps & {
-  description?: React.ReactNode;
+  count?: number;
   isSelected?: boolean;
+  asBadge?: boolean;
+  size?: Size;
 };
 
 const baseClass = 'tab';
@@ -18,10 +22,15 @@ const baseClass = 'tab';
 export const Tab: React.FC<TabProps> = ({
   children,
   className,
-  description,
+  count,
   isSelected,
+  asBadge,
+  size = 'medium',
   ...restProps
 }) => {
+  const { disabled } =
+    restProps as React.ButtonHTMLAttributes<HTMLButtonElement>;
+
   return (
     <Text
       {...restProps}
@@ -29,20 +38,26 @@ export const Tab: React.FC<TabProps> = ({
       size="md"
       bold={isSelected}
       className={cx(
-        styles[baseClass],
         className,
-        isSelected && styles[`${baseClass}--selected`]
+        styles[baseClass],
+        styles[`${baseClass}--${size}`],
+        isSelected && styles[`${baseClass}--selected`],
+        disabled && styles[`${baseClass}--disabled`]
       )}
     >
       {children}
-      {description && (
-        <Text
-          as="span"
-          size="md"
-          className={styles[`${baseClass}__description`]}
-        >
-          ({description})
+      {count && !asBadge && (
+        <Text as="span" size="md" className={styles[`${baseClass}__count`]}>
+          ({count})
         </Text>
+      )}
+      {count && asBadge && (
+        <Badge
+          data-testid="tab-badge"
+          count={count}
+          size="compact"
+          className={styles[`${baseClass}__badge`]}
+        />
       )}
     </Text>
   );

--- a/packages/react-components/src/components/Tab/TabsWrapper.stories.tsx
+++ b/packages/react-components/src/components/Tab/TabsWrapper.stories.tsx
@@ -14,6 +14,8 @@ type ITabArgs = {
     id: string;
     title: string;
     count: number;
+    asBadge?: boolean;
+    isDisabled?: boolean;
   }>;
 };
 
@@ -23,12 +25,14 @@ export const TabsWrapper = ({ items }: ITabArgs): React.ReactElement => {
   return (
     <TabsWrapperComponenet>
       <TabsList>
-        {items.map(({ id, title, count }) => (
+        {items.map(({ id, title, count, asBadge, isDisabled }) => (
           <Tab
             key={id}
-            description={count}
+            count={count}
             isSelected={selectedTab === id}
-            onClick={() => setSelectedTab(id)}
+            disabled={isDisabled}
+            asBadge={asBadge}
+            onClick={() => !isDisabled && setSelectedTab(id)}
           >
             {title}
           </Tab>
@@ -42,5 +46,6 @@ TabsWrapper.args = {
   items: [
     { id: 'agents', title: 'Agents', count: 1 },
     { id: 'groups', title: 'Groups', count: 3 },
+    { id: 'bots', title: 'Bots', count: 2 },
   ],
 } as ITabArgs;


### PR DESCRIPTION
Resolves: #399

## Description
Changes related to the `Tab` component:
- renamed the `description` prop to `count`, also changed the type of that prop to number (we don't want to allow to put anything to the counter)
- added the possibility to display the counter as a badge
- added missing functionality to set the `Tab` size
- added more stories do the `Tab` component

## Storybook
https://feature-399--613a8e945a5665003a05113b.chromatic.com/

## Checklist
**Obligatory:**
- [x] Self-review
- [x] Unit & integration tests
- [x] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**
- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
