### PR TITLE
#500 - Popover -  onClose prop to pass handler for popover close action

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -45,7 +45,8 @@ const placementsWithUnselect = ['default', ...placements];
 const OpenChat = () => {
   return (
     <div className="listElement">
-      <Icon source={Chats} /> <span className="label">Open chat</span>{' '}
+      <Icon source={Chats} />{' '}
+      <span className="label test-class">Open chat</span>{' '}
     </div>
   );
 };

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -45,8 +45,7 @@ const placementsWithUnselect = ['default', ...placements];
 const OpenChat = () => {
   return (
     <div className="listElement">
-      <Icon source={Chats} />{' '}
-      <span className="label test-class">Open chat</span>{' '}
+      <Icon source={Chats} /> <span className="label">Open chat</span>{' '}
     </div>
   );
 };

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -17,11 +17,13 @@ export interface IPopoverProps {
   isVisible?: boolean;
   flipOptions?: Parameters<typeof flip>[0];
   triggerRenderer: () => React.ReactNode;
+  onClose?: () => void;
 }
 
 export const Popover: React.FC<IPopoverProps> = (props) => {
   const {
     triggerRenderer,
+    onClose,
     children,
     className,
     placement,
@@ -29,6 +31,7 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
     isVisible = false,
   } = props;
   const [visible, setVisibility] = React.useState(false);
+  const prevVisibleState = React.useRef(false);
 
   const {
     x,
@@ -47,6 +50,13 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
   React.useEffect(() => {
     setVisibility(isVisible);
   }, [isVisible]);
+
+  React.useEffect(() => {
+    if (onClose && prevVisibleState.current !== visible && !visible) {
+      onClose();
+    }
+    prevVisibleState.current = visible;
+  }, [visible]);
 
   React.useEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {


### PR DESCRIPTION
Resolves: #500 

## Description
A simple change that will allow passing the handler to be fired when `Popover` closes.
No tests and stories update at this moment, because component will be updated in the future.

## Storybook
https://feature-500--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**
- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**
- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
