### PR TITLE
Add aria-pressed attribute to buttons inside segmented control

### DIFF
--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -53,8 +53,9 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
     onButtonClick(id, event);
   };
   const buttonSet = buttons.map(({ id, label, loading, disabled, icon }) => {
-    const activityStyles = id === currentStateId ? styles['btn--active'] : '';
-    const loadingStatus = id === currentStateId ? false : loading;
+    const isPressed = id === currentStateId;
+    const activityStyles = isPressed ? styles['btn--active'] : '';
+    const loadingStatus = isPressed ? false : loading;
 
     return (
       <Button
@@ -62,6 +63,7 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
         fullWidth={fullWidth}
         loading={loadingStatus}
         disabled={disabled}
+        aria-pressed={isPressed}
         kind="secondary"
         icon={icon}
         className={cx(styles['btn'], styles[`btn--${size}`], activityStyles)}


### PR DESCRIPTION
## Description

https://user-images.githubusercontent.com/58426925/212089848-24540f13-17fa-4d5a-b32c-5bd17ce15a90.mov


Proposition to add [aria-pressed](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute to inform screen reader and testing frameworks about currently selected option.

## Storybook
https://feature-{issue-number}--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [ ] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
