### PR TITLE
Provide means for changing icon size used in Tag and by extension Picker component

### DIFF
--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -4,7 +4,7 @@ import cx from 'clsx';
 
 import { Trigger } from './Trigger';
 import { IPickerListItem, PickerList } from './PickerList';
-import { Icon } from '../Icon';
+import { Icon, IconSize } from '../Icon';
 import { KeyCodes } from '../../utils/keyCodes';
 
 import styles from './Picker.module.scss';
@@ -24,6 +24,7 @@ export interface IPickerProps {
   options: IPickerListItem[];
   selected?: IPickerListItem[] | null;
   size?: Size;
+  tagIconSize?: IconSize;
   placeholder?: string;
   isRequired?: boolean;
   noSearchResultText?: string;
@@ -41,6 +42,7 @@ export const Picker: React.FC<IPickerProps> = ({
   options,
   selected,
   size = 'medium',
+  tagIconSize = 'medium',
   placeholder = 'Select option',
   isRequired,
   noSearchResultText = 'No results found',
@@ -207,6 +209,7 @@ export const Picker: React.FC<IPickerProps> = ({
             isOpen={isListOpen}
             isSearchDisabled={searchDisabled}
             placeholder={placeholder}
+            iconSize={tagIconSize}
             items={selected}
             type={type}
             onItemRemove={handleItemRemove}

--- a/packages/react-components/src/components/Picker/TriggerBody.tsx
+++ b/packages/react-components/src/components/Picker/TriggerBody.tsx
@@ -5,6 +5,7 @@ import { Tag } from '../Tag';
 import { PickerType } from './Picker';
 
 import styles from './TriggerBody.module.scss';
+import { IconSize } from 'index';
 
 const baseClass = 'picker-trigger-body';
 
@@ -14,6 +15,7 @@ export interface ITriggerBodyProps {
   placeholder: string;
   items?: IPickerListItem[] | null;
   type: PickerType;
+  iconSize?: IconSize;
   onItemRemove: (item: IPickerListItem) => void;
   onFilter: (text: string) => void;
 }
@@ -24,6 +26,7 @@ export const TriggerBody: React.FC<ITriggerBodyProps> = ({
   placeholder,
   items,
   type,
+  iconSize,
   onItemRemove,
   onFilter,
 }) => {
@@ -71,6 +74,7 @@ export const TriggerBody: React.FC<ITriggerBodyProps> = ({
               <Tag
                 key={item.name}
                 className={styles[`${baseClass}__tag`]}
+                iconSize={iconSize}
                 dismissible
                 onRemove={() => onItemRemove(item)}
               >

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -4,7 +4,7 @@ import cx from 'clsx';
 import { getContrast } from 'polished';
 
 import { Text } from '../Typography';
-import { Icon, IconSource } from '../Icon';
+import { Icon, IconSize, IconSource } from '../Icon';
 
 import styles from './Tag.module.scss';
 
@@ -13,6 +13,7 @@ const baseClass = 'tag';
 export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
   kind?: 'default' | 'info' | 'warning' | 'success' | 'error';
   size?: 'medium' | 'large';
+  iconSize?: IconSize;
   customColor?: string;
   dismissible?: boolean;
   outline?: boolean;
@@ -35,6 +36,7 @@ export const Tag: React.FC<TagProps> = ({
   children,
   dismissible = false,
   size = 'medium',
+  iconSize = 'medium',
   kind = 'default',
   onRemove,
   outline = false,
@@ -120,7 +122,7 @@ export const Tag: React.FC<TagProps> = ({
           <Icon
             data-dismiss-icon
             source={Close}
-            size="medium"
+            size={iconSize}
             customColor={getIconCustomColor()}
           />
         </button>


### PR DESCRIPTION
Resolves: #482
## Description

We need to have a way to change "close" icon size on Tag. This is the way.
## Storybook
https://feature-482--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
