### PR TITLE
remove general react import

### DIFF
--- a/packages/react-components/src/components/Alert/Alert.spec.tsx
+++ b/packages/react-components/src/components/Alert/Alert.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import { Alert, AlertProps } from './Alert';
 

--- a/packages/react-components/src/components/Alert/Alert.stories.tsx
+++ b/packages/react-components/src/components/Alert/Alert.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { Alert as AlertComponent, AlertProps } from './Alert';

--- a/packages/react-components/src/components/Alert/Alert.tsx
+++ b/packages/react-components/src/components/Alert/Alert.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import {
   Close as CloseIcon,
@@ -13,6 +12,7 @@ import { Text } from '../Typography';
 import { Icon, IconSource, IconKind } from '../Icon';
 
 import styles from './Alert.module.scss';
+import { FC, useEffect, useRef, useState } from 'react';
 
 type AlertKind = 'info' | 'warning' | 'success' | 'error';
 
@@ -43,15 +43,15 @@ const IconConfig: Record<AlertKind, { source: IconSource; kind: IconKind }> = {
 
 const baseClass = 'alert';
 
-export const Alert: React.FC<AlertProps> = ({
+export const Alert: FC<AlertProps> = ({
   children,
   className,
   kind = 'info',
   onClose,
   ...props
 }) => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const [isSmallContainer, setIsSmallContainer] = React.useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isSmallContainer, setIsSmallContainer] = useState(false);
 
   const mergedClassNames = cx(
     styles[baseClass],
@@ -60,7 +60,7 @@ export const Alert: React.FC<AlertProps> = ({
     className
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleResize = debounce(() => {
       if (containerRef.current && containerRef.current.offsetWidth <= 400) {
         return setIsSmallContainer(true);

--- a/packages/react-components/src/components/Avatar/Avatar.spec.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.spec.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { render, fireEvent, vi } from 'test-utils';
+import { render, fireEvent } from 'test-utils';
 import { Avatar, AvatarProps } from './Avatar';
 
 const renderComponent = (props: AvatarProps) => {

--- a/packages/react-components/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';

--- a/packages/react-components/src/components/Avatar/Avatar.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Person as PersonIcon } from '@livechat/design-system-icons/react/material';
 
@@ -6,6 +5,7 @@ import { Icon } from '../Icon';
 
 import { getFontColor, getInitials } from './Avatar.helpers';
 import styles from './Avatar.module.scss';
+import { FC, ReactEventHandler, useCallback, useEffect, useState } from 'react';
 
 type AvatarShape = 'circle' | 'rounded-square';
 type AvatarSize =
@@ -35,7 +35,7 @@ export interface AvatarProps {
 
 const baseClass = 'avatar';
 
-export const Avatar: React.FC<AvatarProps> = ({
+export const Avatar: FC<AvatarProps> = ({
   alt,
   className,
   color,
@@ -49,7 +49,7 @@ export const Avatar: React.FC<AvatarProps> = ({
 }) => {
   const isImproperImageSetup = type === 'image' && !src;
   const [shouldDisplayFallbackAvatar, setShouldDisplayFallbackAvatar] =
-    React.useState(isImproperImageSetup);
+    useState(isImproperImageSetup);
 
   const shouldDisplayImage =
     type === 'image' && !!src && !shouldDisplayFallbackAvatar;
@@ -80,10 +80,10 @@ export const Avatar: React.FC<AvatarProps> = ({
     styles[`${baseClass}__rim--${size}`]
   );
 
-  const handleError: React.ReactEventHandler<HTMLImageElement> | undefined =
-    React.useCallback(() => setShouldDisplayFallbackAvatar(true), []);
+  const handleError: ReactEventHandler<HTMLImageElement> | undefined =
+    useCallback(() => setShouldDisplayFallbackAvatar(true), []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setShouldDisplayFallbackAvatar(isImproperImageSetup);
   }, [isImproperImageSetup]);
 

--- a/packages/react-components/src/components/Badge/Badge.spec.tsx
+++ b/packages/react-components/src/components/Badge/Badge.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 
 import { Badge } from './Badge';

--- a/packages/react-components/src/components/Badge/Badge.stories.tsx
+++ b/packages/react-components/src/components/Badge/Badge.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Story } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
 
@@ -10,9 +10,9 @@ export default {
   component: Badge,
 };
 
-export const Default: Story<BadgeProps> = (
-  args: BadgeProps
-): React.ReactElement => <Badge {...args} />;
+export const Default: Story<BadgeProps> = (args: BadgeProps): ReactElement => (
+  <Badge {...args} />
+);
 
 Default.storyName = 'Badge';
 Default.args = {

--- a/packages/react-components/src/components/Badge/Badge.tsx
+++ b/packages/react-components/src/components/Badge/Badge.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
 import cx from 'clsx';
 
 import styles from './Badge.module.scss';
 import { formatCount } from './Badge.helpers';
+import { FC, HTMLAttributes } from 'react';
 
 const baseClass = 'badge';
 
-export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   count?: number;
   kind?: 'primary' | 'secondary' | 'tertiary';
   max?: number;
@@ -14,7 +14,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   type?: 'counter' | 'alert' | 'dot';
 }
 
-export const Badge: React.FC<BadgeProps> = ({
+export const Badge: FC<BadgeProps> = ({
   className,
   count = 0,
   max = 99,

--- a/packages/react-components/src/components/Button/Button.spec.tsx
+++ b/packages/react-components/src/components/Button/Button.spec.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { render, fireEvent, vi } from 'test-utils';
 import { Icon } from '../Icon';
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';
@@ -7,6 +6,7 @@ import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
 
 import { Icon, IconSource } from '../Icon';
 import { Button, ButtonProps } from './Button';
+import { ReactElement } from 'react';
 
 const icons = Object.fromEntries(
   Object.entries(MaterialIcons).map(([key, source]) => [
@@ -38,9 +38,7 @@ export default {
   },
 } as ComponentMeta<typeof Button>;
 
-export const button = (args: ButtonProps): React.ReactElement => (
-  <Button {...args} />
-);
+export const button = (args: ButtonProps): ReactElement => <Button {...args} />;
 button.args = {
   loading: false,
   disabled: false,
@@ -52,7 +50,7 @@ button.args = {
   icon: 'None',
 };
 
-export const kindsAndStates = (args: ButtonProps): React.ReactElement => (
+export const kindsAndStates = (args: ButtonProps): ReactElement => (
   <div>
     <StoryDescriptor title="Basic">
       <Button {...args}>Basic</Button>
@@ -374,7 +372,7 @@ export const kindsAndStates = (args: ButtonProps): React.ReactElement => (
 );
 kindsAndStates.args = {};
 
-export const sizes = (args: ButtonProps): React.ReactElement => (
+export const sizes = (args: ButtonProps): ReactElement => (
   <>
     <div className="story-spacer">
       <Button {...args} size="compact" kind="primary">
@@ -411,7 +409,7 @@ export const sizes = (args: ButtonProps): React.ReactElement => (
 );
 sizes.args = {};
 
-export const buttonAsLink = (args: ButtonProps): React.ReactElement => (
+export const buttonAsLink = (args: ButtonProps): ReactElement => (
   <Button {...args} href="https://livechat.com" target="_blank" kind="primary">
     Button as an external link to livechat.com
   </Button>

--- a/packages/react-components/src/components/Button/Button.tsx
+++ b/packages/react-components/src/components/Button/Button.tsx
@@ -1,8 +1,14 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Loader } from '../Loader';
 import { Size } from 'utils';
 import styles from './Button.module.scss';
+import {
+  ReactElement,
+  ButtonHTMLAttributes,
+  AnchorHTMLAttributes,
+  FC,
+  cloneElement,
+} from 'react';
 
 export type ButtonKind =
   | 'basic'
@@ -19,14 +25,14 @@ export type ButtonProps = {
   loading?: boolean;
   fullWidth?: boolean;
   loaderLabel?: string;
-  icon?: React.ReactElement;
+  icon?: ReactElement;
   iconPosition?: 'left' | 'right';
-} & React.ButtonHTMLAttributes<HTMLButtonElement> &
-  React.AnchorHTMLAttributes<HTMLAnchorElement>;
+} & ButtonHTMLAttributes<HTMLButtonElement> &
+  AnchorHTMLAttributes<HTMLAnchorElement>;
 
 const baseClass = 'btn';
 
-export const Button: React.FC<ButtonProps> = ({
+export const Button: FC<ButtonProps> = ({
   loading = false,
   disabled = false,
   type = 'button',
@@ -90,7 +96,7 @@ export const Button: React.FC<ButtonProps> = ({
         />
       )}
       {icon &&
-        React.cloneElement(icon, {
+        cloneElement(icon, {
           className: cx(
             styles[`${baseClass}__icon`],
             styles[`${baseClass}__icon--${iconPosition}`]

--- a/packages/react-components/src/components/Card/Card.spec.tsx
+++ b/packages/react-components/src/components/Card/Card.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import { Card } from './Card';
 

--- a/packages/react-components/src/components/Card/Card.stories.tsx
+++ b/packages/react-components/src/components/Card/Card.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { Card, CardProps } from '../Card';

--- a/packages/react-components/src/components/Card/Card.tsx
+++ b/packages/react-components/src/components/Card/Card.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import {
   ChevronUp,
@@ -10,17 +9,18 @@ import { Button, ButtonProps } from '../Button';
 import { Icon } from '../Icon';
 
 import styles from './Card.module.scss';
+import { HTMLAttributes, ReactNode, FC, useState } from 'react';
 
 export type CardButtonOptions = Pick<
   ButtonProps,
   'children' | 'kind' | 'onClick'
 >;
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   alt?: string;
   buttonsOptions?: CardButtonOptions[];
   description?: string;
-  expandableContent?: React.ReactNode;
+  expandableContent?: ReactNode;
   src?: string;
   title?: string;
 }
@@ -31,7 +31,7 @@ const headingClass = `${headerClass}__heading`;
 const actionsClass = `${baseClass}__actions`;
 const noImageClass = `${headerClass}__no-image`;
 
-export const Card: React.FC<CardProps> = ({
+export const Card: FC<CardProps> = ({
   alt,
   buttonsOptions = [],
   children,
@@ -42,7 +42,7 @@ export const Card: React.FC<CardProps> = ({
   title,
   ...divProps
 }) => {
-  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const expandIcon = isExpanded ? ChevronUp : ChevronDown;
   const expandButtonText = isExpanded ? 'Hide' : 'Show more';
   const shouldShowActionButtons = buttonsOptions?.length > 0;

--- a/packages/react-components/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, userEvent, vi } from 'test-utils';
 import { Checkbox } from './Checkbox';
 

--- a/packages/react-components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement, useState } from 'react';
 
 import { Checkbox as CheckboxComponent, CheckboxProps } from './Checkbox';
 
@@ -9,8 +9,8 @@ export default {
   argTypes: { onChange: { action: 'changed' } },
 } as ComponentMeta<typeof CheckboxComponent>;
 
-export const Checkbox = (args: CheckboxProps): React.ReactElement => {
-  const [checked, setChecked] = React.useState(true);
+export const Checkbox = (args: CheckboxProps): ReactElement => {
+  const [checked, setChecked] = useState(true);
 
   return (
     <CheckboxComponent

--- a/packages/react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,4 @@
 import cx from 'clsx';
-import * as React from 'react';
 import { Check } from '@livechat/design-system-icons/react/material';
 
 import { Icon } from '../Icon';
@@ -7,8 +6,9 @@ import { Text } from '../Typography';
 import { FieldDescription } from '../FieldDescription';
 
 import styles from './Checkbox.module.scss';
+import { HTMLAttributes, forwardRef } from 'react';
 
-export interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface CheckboxProps extends HTMLAttributes<HTMLInputElement> {
   disabled?: boolean;
   checked?: boolean;
   description?: string;
@@ -16,7 +16,7 @@ export interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
 
 const baseClass = 'checkbox';
 
-export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (
     { checked, disabled, children, description, className, ...restInputProps },
     ref

--- a/packages/react-components/src/components/DatePicker/DatePicker.spec.tsx
+++ b/packages/react-components/src/components/DatePicker/DatePicker.spec.tsx
@@ -1,5 +1,4 @@
 import { within } from '@testing-library/react';
-import * as React from 'react';
 import { render, userEvent } from 'test-utils';
 import { vi } from 'vitest';
 import { DatePicker } from './DatePicker';

--- a/packages/react-components/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react-components/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
+import { useState } from 'react';
 
 import { DatePicker as DatePickerComponent } from './DatePicker';
 import { IDatePickerProps } from './types';
@@ -68,7 +68,7 @@ const StoryTemplate: Story<IDatePickerProps> = (args: IDatePickerProps) => {
   const argsDisabledDays = args.disabledDays
     ? new Date(args.disabledDays as Date)
     : void 0;
-  const [selectedDate, setSelectedDate] = React.useState<
+  const [selectedDate, setSelectedDate] = useState<
     IDatePickerProps['selectedDays'] | undefined
   >(argsSelectedDate);
 

--- a/packages/react-components/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react-components/src/components/DatePicker/DatePicker.tsx
@@ -1,10 +1,17 @@
-import * as React from 'react';
 import ReactDayPicker from 'react-day-picker';
 
 import DatePickerNavbar from './DatePickerNavbar';
 import { IDatePickerProps } from './types';
 import { getDatePickerClassNames, isDateWithinRange } from './helpers';
 import styles from './DatePicker.module.scss';
+import {
+  FC,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  forwardRef,
+} from 'react';
 
 const baseClass = 'date-picker';
 
@@ -18,7 +25,7 @@ const defaultDayRenderer = (day: Date): JSX.Element => {
   );
 };
 
-const DatePickerComponent: React.FC<IDatePickerProps> = (props) => {
+const DatePickerComponent: FC<IDatePickerProps> = (props) => {
   const {
     classNames,
     range,
@@ -33,15 +40,15 @@ const DatePickerComponent: React.FC<IDatePickerProps> = (props) => {
     ...restProps
   } = props;
 
-  const [currentMonth, setCurrentMonth] = React.useState(month || new Date());
+  const [currentMonth, setCurrentMonth] = useState(month || new Date());
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (month && month !== currentMonth) {
       setCurrentMonth(month);
     }
   }, [month, currentMonth]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (toMonth) {
       if (!isDateWithinRange(currentMonth, { from: fromMonth, to: toMonth })) {
         setCurrentMonth(toMonth);
@@ -49,7 +56,7 @@ const DatePickerComponent: React.FC<IDatePickerProps> = (props) => {
     }
   }, [currentMonth, props.toMonth, props.fromMonth]);
 
-  const handleMonthChange = React.useCallback(
+  const handleMonthChange = useCallback(
     (month: Date) => {
       if (props.onMonthChange && month) {
         props.onMonthChange(month);
@@ -70,7 +77,7 @@ const DatePickerComponent: React.FC<IDatePickerProps> = (props) => {
     firstDayOfWeek = propsFirstDayOfWeek;
   }
 
-  const datePickerClassNames = React.useMemo(
+  const datePickerClassNames = useMemo(
     () => getDatePickerClassNames(range, classNames),
     [range, classNames]
   );
@@ -102,7 +109,7 @@ const DatePickerComponent: React.FC<IDatePickerProps> = (props) => {
   );
 };
 
-export const DatePicker = React.forwardRef<ReactDayPicker, IDatePickerProps>(
+export const DatePicker = forwardRef<ReactDayPicker, IDatePickerProps>(
   (props, ref) => <DatePickerComponent innerRef={ref} {...props} />
 );
 

--- a/packages/react-components/src/components/DatePicker/DatePickerNavbar.tsx
+++ b/packages/react-components/src/components/DatePicker/DatePickerNavbar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   subMonths,
   addMonths,
@@ -16,10 +15,11 @@ import { Icon } from '../Icon';
 import { IDatePickerNavbarProps } from './types';
 import clsx from 'clsx';
 import styles from './DatePicker.module.scss';
+import { FC } from 'react';
 
 const baseClass = 'date-picker';
 
-const DatePickerNavbar: React.FC<IDatePickerNavbarProps> = (props) => {
+const DatePickerNavbar: FC<IDatePickerNavbarProps> = (props) => {
   const {
     onPreviousClick,
     onMonthChange,

--- a/packages/react-components/src/components/DatePicker/DatePickerRangeCalendarsWrapper.tsx
+++ b/packages/react-components/src/components/DatePicker/DatePickerRangeCalendarsWrapper.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
-import * as React from 'react';
+import { FC, HTMLAttributes } from 'react';
 
 import styles from './DatePicker.module.scss';
 
-export const DatePickerRangeCalendarsWrapper: React.FC<
-  React.HTMLAttributes<HTMLDivElement>
+export const DatePickerRangeCalendarsWrapper: FC<
+  HTMLAttributes<HTMLDivElement>
 > = (props) => {
   const { className, children, ...restProps } = props;
 

--- a/packages/react-components/src/components/DatePicker/RangeDatePicker.spec.tsx
+++ b/packages/react-components/src/components/DatePicker/RangeDatePicker.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, userEvent } from 'test-utils';
 import { vi } from 'vitest';
 import { RangeDatePicker } from './RangeDatePicker';

--- a/packages/react-components/src/components/DatePicker/RangeDatePicker.stories.tsx
+++ b/packages/react-components/src/components/DatePicker/RangeDatePicker.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import { subDays } from 'date-fns';
 

--- a/packages/react-components/src/components/DatePicker/types.ts
+++ b/packages/react-components/src/components/DatePicker/types.ts
@@ -1,10 +1,11 @@
-import { Reducer } from 'react';
+import { ReactElement } from 'react';
+import { Reducer, Ref } from 'react';
 import ReactDayPicker, { DayPickerProps } from 'react-day-picker';
 import { ClassNames } from 'react-day-picker/types/ClassNames';
 
 export interface IDatePickerProps
   extends Omit<DayPickerProps, 'todayButton' | 'showWeekNumbers'> {
-  innerRef?: React.Ref<ReactDayPicker>;
+  innerRef?: Ref<ReactDayPicker>;
   range?: boolean;
 }
 
@@ -117,5 +118,5 @@ export interface IRangeDatePickerProps {
   initialToDate?: Date;
   toMonth?: Date;
   onChange: (selected: IRangeDatePickerOption | null) => void;
-  children(payload: IRangeDatePickerChildrenPayload): React.ReactElement;
+  children(payload: IRangeDatePickerChildrenPayload): ReactElement;
 }

--- a/packages/react-components/src/components/DatePicker/types.ts
+++ b/packages/react-components/src/components/DatePicker/types.ts
@@ -1,5 +1,4 @@
-import { ReactElement } from 'react';
-import { Reducer, Ref } from 'react';
+import { ReactElement, Reducer, Ref } from 'react';
 import ReactDayPicker, { DayPickerProps } from 'react-day-picker';
 import { ClassNames } from 'react-day-picker/types/ClassNames';
 

--- a/packages/react-components/src/components/FieldDescription/FieldDescription.tsx
+++ b/packages/react-components/src/components/FieldDescription/FieldDescription.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, FC } from 'react';
 import { Text } from '../Typography';
 
 import styles from './FieldDescription.module.scss';
 
-export type FieldDescriptionProps = React.HTMLAttributes<HTMLSpanElement>;
+export type FieldDescriptionProps = HTMLAttributes<HTMLSpanElement>;
 
 const baseClass = 'field-description';
 
-export const FieldDescription: React.FC<FieldDescriptionProps> = ({
+export const FieldDescription: FC<FieldDescriptionProps> = ({
   children,
   className = '',
   ...props

--- a/packages/react-components/src/components/FieldError/FieldError.tsx
+++ b/packages/react-components/src/components/FieldError/FieldError.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, FC } from 'react';
 import { Text } from '../Typography';
 
 import styles from './FieldError.module.scss';
 
-export type FieldErrorProps = React.HTMLAttributes<HTMLSpanElement>;
+export type FieldErrorProps = HTMLAttributes<HTMLSpanElement>;
 
 const baseClass = 'field-error';
 
-export const FieldError: React.FC<FieldErrorProps> = ({
+export const FieldError: FC<FieldErrorProps> = ({
   children,
   className = '',
   ...props

--- a/packages/react-components/src/components/FieldGroup/FieldGroup.spec.tsx
+++ b/packages/react-components/src/components/FieldGroup/FieldGroup.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { FieldGroup } from './FieldGroup';
 

--- a/packages/react-components/src/components/FieldGroup/FieldGroup.stories.tsx
+++ b/packages/react-components/src/components/FieldGroup/FieldGroup.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import {
@@ -6,6 +5,7 @@ import {
   FieldGroupProps,
 } from './FieldGroup';
 import { RadioButton } from '../RadioButton';
+import { ReactElement } from 'react';
 
 export default {
   title: 'Forms (WIP)/Field Group',
@@ -17,9 +17,7 @@ export default {
   },
 } as ComponentMeta<typeof FieldGroupComponent>;
 
-export const FieldGroup = ({
-  ...args
-}: FieldGroupProps): React.ReactElement => (
+export const FieldGroup = ({ ...args }: FieldGroupProps): ReactElement => (
   <FieldGroupComponent {...args}>
     <RadioButton id="field-group-example-1">Radio button label</RadioButton>
     <RadioButton id="field-group-example-2">Radio button label</RadioButton>

--- a/packages/react-components/src/components/FieldGroup/FieldGroup.tsx
+++ b/packages/react-components/src/components/FieldGroup/FieldGroup.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { FieldError } from '../FieldError';
 import { FieldDescription } from '../FieldDescription';
 
 import styles from './FieldGroup.module.scss';
+import { HTMLAttributes, ReactNode, FC } from 'react';
 
-export interface FieldGroupProps extends React.HTMLAttributes<HTMLDivElement> {
-  description?: React.ReactNode;
+export interface FieldGroupProps extends HTMLAttributes<HTMLDivElement> {
+  description?: ReactNode;
   error?: string;
   inline?: boolean;
   stretch?: boolean;
@@ -14,7 +14,7 @@ export interface FieldGroupProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const baseClass = 'field-group';
 
-export const FieldGroup: React.FC<FieldGroupProps> = ({
+export const FieldGroup: FC<FieldGroupProps> = ({
   className = '',
   children,
   description,

--- a/packages/react-components/src/components/FileUploadProgress/FileUploadProgress.stories.tsx
+++ b/packages/react-components/src/components/FileUploadProgress/FileUploadProgress.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import {
   FileUploadProgress as FileUploadProgressComponent,
@@ -7,6 +6,7 @@ import {
 import { Button } from '../Button';
 import noop from '../../utils/noop';
 import { PdfIcon } from '../../utils/PdfIcon';
+import { FC, useState } from 'react';
 
 export default {
   title: 'Components/Progress/FileUploadProgress',
@@ -43,11 +43,11 @@ FileUploadProgressWithIcon.args = {
   progressValue: 50,
 };
 
-export const FileUploadProgressStates: React.FC = () => {
-  const [status, setStatus] = React.useState<'normal' | 'success' | 'error'>(
+export const FileUploadProgressStates: FC = () => {
+  const [status, setStatus] = useState<'normal' | 'success' | 'error'>(
     'normal'
   );
-  const [actionsVisibility, setActionsVisibility] = React.useState<
+  const [actionsVisibility, setActionsVisibility] = useState<
     'hidden' | 'hover' | 'visible'
   >('hidden');
 

--- a/packages/react-components/src/components/FileUploadProgress/FileUploadProgress.tsx
+++ b/packages/react-components/src/components/FileUploadProgress/FileUploadProgress.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Check as CheckIcon } from '@livechat/design-system-icons/react/material';
 
@@ -8,6 +7,7 @@ import { ProgressSize, ProgressStatus } from '../Progress/constants';
 import styles from './FileUploadProgress.module.scss';
 import { Icon } from '../Icon';
 import { FileUploadProgressActions } from './FileUploadProgressActions';
+import { ReactNode, ExoticComponent, RefAttributes, forwardRef } from 'react';
 
 export type UploadProgressActionState = 'visible' | 'hover' | 'hidden';
 
@@ -17,7 +17,7 @@ const wrapperHeaderTitleClass = `${baseClass}__wrapper__header__title`;
 export interface FileUploadProgressProps {
   actionsVisibility?: UploadProgressActionState;
   className?: string;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   title: string;
   progressValue: number;
   size?: ProgressSize;
@@ -26,9 +26,9 @@ export interface FileUploadProgressProps {
   onRetryButtonClick?: () => void;
 }
 
-export const FileUploadProgress: React.ExoticComponent<
-  FileUploadProgressProps & React.RefAttributes<HTMLInputElement>
-> = React.forwardRef(
+export const FileUploadProgress: ExoticComponent<
+  FileUploadProgressProps & RefAttributes<HTMLInputElement>
+> = forwardRef(
   (
     {
       actionsVisibility = 'hidden',

--- a/packages/react-components/src/components/FileUploadProgress/FileUploadProgressActions.tsx
+++ b/packages/react-components/src/components/FileUploadProgress/FileUploadProgressActions.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Close as CloseIcon,
   Refresh as RefreshIcon,
@@ -8,6 +7,7 @@ import { ProgressStatus } from '../Progress/constants';
 import { Icon } from '../Icon';
 
 import styles from './FileUploadProgressActions.module.scss';
+import { FC } from 'react';
 
 const baseClass = 'file-upload-progress-actions';
 
@@ -17,30 +17,33 @@ interface FileUploadProgressActionsProps {
   onRetryButtonClick?: () => void;
 }
 
-export const FileUploadProgressActions: React.FC<FileUploadProgressActionsProps> =
-  ({ status, onCloseButtonClick, onRetryButtonClick }) => {
-    return (
-      <div className={styles[`${baseClass}`]}>
-        {onRetryButtonClick && status === 'error' && (
-          <button
-            type="button"
-            className={styles[`${baseClass}__retry-button`]}
-            aria-label="Retry"
-            onClick={onRetryButtonClick}
-          >
-            <Icon source={RefreshIcon} />
-          </button>
-        )}
-        {onCloseButtonClick && status !== 'success' && (
-          <button
-            type="button"
-            className={styles[`${baseClass}__close-button`]}
-            aria-label="Close"
-            onClick={onCloseButtonClick}
-          >
-            <Icon source={CloseIcon} />
-          </button>
-        )}
-      </div>
-    );
-  };
+export const FileUploadProgressActions: FC<FileUploadProgressActionsProps> = ({
+  status,
+  onCloseButtonClick,
+  onRetryButtonClick,
+}) => {
+  return (
+    <div className={styles[`${baseClass}`]}>
+      {onRetryButtonClick && status === 'error' && (
+        <button
+          type="button"
+          className={styles[`${baseClass}__retry-button`]}
+          aria-label="Retry"
+          onClick={onRetryButtonClick}
+        >
+          <Icon source={RefreshIcon} />
+        </button>
+      )}
+      {onCloseButtonClick && status !== 'success' && (
+        <button
+          type="button"
+          className={styles[`${baseClass}__close-button`]}
+          aria-label="Close"
+          onClick={onCloseButtonClick}
+        >
+          <Icon source={CloseIcon} />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/packages/react-components/src/components/Form/Form.spec.tsx
+++ b/packages/react-components/src/components/Form/Form.spec.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { render } from 'test-utils';
 import noop from '../../utils/noop';
 import { Form } from './Form';

--- a/packages/react-components/src/components/Form/Form.stories.tsx
+++ b/packages/react-components/src/components/Form/Form.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { Form as FormComponenet, FormProps } from '../Form';

--- a/packages/react-components/src/components/Form/Form.tsx
+++ b/packages/react-components/src/components/Form/Form.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, ReactNode, FC } from 'react';
 
 import { Text, Heading } from '../Typography';
 
 import styles from './Form.module.scss';
 
-export interface FormProps extends React.HTMLAttributes<HTMLFormElement> {
+export interface FormProps extends HTMLAttributes<HTMLFormElement> {
   labelText?: string;
   helperText?: string;
-  formFooter?: React.ReactNode;
+  formFooter?: ReactNode;
 }
 
 const baseClass = 'form';
 
-export const Form: React.FC<FormProps> = ({
+export const Form: FC<FormProps> = ({
   className,
   children,
   labelText,

--- a/packages/react-components/src/components/FormField/FormField.spec.tsx
+++ b/packages/react-components/src/components/FormField/FormField.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { FormFieldProps, FormField } from './FormField';
 

--- a/packages/react-components/src/components/FormField/FormField.stories.tsx
+++ b/packages/react-components/src/components/FormField/FormField.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { FormField as FormFieldComponent, FormFieldProps } from './FormField';

--- a/packages/react-components/src/components/FormField/FormField.tsx
+++ b/packages/react-components/src/components/FormField/FormField.tsx
@@ -1,26 +1,26 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Text } from '../Typography';
 import { FieldError } from '../FieldError';
 import { FieldDescription } from '../FieldDescription';
 
 import styles from './FormField.module.scss';
+import { ReactNode, FC, Fragment } from 'react';
 
 const baseClass = 'form-field';
 
 export interface FormFieldProps {
   labelText?: string;
-  labelAdornment?: React.ReactNode;
+  labelAdornment?: ReactNode;
   labelFor?: string;
   className?: string;
   inline?: boolean;
   error?: string;
-  description?: React.ReactNode;
-  children?: React.ReactNode;
-  labelRightNode?: React.ReactNode;
+  description?: ReactNode;
+  children?: ReactNode;
+  labelRightNode?: ReactNode;
 }
 
-export const FormField: React.FC<FormFieldProps> = ({
+export const FormField: FC<FormFieldProps> = ({
   inline,
   error,
   description,
@@ -42,7 +42,7 @@ export const FormField: React.FC<FormFieldProps> = ({
   return (
     <div className={mergedClassNames}>
       {labelRightNode && inline && (
-        <React.Fragment>
+        <Fragment>
           <div
             className={cx(
               styles[`${baseClass}__label-right-node`],
@@ -52,7 +52,7 @@ export const FormField: React.FC<FormFieldProps> = ({
             {labelRightNode}
           </div>
           <div className={styles[`${baseClass}__row-break`]} />
-        </React.Fragment>
+        </Fragment>
       )}
       <div
         className={cx(

--- a/packages/react-components/src/components/FormGroup/FormGroup.spec.tsx
+++ b/packages/react-components/src/components/FormGroup/FormGroup.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { FormGroup } from './FormGroup';
 

--- a/packages/react-components/src/components/FormGroup/FormGroup.stories.tsx
+++ b/packages/react-components/src/components/FormGroup/FormGroup.stories.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { FormGroup as FormGroupComponent, FormGroupProps } from './FormGroup';
 import { RadioButton } from '../RadioButton';
 import { FieldGroup } from '../FieldGroup';
+import { ReactElement } from 'react';
 
 export default {
   title: 'Forms/Form Group',
@@ -15,7 +15,7 @@ export default {
   },
 } as ComponentMeta<typeof FormGroupComponent>;
 
-export const FormGroup = ({ ...args }: FormGroupProps): React.ReactElement => (
+export const FormGroup = ({ ...args }: FormGroupProps): ReactElement => (
   <FormGroupComponent {...args}>
     <FieldGroup>
       <RadioButton id="field-group-example-1">Radio button label</RadioButton>

--- a/packages/react-components/src/components/FormGroup/FormGroup.tsx
+++ b/packages/react-components/src/components/FormGroup/FormGroup.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, FC } from 'react';
 import { Text, Heading } from '../Typography';
 
 import styles from './FormGroup.module.scss';
 
-export interface FormGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface FormGroupProps extends HTMLAttributes<HTMLDivElement> {
   className?: string;
   labelText?: string;
   helperText?: string;
@@ -12,7 +12,7 @@ export interface FormGroupProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const baseClass = 'form-group';
 
-export const FormGroup: React.FC<FormGroupProps> = ({
+export const FormGroup: FC<FormGroupProps> = ({
   className = '',
   children,
   labelText,

--- a/packages/react-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/react-components/src/components/Icon/Icon.stories.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';
 
 import { Icon as IconComponent, IconProps } from './Icon';
+import { ReactElement } from 'react';
 
 const iterator = Object.keys(MaterialIcons);
 
@@ -35,7 +35,7 @@ export default {
   },
 } as ComponentMeta<typeof IconComponent>;
 
-export const Icon = (args: IconProps): React.ReactElement => (
+export const Icon = (args: IconProps): ReactElement => (
   <div style={{ width: '300px' }}>
     <IconComponent {...args} />
   </div>

--- a/packages/react-components/src/components/Icon/Icon.tsx
+++ b/packages/react-components/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { FC, SVGProps, ReactElement, createElement } from 'react';
 import styles from './Icon.module.scss';
 
 export type IconSize = 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge';
@@ -36,8 +36,7 @@ const IconSizeMap: Record<IconSize, { width: number; height: number }> = {
   },
 };
 
-export type IconSource = React.FC<React.SVGProps<SVGSVGElement>> &
-  React.ReactElement;
+export type IconSource = FC<SVGProps<SVGSVGElement>> & ReactElement;
 export interface IconProps {
   source: IconSource;
   size?: IconSize;
@@ -49,7 +48,7 @@ export interface IconProps {
 
 const baseClass = 'icon';
 
-export const Icon: React.FC<IconProps> = (props) => {
+export const Icon: FC<IconProps> = (props) => {
   const {
     source,
     size = 'medium',
@@ -60,7 +59,7 @@ export const Icon: React.FC<IconProps> = (props) => {
     ...restProps
   } = props;
 
-  const GeneratedIcon = React.createElement(source, {
+  const GeneratedIcon = createElement(source, {
     ...IconSizeMap[size],
     color: customColor,
   });

--- a/packages/react-components/src/components/Input/Input.spec.tsx
+++ b/packages/react-components/src/components/Input/Input.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { fireEvent, render } from 'test-utils';
 import { AddCircle as AddCircleIcon } from '@livechat/design-system-icons/react/material';
 import { Input } from './Input';

--- a/packages/react-components/src/components/Input/Input.stories.tsx
+++ b/packages/react-components/src/components/Input/Input.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import { AddCircle as AddCircleIcon } from '@livechat/design-system-icons/react/material';
 

--- a/packages/react-components/src/components/Input/Input.tsx
+++ b/packages/react-components/src/components/Input/Input.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 
 import {
@@ -10,14 +9,20 @@ import { Size } from 'utils/constants';
 import styles from './Input.module.scss';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
+import {
+  cloneElement,
+  forwardRef,
+  InputHTMLAttributes,
+  ReactElement,
+  useState,
+} from 'react';
 
 interface InputIcon {
-  source: React.ReactElement;
+  source: ReactElement;
   place: 'left' | 'right';
 }
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   inputSize?: Size;
   error?: boolean;
   disabled?: boolean;
@@ -27,7 +32,7 @@ export interface InputProps
 const baseClass = 'input';
 
 const renderIcon = (icon: InputIcon, disabled?: boolean) =>
-  React.cloneElement(icon.source, {
+  cloneElement(icon.source, {
     ['data-testid']: `input-icon-${icon.place}`,
     className: cx(
       styles[`${baseClass}__icon`],
@@ -38,7 +43,7 @@ const renderIcon = (icon: InputIcon, disabled?: boolean) =>
     ),
   });
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       inputSize = 'medium',
@@ -50,8 +55,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     },
     ref
   ) => {
-    const [isFocused, setIsFocused] = React.useState(false);
-    const [isPasswordVisible, setIsPasswordVisible] = React.useState(false);
+    const [isFocused, setIsFocused] = useState(false);
+    const [isPasswordVisible, setIsPasswordVisible] = useState(false);
     const { type, onFocus, onBlur } = inputProps;
     const mergedClassNames = cx(
       className,

--- a/packages/react-components/src/components/Link/Link.stories.tsx
+++ b/packages/react-components/src/components/Link/Link.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import { Link as LinkComponent, LinkProps } from './Link';
 
@@ -8,7 +8,7 @@ export default {
   component: LinkComponent,
 } as ComponentMeta<typeof LinkComponent>;
 
-export const Link = ({ ...args }: LinkProps): React.ReactElement => (
+export const Link = ({ ...args }: LinkProps): ReactElement => (
   <LinkComponent {...args}>This is a link</LinkComponent>
 );
 

--- a/packages/react-components/src/components/Link/Link.tsx
+++ b/packages/react-components/src/components/Link/Link.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { AnchorHTMLAttributes, FC } from 'react';
 
 import styles from './Link.module.scss';
 
-export interface LinkProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   bold: boolean;
 }
 
@@ -19,7 +18,7 @@ const baseClass = 'link';
  *
  * Use `<Button href="">` to display as a `<Button>` - <a target="_self" href="/story/components-button--link">see the story</a>.
  */
-export const Link: React.FC<LinkProps> = ({
+export const Link: FC<LinkProps> = ({
   bold = false,
   className = '',
   ...rest

--- a/packages/react-components/src/components/Loader/Loader.spec.tsx
+++ b/packages/react-components/src/components/Loader/Loader.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 
 import { Loader } from './Loader';

--- a/packages/react-components/src/components/Loader/Loader.stories.tsx
+++ b/packages/react-components/src/components/Loader/Loader.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import { Loader, LoaderProps } from './Loader';
 
@@ -8,7 +8,7 @@ export default {
   component: Loader,
 } as ComponentMeta<typeof Loader>;
 
-export const sizes = (): React.ReactElement => (
+export const sizes = (): ReactElement => (
   <div className="story-spacer">
     <Loader size="small" />
     <Loader size="medium" />
@@ -16,10 +16,10 @@ export const sizes = (): React.ReactElement => (
   </div>
 );
 
-export const labeled = (args: LoaderProps): React.ReactElement => (
+export const labeled = (args: LoaderProps): ReactElement => (
   <Loader size="small" label="Loading..." {...args} />
 );
 
-export const customColors = (args: LoaderProps): React.ReactElement => (
+export const customColors = (args: LoaderProps): ReactElement => (
   <Loader primaryColor="#d64646" secondaryColor="#eec4c5" {...args} />
 );

--- a/packages/react-components/src/components/Loader/Loader.tsx
+++ b/packages/react-components/src/components/Loader/Loader.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, FC } from 'react';
 
 import { Text } from '../Typography';
 
@@ -8,7 +8,7 @@ import styles from './Loader.module.scss';
 const baseClass = 'loader';
 const spinnerClass = `${baseClass}__spinner`;
 
-export interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface LoaderProps extends HTMLAttributes<HTMLDivElement> {
   size?: 'small' | 'medium' | 'large';
   label?: string;
   /** Fragment circle color */
@@ -17,7 +17,7 @@ export interface LoaderProps extends React.HTMLAttributes<HTMLDivElement> {
   secondaryColor?: string;
 }
 
-export const Loader: React.FC<LoaderProps> = ({
+export const Loader: FC<LoaderProps> = ({
   primaryColor,
   secondaryColor,
   label,

--- a/packages/react-components/src/components/Modal/Modal.spec.tsx
+++ b/packages/react-components/src/components/Modal/Modal.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, vi } from 'test-utils';
 import { Modal } from './Modal';

--- a/packages/react-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/react-components/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import {
   Modal as ModalComponent,
@@ -38,7 +38,7 @@ const defaultModalProps = {
 const StoryTemplate: Story<ModalProps> = ({
   children,
   ...args
-}: ModalProps): React.ReactElement => (
+}: ModalProps): ReactElement => (
   <ModalComponent {...args} title="Modal">
     {children}
   </ModalComponent>
@@ -73,7 +73,7 @@ ModalWithFullSpaceContent.args = {
 export const ModalPortal = ({
   children,
   ...args
-}: ModalPortalProps): React.ReactElement => (
+}: ModalPortalProps): ReactElement => (
   <ModalPortalComponent {...args}>{children}</ModalPortalComponent>
 );
 

--- a/packages/react-components/src/components/Modal/Modal.tsx
+++ b/packages/react-components/src/components/Modal/Modal.tsx
@@ -1,21 +1,21 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { ModalBaseProps, ModalBase } from './ModalBase';
 import { Heading } from '../Typography';
 
 import styles from './Modal.module.scss';
 import { ModalCloseButton } from './ModalCloseButton';
+import { ReactNode, FC, MouseEvent } from 'react';
 
 export interface ModalProps extends ModalBaseProps {
-  heading?: React.ReactNode;
-  labelHeading?: React.ReactNode;
+  heading?: ReactNode;
+  labelHeading?: ReactNode;
   fullSpaceContent?: boolean;
-  footer?: React.ReactNode;
+  footer?: ReactNode;
 }
 
 const baseClass = 'modal';
 
-export const Modal: React.FC<ModalProps> = ({
+export const Modal: FC<ModalProps> = ({
   children,
   className = '',
   heading,
@@ -27,7 +27,7 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const mergedClassNames = cx(styles[baseClass], className);
 
-  const onCloseButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const onCloseButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
     onClose();

--- a/packages/react-components/src/components/Modal/ModalBase.spec.tsx
+++ b/packages/react-components/src/components/Modal/ModalBase.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, vi } from 'test-utils';
 import { ModalBase } from './ModalBase';

--- a/packages/react-components/src/components/Modal/ModalBase.tsx
+++ b/packages/react-components/src/components/Modal/ModalBase.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, FC, useEffect, MouseEvent } from 'react';
 import { KeyCodes } from '../../utils/keyCodes';
 
 import styles from './Modal.module.scss';
 
-export interface ModalBaseProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ModalBaseProps extends HTMLAttributes<HTMLDivElement> {
   onClose(): void;
   closeOnEscPress?: boolean;
   closeOnOverlayPress?: boolean;
@@ -12,7 +12,7 @@ export interface ModalBaseProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const baseClass = 'modal-base';
 
-export const ModalBase: React.FC<ModalBaseProps> = ({
+export const ModalBase: FC<ModalBaseProps> = ({
   children,
   className = '',
   onClose,
@@ -22,7 +22,7 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
 }) => {
   const mergedClassNames = cx(styles[baseClass], className);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!closeOnEscPress) {
       return;
     }
@@ -37,7 +37,7 @@ export const ModalBase: React.FC<ModalBaseProps> = ({
     return () => document.removeEventListener('keyup', onKeyUp, true);
   }, [closeOnEscPress]);
 
-  const onOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const onOverlayClick = (event: MouseEvent<HTMLDivElement>) => {
     if (closeOnOverlayPress && event.target === event.currentTarget) {
       onClose();
     }

--- a/packages/react-components/src/components/Modal/ModalCloseButton.tsx
+++ b/packages/react-components/src/components/Modal/ModalCloseButton.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Close } from '@livechat/design-system-icons/react/material';
 import { Icon } from '../Icon';
 
 import styles from './Modal.module.scss';
+import { HTMLAttributes, FC } from 'react';
 
 export interface ModalCloseButtonProps
-  extends React.HTMLAttributes<HTMLButtonElement> {
+  extends HTMLAttributes<HTMLButtonElement> {
   labelType?: boolean;
   customColor?: string;
 }
 
-export const ModalCloseButton: React.FC<ModalCloseButtonProps> = ({
+export const ModalCloseButton: FC<ModalCloseButtonProps> = ({
   labelType,
   customColor,
   onClick,

--- a/packages/react-components/src/components/Modal/ModalPortal.tsx
+++ b/packages/react-components/src/components/Modal/ModalPortal.tsx
@@ -1,19 +1,19 @@
-import * as React from 'react';
+import { HTMLAttributes, ReactNode, FC, useState, useEffect } from 'react';
 import * as ReactDOM from 'react-dom';
 
-export interface ModalPortalProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
+export interface ModalPortalProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
   zIndex: number;
   parentElementName?: string;
 }
 
-export const ModalPortal: React.FC<ModalPortalProps> = ({
+export const ModalPortal: FC<ModalPortalProps> = ({
   children,
   className = '',
   parentElementName = 'body',
   zIndex,
 }) => {
-  const [container] = React.useState(() => document.createElement('div'));
+  const [container] = useState(() => document.createElement('div'));
 
   if (className) {
     container.classList.add(className);
@@ -23,7 +23,7 @@ export const ModalPortal: React.FC<ModalPortalProps> = ({
     container.style.zIndex = zIndex.toString();
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.querySelector(parentElementName)?.appendChild(container);
     return () => {
       document.querySelector(parentElementName)?.removeChild(container);

--- a/packages/react-components/src/components/Modal/StoriesComponents.tsx
+++ b/packages/react-components/src/components/Modal/StoriesComponents.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { GreetingQuickReply } from '@livechat/design-system-icons/react/material';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
@@ -10,12 +9,13 @@ import { Input } from '../Input';
 import { defaultPickerOptions } from '../Picker/constants';
 import { Picker } from '../Picker';
 import noop from '../../utils/noop';
+import { FC } from 'react';
 
 interface ModalHeaderProps {
   color?: string;
 }
 
-export const ModalHeader: React.FC<ModalHeaderProps> = ({ color }) => {
+export const ModalHeader: FC<ModalHeaderProps> = ({ color }) => {
   return (
     <div className="heading-wrapper">
       <Icon
@@ -33,7 +33,7 @@ export const ModalHeader: React.FC<ModalHeaderProps> = ({ color }) => {
   );
 };
 
-export const ModalFooter: React.FC = () => {
+export const ModalFooter: FC = () => {
   return (
     <div className="footer">
       <Button size="medium" kind="secondary" style={{ marginRight: '8px' }}>
@@ -46,7 +46,7 @@ export const ModalFooter: React.FC = () => {
   );
 };
 
-export const ModalFullSpaceContent: React.FC = () => {
+export const ModalFullSpaceContent: FC = () => {
   return (
     <div className="full-space-wrapper">
       <img src={modalImage} alt="modal image" />
@@ -77,7 +77,7 @@ export const ModalFullSpaceContent: React.FC = () => {
   );
 };
 
-export const ModalContent: React.FC = () => (
+export const ModalContent: FC = () => (
   <div style={{ maxWidth: 400 }}>
     <Heading size="lg" as="div">
       Modal header

--- a/packages/react-components/src/components/NumericInput/NumericInput.spec.tsx
+++ b/packages/react-components/src/components/NumericInput/NumericInput.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import noop from '../../utils/noop';
 import { NumericInputProps, NumericInput } from './NumericInput';

--- a/packages/react-components/src/components/NumericInput/NumericInput.stories.tsx
+++ b/packages/react-components/src/components/NumericInput/NumericInput.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
+import { useState } from 'react';
 
 import {
   NumericInputProps,
@@ -19,7 +19,7 @@ export default {
 } as ComponentMeta<typeof NumericInputComponent>;
 
 const StoryTemplate: Story<NumericInputProps> = (args: NumericInputProps) => {
-  const [value, setValue] = React.useState('0');
+  const [value, setValue] = useState('0');
   return (
     <div>
       <NumericInputComponent

--- a/packages/react-components/src/components/NumericInput/NumericInput.tsx
+++ b/packages/react-components/src/components/NumericInput/NumericInput.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import {
   ChevronUp,
@@ -8,6 +7,13 @@ import { Icon } from '../Icon';
 import { KeyCodes } from '../../utils/keyCodes';
 
 import styles from './NumericInput.module.scss';
+import {
+  InputHTMLAttributes,
+  FC,
+  useRef,
+  KeyboardEventHandler,
+  FormEvent,
+} from 'react';
 
 const baseClass = 'numeric-input';
 
@@ -22,10 +28,9 @@ interface Props {
   onChange: (value: string) => void;
 }
 
-export type NumericInputProps = React.InputHTMLAttributes<HTMLInputElement> &
-  Props;
+export type NumericInputProps = InputHTMLAttributes<HTMLInputElement> & Props;
 
-export const NumericInput: React.FC<NumericInputProps> = ({
+export const NumericInput: FC<NumericInputProps> = ({
   className,
   error,
   value,
@@ -37,7 +42,7 @@ export const NumericInput: React.FC<NumericInputProps> = ({
   onChange,
   ...restProps
 }) => {
-  const inputRef = React.useRef<null | HTMLInputElement>(null);
+  const inputRef = useRef<null | HTMLInputElement>(null);
 
   const mergedClassNames = cx(
     styles[baseClass],
@@ -69,7 +74,7 @@ export const NumericInput: React.FC<NumericInputProps> = ({
     return callOnChange(calcValue(newValue));
   };
 
-  const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === KeyCodes.arrowDown) {
       e.preventDefault();
       updateValue(-1);
@@ -84,7 +89,7 @@ export const NumericInput: React.FC<NumericInputProps> = ({
   const hasReachedTheLimit = (value: string, margin?: number) =>
     margin !== undefined && parseInt(value, 10) === margin;
 
-  const handleOnChange = (e: React.FormEvent<HTMLInputElement>) => {
+  const handleOnChange = (e: FormEvent<HTMLInputElement>) => {
     e.preventDefault();
     e.stopPropagation();
     const inputVal = e.currentTarget.value.replace(

--- a/packages/react-components/src/components/Picker/Picker.spec.tsx
+++ b/packages/react-components/src/components/Picker/Picker.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, vi } from 'test-utils';
 import userEvent from '@testing-library/user-event';
 import noop from '../../utils/noop';

--- a/packages/react-components/src/components/Picker/Picker.stories.tsx
+++ b/packages/react-components/src/components/Picker/Picker.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { IPickerProps, Picker } from './Picker';
@@ -7,6 +6,7 @@ import { IPickerListItem } from './PickerList';
 
 import './Picker.stories.css';
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
+import { CSSProperties, useState, ReactElement, FC } from 'react';
 
 export default {
   title: 'Components/Picker',
@@ -19,12 +19,12 @@ export default {
   },
 } as ComponentMeta<typeof Picker>;
 
-const commonWidth: React.CSSProperties = { width: 300 };
+const commonWidth: CSSProperties = { width: 300 };
 
 const PickerComponent = (args: IPickerProps) => {
-  const [selectedItems, setSelectedItems] = React.useState<
-    IPickerListItem[] | null
-  >(args.selected || null);
+  const [selectedItems, setSelectedItems] = useState<IPickerListItem[] | null>(
+    args.selected || null
+  );
 
   return (
     <Picker
@@ -48,7 +48,7 @@ Default.args = {
   options: defaultPickerOptions,
 };
 
-export const States = (args: IPickerProps): React.ReactElement => (
+export const States = (args: IPickerProps): ReactElement => (
   <div style={{ ...commonWidth, marginBottom: 100 }}>
     <StoryDescriptor title="Basic">
       <PickerComponent {...args} />
@@ -90,9 +90,7 @@ States.args = {
   label: 'Example label',
 };
 
-export const PickerWithGroupedOptions = (
-  args: IPickerProps
-): React.ReactElement => (
+export const PickerWithGroupedOptions = (args: IPickerProps): ReactElement => (
   <div style={{ ...commonWidth, marginBottom: 320 }}>
     <PickerComponent {...args} />
   </div>
@@ -101,13 +99,13 @@ PickerWithGroupedOptions.args = {
   options: defaultExtendedOptions,
 };
 
-const CustomPickerOption: React.FC = ({ children }) => (
+const CustomPickerOption: FC = ({ children }) => (
   <div className="custom-picker-option">{children}</div>
 );
 
 export const PickerWithOptionsAsCustomElements = (
   args: IPickerProps
-): React.ReactElement => (
+): ReactElement => (
   <div style={{ ...commonWidth, marginBottom: 320 }}>
     <StoryDescriptor title="Single select">
       <PickerComponent {...args} />

--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 
 import { Trigger } from './Trigger';
@@ -10,6 +9,7 @@ import styles from './Picker.module.scss';
 import { TriggerBody } from './TriggerBody';
 import { SELECT_ALL_OPTION_KEY } from './constants';
 import { Size } from 'utils';
+import { FC, useState, useRef, useEffect, useMemo } from 'react';
 
 const baseClass = 'picker';
 
@@ -33,7 +33,7 @@ export interface IPickerProps {
   onSelect: (selectedItems: IPickerListItem[] | null) => void;
 }
 
-export const Picker: React.FC<IPickerProps> = ({
+export const Picker: FC<IPickerProps> = ({
   className,
   disabled,
   error,
@@ -50,13 +50,13 @@ export const Picker: React.FC<IPickerProps> = ({
   onSelect,
   ...props
 }) => {
-  const [isListOpen, setIsListOpen] = React.useState<boolean>(false);
-  const [searchPhrase, setSearchPhrase] = React.useState<string | null>(null);
-  const triggerRef = React.useRef<HTMLDivElement>(null);
+  const [isListOpen, setIsListOpen] = useState<boolean>(false);
+  const [searchPhrase, setSearchPhrase] = useState<string | null>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
 
   const mergedClassNames = cx(styles[baseClass], className);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isListOpen) {
       const onDocumentClick = (e: MouseEvent) => {
         if (!triggerRef.current?.contains(e.target as Element)) {
@@ -156,7 +156,7 @@ export const Picker: React.FC<IPickerProps> = ({
     onSelect(newSelectedItems);
   };
 
-  const items = React.useMemo<IPickerListItem[]>(() => {
+  const items = useMemo<IPickerListItem[]>(() => {
     if (!searchPhrase) {
       return options;
     }
@@ -172,7 +172,7 @@ export const Picker: React.FC<IPickerProps> = ({
     });
   }, [searchPhrase]);
 
-  const selectedItemsKeys = React.useMemo(() => {
+  const selectedItemsKeys = useMemo(() => {
     if (!selected) {
       return null;
     }

--- a/packages/react-components/src/components/Picker/PickerList.spec.tsx
+++ b/packages/react-components/src/components/Picker/PickerList.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, vi } from 'test-utils';
 import userEvent from '@testing-library/user-event';
 import noop from '../../utils/noop';

--- a/packages/react-components/src/components/Picker/PickerList.tsx
+++ b/packages/react-components/src/components/Picker/PickerList.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Check } from '@livechat/design-system-icons/react/material';
 import { Icon } from '../Icon';
 import styles from './PickerList.module.scss';
 import { KeyCodes } from '../../utils/keyCodes';
 import { SELECT_ALL_OPTION_KEY } from './constants';
+import { ReactElement, FC, useState, useRef, useEffect } from 'react';
 
 const baseClass = 'picker-list';
 const itemClassName = `${baseClass}__item`;
@@ -13,8 +13,8 @@ export interface IPickerListItem {
   key: string;
   name: string;
   customElement?: {
-    listItemBody: React.ReactElement;
-    selectedItemBody: React.ReactElement;
+    listItemBody: ReactElement;
+    selectedItemBody: ReactElement;
   };
   groupHeader?: boolean;
   disabled?: boolean;
@@ -32,7 +32,7 @@ export interface IPickerListProps {
   onSelectAll: () => void;
 }
 
-export const PickerList: React.FC<IPickerListProps> = ({
+export const PickerList: FC<IPickerListProps> = ({
   isOpen,
   items,
   selectedItemsKeys,
@@ -47,12 +47,10 @@ export const PickerList: React.FC<IPickerListProps> = ({
     [styles[`${baseClass}__no-results`]]: items.length === 0,
   });
 
-  const [currentItemKey, setCurrentItemKey] = React.useState<string | null>(
-    null
-  );
-  const indexRef = React.useRef(-1);
-  const lastIndexRef = React.useRef(0);
-  const listRef = React.useRef<HTMLUListElement>(null);
+  const [currentItemKey, setCurrentItemKey] = useState<string | null>(null);
+  const indexRef = useRef(-1);
+  const lastIndexRef = useRef(0);
+  const listRef = useRef<HTMLUListElement>(null);
 
   const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === KeyCodes.esc) {
@@ -87,7 +85,7 @@ export const PickerList: React.FC<IPickerListProps> = ({
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (indexRef.current > -1 && items.length > 0) {
       setCurrentItemKey(items[indexRef.current].key);
     }

--- a/packages/react-components/src/components/Picker/Trigger.spec.tsx
+++ b/packages/react-components/src/components/Picker/Trigger.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import noop from '../../utils/noop';
 import { ITriggerProps, Trigger } from './Trigger';

--- a/packages/react-components/src/components/Picker/Trigger.tsx
+++ b/packages/react-components/src/components/Picker/Trigger.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import {
   ChevronDown,
@@ -9,6 +8,7 @@ import { Icon } from '../Icon';
 import styles from './Trigger.module.scss';
 import { KeyCodes } from '../../utils/keyCodes';
 import { Size } from 'utils';
+import { FC, useRef, useEffect, MouseEvent } from 'react';
 
 const baseClass = 'picker-trigger';
 
@@ -21,11 +21,11 @@ export interface ITriggerProps {
   isRequired?: boolean;
   isMultiSelect?: boolean;
   size?: Size;
-  onTrigger: (e: React.MouseEvent | KeyboardEvent) => void;
+  onTrigger: (e: MouseEvent | KeyboardEvent) => void;
   onClear: () => void;
 }
 
-export const Trigger: React.FC<ITriggerProps> = ({
+export const Trigger: FC<ITriggerProps> = ({
   children,
   isSearchDisabled,
   isDisabled,
@@ -38,7 +38,7 @@ export const Trigger: React.FC<ITriggerProps> = ({
   onTrigger,
   onClear,
 }) => {
-  const triggerRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const mergedClassNames = cx(
     styles[baseClass],
     styles[`${baseClass}--${size}`],
@@ -51,7 +51,7 @@ export const Trigger: React.FC<ITriggerProps> = ({
     isError && styles[`${baseClass}--error`]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       const isFocused = document.activeElement === triggerRef.current;
 
@@ -71,11 +71,11 @@ export const Trigger: React.FC<ITriggerProps> = ({
     };
   }, [isSearchDisabled]);
 
-  const handleTriggerClick = (e: React.MouseEvent) => {
+  const handleTriggerClick = (e: MouseEvent) => {
     onTrigger(e);
   };
 
-  const handleOnClearClick = (e: React.MouseEvent) => {
+  const handleOnClearClick = (e: MouseEvent) => {
     e.stopPropagation();
     onClear();
   };

--- a/packages/react-components/src/components/Picker/TriggerBody.spec.tsx
+++ b/packages/react-components/src/components/Picker/TriggerBody.spec.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { render, fireEvent, userEvent, vi } from 'test-utils';
+import { render, userEvent, vi } from 'test-utils';
 import noop from '../../utils/noop';
 import { TriggerBody, ITriggerBodyProps } from './TriggerBody';
 import { PickerType } from './Picker';

--- a/packages/react-components/src/components/Picker/TriggerBody.tsx
+++ b/packages/react-components/src/components/Picker/TriggerBody.tsx
@@ -1,12 +1,10 @@
-import * as React from 'react';
-import cx from 'clsx';
-
 import { IPickerListItem } from './PickerList';
 import { Tag } from '../Tag';
 import { PickerType } from './Picker';
 
 import styles from './TriggerBody.module.scss';
 import { IconSize } from 'index';
+import { FC, ChangeEvent } from 'react';
 
 const baseClass = 'picker-trigger-body';
 
@@ -22,7 +20,7 @@ export interface ITriggerBodyProps {
   onFilter: (text: string) => void;
 }
 
-export const TriggerBody: React.FC<ITriggerBodyProps> = ({
+export const TriggerBody: FC<ITriggerBodyProps> = ({
   isOpen,
   isSearchDisabled,
   isDisabled,
@@ -51,7 +49,7 @@ export const TriggerBody: React.FC<ITriggerBodyProps> = ({
     return <div className={styles[`${baseClass}__item`]}>{item.name}</div>;
   };
 
-  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
     onFilter(e.target.value);
   };
 

--- a/packages/react-components/src/components/Popover/Popover.spec.tsx
+++ b/packages/react-components/src/components/Popover/Popover.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent } from 'test-utils';
 import { Popover } from './Popover';
 import { vi } from 'vitest';

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { Placement } from '@floating-ui/react-dom';
 import { Button } from '../Button';
@@ -15,6 +14,7 @@ import {
 import { Icon } from '../Icon';
 
 import './Popover.stories.css';
+import { ReactElement } from 'react';
 
 const placements = [
   'top',
@@ -82,7 +82,7 @@ export const Popover = ({
   placement: Placement;
   isVisible: boolean;
   flipOptions: Placement;
-}): React.ReactElement => (
+}): ReactElement => (
   <div className="wrap">
     <PopoverComponent
       placement={placement}
@@ -137,7 +137,7 @@ export const Actions = ({
   placement: Placement;
   isVisible: boolean;
   flipOptions: Placement;
-}): React.ReactElement => {
+}): ReactElement => {
   return (
     <div style={{ minHeight: '200px' }}>
       <PopoverComponent

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import {
   useFloating,
@@ -9,18 +8,19 @@ import {
 } from '@floating-ui/react-dom';
 
 import cssStyles from './Popover.module.scss';
+import { ReactNode, FC, useState, useRef, useEffect } from 'react';
 
 export interface IPopoverProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
   placement?: Placement;
   isVisible?: boolean;
   flipOptions?: Parameters<typeof flip>[0];
-  triggerRenderer: () => React.ReactNode;
+  triggerRenderer: () => ReactNode;
   onClose?: () => void;
 }
 
-export const Popover: React.FC<IPopoverProps> = (props) => {
+export const Popover: FC<IPopoverProps> = (props) => {
   const {
     triggerRenderer,
     onClose,
@@ -30,8 +30,8 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
     flipOptions,
     isVisible = false,
   } = props;
-  const [visible, setVisibility] = React.useState(false);
-  const prevVisibleState = React.useRef(false);
+  const [visible, setVisibility] = useState(false);
+  const prevVisibleState = useRef(false);
 
   const {
     x,
@@ -47,18 +47,18 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
     placement: placement,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     setVisibility(isVisible);
   }, [isVisible]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (onClose && prevVisibleState.current !== visible && !visible) {
       onClose();
     }
     prevVisibleState.current = visible;
   }, [visible]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {
       return;
     }
@@ -89,7 +89,7 @@ export const Popover: React.FC<IPopoverProps> = (props) => {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.addEventListener('keydown', handleHideOnEscape);
     document.addEventListener('mousedown', handleDocumentClick);
     return () => {

--- a/packages/react-components/src/components/Progress/ProgressBar.spec.tsx
+++ b/packages/react-components/src/components/Progress/ProgressBar.spec.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { render } from 'test-utils';
 import { ProgressBar } from './ProgressBar';
 

--- a/packages/react-components/src/components/Progress/ProgressBar.stories.tsx
+++ b/packages/react-components/src/components/Progress/ProgressBar.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import {
   ProgressBar as ProgressBarComponent,
@@ -11,7 +11,7 @@ export default {
   component: ProgressBarComponent,
 } as ComponentMeta<typeof ProgressBarComponent>;
 
-export const ProgressBar = (args: ProgressBarProps): React.ReactElement => {
+export const ProgressBar = (args: ProgressBarProps): ReactElement => {
   return <ProgressBarComponent {...args} />;
 };
 

--- a/packages/react-components/src/components/Progress/ProgressBar.tsx
+++ b/packages/react-components/src/components/Progress/ProgressBar.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { ExoticComponent, RefAttributes, forwardRef, LegacyRef } from 'react';
 
 import { ProgressSize, ProgressStatus } from './constants';
 import { getPercentNumber, getProgressStatus } from './helpers';
@@ -15,9 +15,9 @@ export interface ProgressBarProps {
   size?: ProgressSize;
 }
 
-export const ProgressBar: React.ExoticComponent<
-  ProgressBarProps & React.RefAttributes<HTMLInputElement>
-> = React.forwardRef(
+export const ProgressBar: ExoticComponent<
+  ProgressBarProps & RefAttributes<HTMLInputElement>
+> = forwardRef(
   (
     {
       status = 'normal',
@@ -26,7 +26,7 @@ export const ProgressBar: React.ExoticComponent<
       className = '',
       ...restProps
     },
-    ref: React.LegacyRef<HTMLInputElement>
+    ref: LegacyRef<HTMLInputElement>
   ) => {
     const progressStatus = getProgressStatus(status, percent);
     const percentNumber = getPercentNumber(progressStatus, percent);

--- a/packages/react-components/src/components/Progress/ProgressCircle.spec.tsx
+++ b/packages/react-components/src/components/Progress/ProgressCircle.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { ProgressCircle } from './ProgressCircle';
 

--- a/packages/react-components/src/components/Progress/ProgressCircle.stories.tsx
+++ b/packages/react-components/src/components/Progress/ProgressCircle.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import {
   ProgressCircle as ProgressCircleComponent,
@@ -11,9 +11,7 @@ export default {
   component: ProgressCircleComponent,
 } as ComponentMeta<typeof ProgressCircleComponent>;
 
-export const ProgressCircle = (
-  args: ProgressCircleProps
-): React.ReactElement => {
+export const ProgressCircle = (args: ProgressCircleProps): ReactElement => {
   return (
     <div>
       <ProgressCircleComponent {...args} />

--- a/packages/react-components/src/components/Progress/ProgressCircle.tsx
+++ b/packages/react-components/src/components/Progress/ProgressCircle.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { ExoticComponent, RefAttributes, forwardRef, LegacyRef } from 'react';
 import { ProgressSize, ProgressStatus } from './constants';
 import { getPercentNumber, getProgressStatus } from './helpers';
 
@@ -26,9 +26,9 @@ export interface ProgressCircleProps {
   size?: ProgressSize;
 }
 
-export const ProgressCircle: React.ExoticComponent<
-  ProgressCircleProps & React.RefAttributes<HTMLInputElement>
-> = React.forwardRef(
+export const ProgressCircle: ExoticComponent<
+  ProgressCircleProps & RefAttributes<HTMLInputElement>
+> = forwardRef(
   (
     {
       status = 'normal',
@@ -37,7 +37,7 @@ export const ProgressCircle: React.ExoticComponent<
       size = 'medium',
       ...restProps
     },
-    ref: React.LegacyRef<HTMLInputElement>
+    ref: LegacyRef<HTMLInputElement>
   ) => {
     const progressStatus = getProgressStatus(status, progressValue);
     const percentNumber = getPercentNumber(progressStatus, progressValue);

--- a/packages/react-components/src/components/PromoBanner/PromoBanner.spec.tsx
+++ b/packages/react-components/src/components/PromoBanner/PromoBanner.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import { PromoBannerProps, PromoBanner } from './PromoBanner';
 

--- a/packages/react-components/src/components/PromoBanner/PromoBanner.stories.tsx
+++ b/packages/react-components/src/components/PromoBanner/PromoBanner.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import {

--- a/packages/react-components/src/components/PromoBanner/PromoBanner.tsx
+++ b/packages/react-components/src/components/PromoBanner/PromoBanner.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Close as CloseIcon } from '@livechat/design-system-icons/react/material';
 import debounce from 'lodash.debounce';
@@ -7,6 +6,7 @@ import { Button } from '../Button';
 import { Icon } from '../Icon';
 
 import styles from './PromoBanner.module.scss';
+import { FC, useRef, useState, useEffect } from 'react';
 
 const SMALL_CONTAINER_WIDTH_TRESHOLD = 400;
 const LARGE_CONTAINER_WIDTH_TRESHOLD = 800;
@@ -26,7 +26,7 @@ export interface PromoBannerProps {
   onLinkClick?: () => void;
 }
 
-export const PromoBanner: React.FC<PromoBannerProps> = ({
+export const PromoBanner: FC<PromoBannerProps> = ({
   className,
   buttonText,
   children,
@@ -38,8 +38,8 @@ export const PromoBanner: React.FC<PromoBannerProps> = ({
   onClose,
   onLinkClick,
 }) => {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const [containerSize, setContainerSize] = React.useState<
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState<
     'small' | 'medium' | 'large'
   >('medium');
 
@@ -53,7 +53,7 @@ export const PromoBanner: React.FC<PromoBannerProps> = ({
     className
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleResize = () => {
       if (
         containerRef.current &&

--- a/packages/react-components/src/components/RadioButton/RadioButton.spec.tsx
+++ b/packages/react-components/src/components/RadioButton/RadioButton.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, userEvent, vi } from 'test-utils';
 import { RadioButton } from './RadioButton';
 

--- a/packages/react-components/src/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/react-components/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import {
   RadioButton as RadioButtonComponent,
@@ -20,7 +20,7 @@ export default {
 export const RadioButton = ({
   children,
   ...args
-}: RadioButtonProps): React.ReactElement => (
+}: RadioButtonProps): ReactElement => (
   <div>
     <RadioButtonComponent {...args}>{children}</RadioButtonComponent>
   </div>

--- a/packages/react-components/src/components/RadioButton/RadioButton.tsx
+++ b/packages/react-components/src/components/RadioButton/RadioButton.tsx
@@ -1,12 +1,11 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { HTMLAttributes, forwardRef } from 'react';
 import { FieldDescription } from '../FieldDescription';
 import { Text } from '../Typography';
 
 import styles from './RadioButton.module.scss';
 
-export interface RadioButtonProps
-  extends React.HTMLAttributes<HTMLInputElement> {
+export interface RadioButtonProps extends HTMLAttributes<HTMLInputElement> {
   description?: string;
   checked?: boolean;
   disabled?: boolean;
@@ -14,7 +13,7 @@ export interface RadioButtonProps
 
 const baseClass = 'radio-button';
 
-export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
+export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
   (
     { children, className = '', description, checked, disabled, ...props },
     ref

--- a/packages/react-components/src/components/Search/Search.spec.tsx
+++ b/packages/react-components/src/components/Search/Search.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useState } from 'react';
 import { render, userEvent, vi } from 'test-utils';
 import noop from '../../utils/noop';
 import { ISearchInputProps, SearchInput } from './Search';
@@ -174,7 +174,7 @@ describe('<Search> component', () => {
   it('should call onChange if input value change', () => {
     const onChangeFunction = vi.fn();
     const SearchWrapper = () => {
-      const [value, setValue] = React.useState('');
+      const [value, setValue] = useState('');
       return (
         <SearchInput
           value={value}

--- a/packages/react-components/src/components/Search/Search.stories.tsx
+++ b/packages/react-components/src/components/Search/Search.stories.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
+import { CSSProperties, useState, ReactElement } from 'react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
 
 import { SearchInput, ISearchInputProps } from './Search';
 
-const commonWidth: React.CSSProperties = { width: 300 };
+const commonWidth: CSSProperties = { width: 300 };
 
 export default {
   title: 'Components/Search',
@@ -14,7 +14,7 @@ export default {
 } as ComponentMeta<typeof SearchInput>;
 
 const SearchInputComponent = (args: ISearchInputProps) => {
-  const [value, setValue] = React.useState(args.value || '');
+  const [value, setValue] = useState(args.value || '');
   return <SearchInput {...args} value={value} onChange={setValue} />;
 };
 
@@ -25,7 +25,7 @@ const StoryTemplate: Story<ISearchInputProps> = (args: ISearchInputProps) => {
 export const Search = StoryTemplate.bind({});
 Search.args = {};
 
-export const States = (args: ISearchInputProps): React.ReactElement => (
+export const States = (args: ISearchInputProps): ReactElement => (
   <div style={commonWidth}>
     <StoryDescriptor title="Basic">
       <SearchInputComponent {...args} />
@@ -49,7 +49,7 @@ export const States = (args: ISearchInputProps): React.ReactElement => (
 
 States.args = {};
 
-export const Sizes = (args: ISearchInputProps): React.ReactElement => (
+export const Sizes = (args: ISearchInputProps): ReactElement => (
   <div style={commonWidth}>
     <StoryDescriptor title="Compact">
       <SearchInputComponent {...args} size="compact" />
@@ -65,9 +65,7 @@ export const Sizes = (args: ISearchInputProps): React.ReactElement => (
 
 Sizes.args = {};
 
-export const CollapsableSearch = (
-  args: ISearchInputProps
-): React.ReactElement => (
+export const CollapsableSearch = (args: ISearchInputProps): ReactElement => (
   <div style={commonWidth}>
     <StoryDescriptor title="Collapsed">
       <SearchInputComponent {...args} isCollapsable />

--- a/packages/react-components/src/components/Search/Search.tsx
+++ b/packages/react-components/src/components/Search/Search.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Search, Close } from '@livechat/design-system-icons/react/material';
 import { Icon } from '../Icon';
@@ -6,6 +5,14 @@ import { Loader } from '../Loader';
 
 import styles from './Search.module.scss';
 import { KeyCodes } from '../../utils/keyCodes';
+import {
+  FC,
+  useState,
+  useRef,
+  useEffect,
+  FormEvent,
+  KeyboardEvent,
+} from 'react';
 
 const baseClass = 'search-input';
 const inputBaseClass = `${baseClass}__input`;
@@ -21,7 +28,7 @@ export interface ISearchInputProps {
   onChange: (value: string) => void;
 }
 
-export const SearchInput: React.FC<ISearchInputProps> = ({
+export const SearchInput: FC<ISearchInputProps> = ({
   isCollapsable,
   isDisabled,
   isLoading,
@@ -31,9 +38,9 @@ export const SearchInput: React.FC<ISearchInputProps> = ({
   className,
   onChange,
 }) => {
-  const [isCollapsed, setIsCollapsed] = React.useState<boolean>(true);
-  const [isFocused, setIsFocused] = React.useState<boolean>(false);
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [isCollapsed, setIsCollapsed] = useState<boolean>(true);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   const isCloseIconVisible = !!value && !isDisabled && !isLoading;
   const ariaExpandedValue = isCollapsable && !isCollapsed && 'true';
 
@@ -47,13 +54,13 @@ export const SearchInput: React.FC<ISearchInputProps> = ({
     !isCollapsed && styles[`${baseClass}--collapsable--open`]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isCollapsable && !!value) {
       setIsCollapsed(false);
     }
   }, [isCollapsable]);
 
-  const handleOnChange = (e: React.FormEvent<HTMLInputElement>) => {
+  const handleOnChange = (e: FormEvent<HTMLInputElement>) => {
     const value = e.currentTarget.value;
     onChange(value);
   };
@@ -80,7 +87,7 @@ export const SearchInput: React.FC<ISearchInputProps> = ({
     setIsFocused(false);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === KeyCodes.enter) {
       e.preventDefault();
       onChange(value);

--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.spec.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, userEvent, vi } from 'test-utils';
 import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';
 

--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';

--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 
 import { Button, ButtonProps } from '../Button';
@@ -6,6 +5,7 @@ import { Button, ButtonProps } from '../Button';
 import styles from './SegmentedControl.module.scss';
 
 import noop from '../../utils/noop';
+import { HTMLAttributes, FC, useState, useEffect, MouseEvent } from 'react';
 
 const baseClass = 'segmented-control';
 
@@ -16,18 +16,17 @@ type ButtonElement = {
   label: string;
 } & Pick<ButtonProps, 'disabled' | 'loading' | 'icon'>;
 
-export interface SegmentedControlProps
-  extends React.HTMLAttributes<HTMLDivElement> {
+export interface SegmentedControlProps extends HTMLAttributes<HTMLDivElement> {
   className?: string;
   buttons: ButtonElement[];
   fullWidth?: boolean;
   size?: ButtonSize;
   initialId?: string;
   currentId?: string;
-  onButtonClick?: (id: string, event: React.MouseEvent<HTMLElement>) => void;
+  onButtonClick?: (id: string, event: MouseEvent<HTMLElement>) => void;
 }
 
-export const SegmentedControl: React.FC<SegmentedControlProps> = ({
+export const SegmentedControl: FC<SegmentedControlProps> = ({
   size = 'medium',
   buttons,
   className,
@@ -37,11 +36,11 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
   onButtonClick = noop,
 }) => {
   const mergedClassName = cx(styles[baseClass], className);
-  const [currentStateId, setCurrentStateId] = React.useState(() => initialId);
+  const [currentStateId, setCurrentStateId] = useState(() => initialId);
 
   const isControlled = typeof currentId === 'string';
 
-  React.useEffect(() => {
+  useEffect(() => {
     isControlled && setCurrentStateId(currentId);
   }, [currentId]);
 
@@ -67,7 +66,7 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = ({
         kind="secondary"
         icon={icon}
         className={cx(styles['btn'], styles[`btn--${size}`], activityStyles)}
-        onClick={(event: React.MouseEvent<HTMLElement>) => {
+        onClick={(event: MouseEvent<HTMLElement>) => {
           handleClick(id, event);
         }}
       >

--- a/packages/react-components/src/components/Switch/Switch.spec.tsx
+++ b/packages/react-components/src/components/Switch/Switch.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import { Switch } from './Switch';
 import loaderStyles from '../Loader/Loader.module.scss';

--- a/packages/react-components/src/components/Switch/Switch.stories.tsx
+++ b/packages/react-components/src/components/Switch/Switch.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { LockBlack as LockIcon } from '@livechat/design-system-icons/react/material';
 
@@ -7,6 +6,7 @@ import noop from '../../utils/noop';
 
 import styles from './Switch.module.scss';
 import { Loader } from '../Loader';
+import { LegacyRef, FormEvent, FC, useState, useEffect } from 'react';
 
 export const baseClass = 'switch';
 
@@ -18,15 +18,15 @@ export interface SwitchProps {
   className?: string;
   defaultOn?: boolean;
   disabled?: boolean;
-  innerRef?: React.LegacyRef<HTMLInputElement> | undefined;
+  innerRef?: LegacyRef<HTMLInputElement> | undefined;
   name?: string;
   on?: boolean;
-  onChange?(e: React.FormEvent, value: boolean): void;
+  onChange?(e: FormEvent, value: boolean): void;
   size?: SwitchSize;
   state?: SwitchState;
 }
 
-export const Switch: React.FC<SwitchProps> = ({
+export const Switch: FC<SwitchProps> = ({
   className = '',
   defaultOn = false,
   disabled = false,
@@ -39,11 +39,11 @@ export const Switch: React.FC<SwitchProps> = ({
   ariaLabel,
   ...props
 }) => {
-  const [checked, setChecked] = React.useState(() =>
+  const [checked, setChecked] = useState(() =>
     on !== undefined ? on : defaultOn
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (on !== undefined) {
       setChecked(on);
     }
@@ -61,7 +61,7 @@ export const Switch: React.FC<SwitchProps> = ({
     className
   );
 
-  const handleChange = (e: React.FormEvent) => {
+  const handleChange = (e: FormEvent) => {
     const hasOnChangePassed = onChange !== noop;
     if (hasOnChangePassed) {
       onChange(e, checked);

--- a/packages/react-components/src/components/Tab/Tab.spec.tsx
+++ b/packages/react-components/src/components/Tab/Tab.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { Tab } from './Tab';
 

--- a/packages/react-components/src/components/Tab/Tab.stories.tsx
+++ b/packages/react-components/src/components/Tab/Tab.stories.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { Tab as TabComponent, TabProps } from './Tab';
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
+import { ReactElement } from 'react';
 
 export default {
   title: 'Components/Tabs',
@@ -11,7 +11,7 @@ export default {
 
 type ITabArgs = TabProps;
 
-export const Tab = (args: ITabArgs): React.ReactElement => {
+export const Tab = (args: ITabArgs): ReactElement => {
   return <TabComponent {...args} />;
 };
 

--- a/packages/react-components/src/components/Tab/Tab.tsx
+++ b/packages/react-components/src/components/Tab/Tab.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { Text } from '../Typography';
 
 import styles from './Tab.module.scss';
 import { Badge } from '../Badge';
 import { Size } from 'utils';
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, FC } from 'react';
 
 type HTMLProps =
-  | (React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string })
-  | (React.ButtonHTMLAttributes<HTMLButtonElement> & { href?: never });
+  | (AnchorHTMLAttributes<HTMLAnchorElement> & { href: string })
+  | (ButtonHTMLAttributes<HTMLButtonElement> & { href?: never });
 
 export type TabProps = HTMLProps & {
   count?: number;
@@ -19,7 +19,7 @@ export type TabProps = HTMLProps & {
 
 const baseClass = 'tab';
 
-export const Tab: React.FC<TabProps> = ({
+export const Tab: FC<TabProps> = ({
   children,
   className,
   count,
@@ -28,8 +28,7 @@ export const Tab: React.FC<TabProps> = ({
   size = 'medium',
   ...restProps
 }) => {
-  const { disabled } =
-    restProps as React.ButtonHTMLAttributes<HTMLButtonElement>;
+  const { disabled } = restProps as ButtonHTMLAttributes<HTMLButtonElement>;
   const shouldDisplayAsCounter = count !== undefined && !asBadge;
   const shouldDisplayAsBadge = count !== undefined && asBadge;
 

--- a/packages/react-components/src/components/Tab/TabsWrapper.spec.tsx
+++ b/packages/react-components/src/components/Tab/TabsWrapper.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { TabsWrapper, TabsList } from './TabsWrapper';
 

--- a/packages/react-components/src/components/Tab/TabsWrapper.stories.tsx
+++ b/packages/react-components/src/components/Tab/TabsWrapper.stories.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { TabsList, TabsWrapper as TabsWrapperComponenet } from './TabsWrapper';
 import { Tab } from './Tab';
+import { ReactElement, useState } from 'react';
 
 export default {
   title: 'Components/Tabs',
@@ -19,8 +19,8 @@ type ITabArgs = {
   }>;
 };
 
-export const TabsWrapper = ({ items }: ITabArgs): React.ReactElement => {
-  const [selectedTab, setSelectedTab] = React.useState(items[0].id);
+export const TabsWrapper = ({ items }: ITabArgs): ReactElement => {
+  const [selectedTab, setSelectedTab] = useState(items[0].id);
 
   return (
     <TabsWrapperComponenet>

--- a/packages/react-components/src/components/Tab/TabsWrapper.tsx
+++ b/packages/react-components/src/components/Tab/TabsWrapper.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { FC, HTMLAttributes } from 'react';
 
 import styles from './TabsWrapper.module.scss';
 
 const baseClass = 'tabs';
 
-export const TabsWrapper: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+export const TabsWrapper: FC<HTMLAttributes<HTMLDivElement>> = ({
   className,
   children,
 }) => {
   return <div className={cx(styles[baseClass], className)}>{children}</div>;
 };
 
-export const TabsList: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+export const TabsList: FC<HTMLAttributes<HTMLDivElement>> = ({
   className,
   children,
 }) => {

--- a/packages/react-components/src/components/Tag/Tag.spec.tsx
+++ b/packages/react-components/src/components/Tag/Tag.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, userEvent, vi } from 'test-utils';
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';
 import noop from '../../utils/noop';

--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';
 
 import { Tag as TagComponent, TagProps } from './Tag';
+import { ReactElement } from 'react';
 
 const iterator = Object.keys(MaterialIcons);
 
@@ -21,7 +21,7 @@ export default {
   },
 } as ComponentMeta<typeof TagComponent>;
 
-export const Tag = ({ children, ...args }: TagProps): React.ReactElement => {
+export const Tag = ({ children, ...args }: TagProps): ReactElement => {
   return <TagComponent {...args}>{children}</TagComponent>;
 };
 
@@ -36,7 +36,7 @@ Tag.args = {
 const avatar =
   'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=200';
 
-export const kinds = ({ children, ...args }: TagProps): React.ReactElement => {
+export const kinds = ({ children, ...args }: TagProps): ReactElement => {
   return (
     <div className="story-spacer" style={{ display: 'flex' }}>
       <TagComponent {...args} kind="default">
@@ -71,7 +71,7 @@ kinds.args = {
 export const kindsWithOutline = ({
   children,
   ...args
-}: TagProps): React.ReactElement => {
+}: TagProps): ReactElement => {
   return (
     <div className="story-spacer" style={{ display: 'flex' }}>
       <TagComponent {...args} kind="default" outline>
@@ -106,7 +106,7 @@ kindsWithOutline.args = {
 export const kindsWithIcon = ({
   children,
   ...args
-}: TagProps): React.ReactElement => {
+}: TagProps): ReactElement => {
   return (
     <div className="story-spacer" style={{ display: 'flex' }}>
       <TagComponent {...args} kind="default">
@@ -142,7 +142,7 @@ kindsWithIcon.args = {
 export const kindsWithAvatar = ({
   children,
   ...args
-}: TagProps): React.ReactElement => {
+}: TagProps): ReactElement => {
   return (
     <div className="story-spacer" style={{ display: 'flex' }}>
       <TagComponent {...args} kind="default" avatar={avatar}>

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Close } from '@livechat/design-system-icons/react/material';
 import cx from 'clsx';
 import { getContrast } from 'polished';
@@ -7,10 +6,11 @@ import { Text } from '../Typography';
 import { Icon, IconSize, IconSource } from '../Icon';
 
 import styles from './Tag.module.scss';
+import { HTMLAttributes, FC } from 'react';
 
 const baseClass = 'tag';
 
-export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface TagProps extends HTMLAttributes<HTMLDivElement> {
   kind?:
     | 'default'
     | 'info'
@@ -38,7 +38,7 @@ const getCustomTextClass = (customColor?: string) => {
     : 'text-black';
 };
 
-export const Tag: React.FC<TagProps> = ({
+export const Tag: FC<TagProps> = ({
   className = '',
   children,
   dismissible = false,

--- a/packages/react-components/src/components/TagInput/EditableTag.tsx
+++ b/packages/react-components/src/components/TagInput/EditableTag.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
 import { EditableTagContent } from './EditableTagContent';
 import { Tag } from '../Tag';
 
 import styles from './TagInput.module.scss';
+import { HTMLAttributes, RefObject, FC, useMemo, useRef } from 'react';
 
 const baseClass = 'tag-input__tag';
 
-export interface EditableTagProps extends React.HTMLAttributes<HTMLDivElement> {
-  inputRef: React.RefObject<HTMLInputElement>;
+export interface EditableTagProps extends HTMLAttributes<HTMLDivElement> {
+  inputRef: RefObject<HTMLInputElement>;
   index: number;
   update: (idx: number, value: string) => void;
   remove: (idx: number) => void;
@@ -16,7 +16,7 @@ export interface EditableTagProps extends React.HTMLAttributes<HTMLDivElement> {
   size: 'medium' | 'large';
 }
 
-export const EditableTag: React.FC<EditableTagProps> = ({
+export const EditableTag: FC<EditableTagProps> = ({
   children,
   index,
   remove,
@@ -25,11 +25,11 @@ export const EditableTag: React.FC<EditableTagProps> = ({
   update,
   size,
 }) => {
-  const isValid = React.useMemo(() => {
+  const isValid = useMemo(() => {
     return validator !== undefined ? validator(children) : true;
   }, [children, validator]);
 
-  const innerEditableRef = React.useRef<HTMLInputElement>(null);
+  const innerEditableRef = useRef<HTMLInputElement>(null);
 
   const removeTag = () => remove(index);
 

--- a/packages/react-components/src/components/TagInput/EditableTagContent.tsx
+++ b/packages/react-components/src/components/TagInput/EditableTagContent.tsx
@@ -1,18 +1,18 @@
-import * as React from 'react';
 import { KeyCodes } from '../../utils/keyCodes';
 import escape from 'lodash.escape';
+import { RefObject, FC, useState, KeyboardEvent, ClipboardEvent } from 'react';
 
 export interface EditableTagContentProps {
   value: string;
   className?: string;
-  innerEditableRef: React.RefObject<HTMLDivElement>;
-  inputRef: React.RefObject<HTMLInputElement>;
+  innerEditableRef: RefObject<HTMLDivElement>;
+  inputRef: RefObject<HTMLInputElement>;
   change: (value: string) => void;
   remove: () => void;
   validator?: (value: string) => boolean;
 }
 
-export const EditableTagContent: React.FC<EditableTagContentProps> = ({
+export const EditableTagContent: FC<EditableTagContentProps> = ({
   className = '',
   innerEditableRef,
   inputRef,
@@ -20,7 +20,7 @@ export const EditableTagContent: React.FC<EditableTagContentProps> = ({
   remove,
   value,
 }) => {
-  const [removed, setRemoved] = React.useState(false);
+  const [removed, setRemoved] = useState(false);
 
   const getRef = () => innerEditableRef.current;
 
@@ -35,7 +35,7 @@ export const EditableTagContent: React.FC<EditableTagContentProps> = ({
     }
   };
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === KeyCodes.enter) {
       e.preventDefault();
       focusInputRef();
@@ -61,7 +61,7 @@ export const EditableTagContent: React.FC<EditableTagContentProps> = ({
     change(ref.innerText);
   };
 
-  const onPaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+  const onPaste = (e: ClipboardEvent<HTMLDivElement>) => {
     e.preventDefault();
     const text = e.clipboardData.getData('text/plain');
     document.execCommand('insertHTML', false, escape(text));

--- a/packages/react-components/src/components/TagInput/EmailTagInput.tsx
+++ b/packages/react-components/src/components/TagInput/EmailTagInput.tsx
@@ -1,5 +1,5 @@
+import { FC } from 'react';
 import { TagInputProps, TagInput } from './TagInput';
-import * as React from 'react';
 
 export type EmailTagInputProps = Omit<TagInputProps, 'validator'>;
 
@@ -11,7 +11,7 @@ const emailValidator = (value: string) => {
   return emailRegex.test(value);
 };
 
-export const EmailTagInput: React.FC<EmailTagInputProps> = ({
+export const EmailTagInput: FC<EmailTagInputProps> = ({
   id,
   tags,
   onChange,

--- a/packages/react-components/src/components/TagInput/TagInput.spec.tsx
+++ b/packages/react-components/src/components/TagInput/TagInput.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, userEvent, vi } from 'test-utils';
 import noop from '../../utils/noop';
 

--- a/packages/react-components/src/components/TagInput/TagInput.stories.tsx
+++ b/packages/react-components/src/components/TagInput/TagInput.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import noop from '../../utils/noop';
@@ -10,6 +9,7 @@ import {
   EmailTagInput,
   EmailTagInputProps,
 } from './index';
+import { useState } from 'react';
 
 const placeholderText = 'Placeholder text';
 
@@ -28,7 +28,7 @@ export default {
 export const DefaultTagInput: Story<TagInputProps> = ({
   ...args
 }: TagInputProps) => {
-  const [tags, setTags] = React.useState(['tag1', 'tag2']);
+  const [tags, setTags] = useState(['tag1', 'tag2']);
   return (
     <div>
       <TagInput {...args} tags={tags} onChange={setTags} />
@@ -44,7 +44,7 @@ DefaultTagInput.args = {
 export const DefaultEmailTagInput: Story<EmailTagInputProps> = ({
   ...args
 }: EmailTagInputProps) => {
-  const [tags, setTags] = React.useState(['one@test.com', 'two@test.com']);
+  const [tags, setTags] = useState(['one@test.com', 'two@test.com']);
   return (
     <div>
       <EmailTagInput {...args} tags={tags} onChange={setTags} />

--- a/packages/react-components/src/components/TagInput/TagInput.tsx
+++ b/packages/react-components/src/components/TagInput/TagInput.tsx
@@ -1,10 +1,17 @@
-import * as React from 'react';
 import cx from 'clsx';
 import { EditableTag } from './EditableTag';
 import { KeyCodes } from '../../utils/keyCodes';
 import { FieldError } from '../FieldError';
 
 import styles from './TagInput.module.scss';
+import {
+  FC,
+  useState,
+  useRef,
+  ChangeEvent,
+  KeyboardEvent,
+  ClipboardEvent,
+} from 'react';
 
 const baseClass = 'tag-input';
 
@@ -29,7 +36,7 @@ export interface TagInputProps {
   size?: 'medium' | 'large';
 }
 
-export const TagInput: React.FC<TagInputProps> = ({
+export const TagInput: FC<TagInputProps> = ({
   id,
   tags,
   onChange,
@@ -46,8 +53,8 @@ export const TagInput: React.FC<TagInputProps> = ({
     styles[`${baseClass}__input--${size}`]
   );
 
-  const [inputValue, setInputValue] = React.useState('');
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [inputValue, setInputValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const addTag = (value: string) => {
     onChange([...(tags || []), value]);
@@ -60,10 +67,10 @@ export const TagInput: React.FC<TagInputProps> = ({
     onChange(newTags);
   };
 
-  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) =>
     setInputValue(e.target.value);
 
-  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (tagSeparatorKeys.includes(e.key)) {
       e.preventDefault();
 
@@ -96,7 +103,7 @@ export const TagInput: React.FC<TagInputProps> = ({
     onChange(newTags);
   };
 
-  const onPaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+  const onPaste = (e: ClipboardEvent<HTMLInputElement>) => {
     e.preventDefault();
     const text = e.clipboardData.getData('text/plain');
     const newTags = text.split(/[\s,;\n]+/);

--- a/packages/react-components/src/components/Textarea/Textarea.spec.tsx
+++ b/packages/react-components/src/components/Textarea/Textarea.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import noop from '../../utils/noop';
 import { Textarea, TextareaProps } from './Textarea';

--- a/packages/react-components/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react-components/src/components/Textarea/Textarea.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';

--- a/packages/react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/react-components/src/components/Textarea/Textarea.tsx
@@ -1,20 +1,20 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { TextareaHTMLAttributes, forwardRef, useState } from 'react';
 
 import styles from './Textarea.module.scss';
 
 const baseClass = 'textarea';
 
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   className?: string;
   error?: boolean;
 }
 
-export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, error, ...textareaProps }, ref) => {
     const { disabled } = textareaProps;
-    const [isFocused, setIsFocused] = React.useState(false);
+    const [isFocused, setIsFocused] = useState(false);
     const mergedClassNames = cx(className, styles[baseClass], {
       [styles[`${baseClass}--disabled`]]: disabled,
       [styles[`${baseClass}--focused`]]: isFocused,

--- a/packages/react-components/src/components/Toast/Toast.spec.tsx
+++ b/packages/react-components/src/components/Toast/Toast.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, vi } from 'test-utils';
 import { ToastProps, Toast } from './Toast';
 

--- a/packages/react-components/src/components/Toast/Toast.stories.tsx
+++ b/packages/react-components/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta, Story } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 

--- a/packages/react-components/src/components/Toast/Toast.tsx
+++ b/packages/react-components/src/components/Toast/Toast.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   Close,
   Info,
@@ -7,6 +6,7 @@ import {
   Block,
 } from '@livechat/design-system-icons/react/material';
 import cx from 'clsx';
+import { HTMLAttributes, FC } from 'react';
 
 import { Button } from '../Button';
 import { Icon, IconKind, IconSource } from '../Icon';
@@ -21,7 +21,7 @@ type ToastAction = {
   closesOnClick?: boolean;
 };
 
-export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ToastProps extends HTMLAttributes<HTMLDivElement> {
   action?: ToastAction;
   className?: string;
   removable?: boolean;
@@ -46,7 +46,7 @@ const iconConfig: Record<ToastKind, { source: IconSource; kind?: IconKind }> = {
 
 const baseClass = 'toast';
 
-export const Toast: React.FC<ToastProps> = ({
+export const Toast: FC<ToastProps> = ({
   action,
   className,
   children,

--- a/packages/react-components/src/components/Toast/ToastWrapper.spec.tsx
+++ b/packages/react-components/src/components/Toast/ToastWrapper.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render } from 'test-utils';
 import { ToastWrapper } from './ToastWrapper';
 

--- a/packages/react-components/src/components/Toast/ToastWrapper.stories.tsx
+++ b/packages/react-components/src/components/Toast/ToastWrapper.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
+import { ReactElement } from 'react';
 
 import {
   ToastWrapperProps,
@@ -16,7 +16,7 @@ export default {
   },
 } as ComponentMeta<typeof ToastWrapperComponent>;
 
-export const ToastWrapper = (args: ToastWrapperProps): React.ReactElement => (
+export const ToastWrapper = (args: ToastWrapperProps): ReactElement => (
   <div style={{ width: '100%', height: 700, position: 'relative' }}>
     <ToastWrapperComponent {...args} />
   </div>

--- a/packages/react-components/src/components/Toast/ToastWrapper.tsx
+++ b/packages/react-components/src/components/Toast/ToastWrapper.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { ReactElement, FC } from 'react';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 import { ToastProps, Toast } from './Toast';
@@ -15,7 +15,7 @@ const baseClass = 'toast-wrapper';
 
 interface Toast extends ToastProps {
   id: string;
-  content: React.ReactElement | string;
+  content: ReactElement | string;
 }
 
 export interface ToastWrapperProps {
@@ -28,7 +28,7 @@ export interface ToastWrapperProps {
   horizontalPosition?: HorizontalPosition;
 }
 
-export const ToastWrapper: React.FC<ToastWrapperProps> = ({
+export const ToastWrapper: FC<ToastWrapperProps> = ({
   className,
   toasts = [],
   fixed = true,

--- a/packages/react-components/src/components/Tooltip/Info.tsx
+++ b/packages/react-components/src/components/Tooltip/Info.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react';
 import { Icon } from '../Icon';
 import { Close } from '@livechat/design-system-icons/react/material';
 import { getIconType } from './helpers';
 import styles from './Tooltip.module.scss';
+import { FC, MouseEvent } from 'react';
 
 const baseClass = 'tooltip';
 
-export const Info: React.FC<{
+export const Info: FC<{
   header: string;
   text: string;
   closeWithX?: boolean;
   theme?: string;
-  handleCloseAction?: (ev: React.MouseEvent) => void;
+  handleCloseAction?: (ev: MouseEvent) => void;
 }> = ({ header, text, closeWithX, theme, handleCloseAction }) => {
   return (
     <div style={{ position: 'relative' }}>

--- a/packages/react-components/src/components/Tooltip/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/Interactive.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
 import { Icon } from '../Icon';
 import { Close } from '@livechat/design-system-icons/react/material';
 import { Button } from '../Button';
 import { getIconType } from './helpers';
 import styles from './Tooltip.module.scss';
+import { FC, MouseEvent } from 'react';
 
 const baseClass = 'tooltip';
 
-export const Interactive: React.FC<{
+export const Interactive: FC<{
   header: string;
   text: string;
   image?: {
@@ -18,7 +18,7 @@ export const Interactive: React.FC<{
   theme?: 'invert' | 'important';
   handleClickPrimary: () => void;
   handleClickSecondary: () => void;
-  handleCloseAction?: (ev: React.MouseEvent) => void;
+  handleCloseAction?: (ev: MouseEvent) => void;
 }> = ({
   header,
   text,

--- a/packages/react-components/src/components/Tooltip/Simple.tsx
+++ b/packages/react-components/src/components/Tooltip/Simple.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
+import { FC } from 'react';
 
-export const Simple: React.FC<{ text: string }> = ({ text }) => {
+export const Simple: FC<{ text: string }> = ({ text }) => {
   return <div>{text}</div>;
 };

--- a/packages/react-components/src/components/Tooltip/SpotlightOverlay.tsx
+++ b/packages/react-components/src/components/Tooltip/SpotlightOverlay.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import styles from './Tooltip.module.scss';
 

--- a/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { render, fireEvent, cleanup } from 'test-utils';
 import { vi } from 'vitest';
 

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { Button } from '../Button';
 import { ITooltipProps, Tooltip as TooltipComponent } from './Tooltip';
@@ -18,6 +17,7 @@ import { Interactive as TooltipInteractiveComponent } from './Interactive';
 import { UserGuide as TooltipUserGuideComponent } from './UserGuide';
 import { UserGuideStep } from './UserGuideStep';
 import beutifulImage from './placeholder.png';
+import { ReactElement, FC, useReducer } from 'react';
 
 const tooltipPlacements = [
   'bottom',
@@ -38,7 +38,7 @@ const isVisibleOptions = [true, false, undefined];
 
 const tooltipThemes = ['invert', 'important', 'default'];
 
-export const Tooltip = (args: ITooltipProps): React.ReactElement => (
+export const Tooltip = (args: ITooltipProps): ReactElement => (
   <div
     style={{
       height: '100vh',
@@ -154,7 +154,7 @@ TooltipUserGuide.args = {
   hoverOutDelayTimeout: 100,
 };
 
-const TooltipSimpleExample: React.FC<ITooltipProps> = (props) => {
+const TooltipSimpleExample: FC<ITooltipProps> = (props) => {
   return (
     <div
       style={{
@@ -173,7 +173,7 @@ const TooltipSimpleExample: React.FC<ITooltipProps> = (props) => {
   );
 };
 
-const TooltipInteractiveExample: React.FC<ITooltipProps> = (props) => {
+const TooltipInteractiveExample: FC<ITooltipProps> = (props) => {
   return (
     <div
       style={{
@@ -215,7 +215,7 @@ const TooltipInteractiveExample: React.FC<ITooltipProps> = (props) => {
   );
 };
 
-const TooltipUserGuideExample: React.FC<ITooltipProps> = (props) => {
+const TooltipUserGuideExample: FC<ITooltipProps> = (props) => {
   const reducer = (
     state: { isVisible: boolean; reference: string },
     action: { type: string }
@@ -247,7 +247,7 @@ const TooltipUserGuideExample: React.FC<ITooltipProps> = (props) => {
     return state;
   };
 
-  const [state, dispatch] = React.useReducer(reducer, {
+  const [state, dispatch] = useReducer(reducer, {
     reference: 'reference1',
     isVisible: false,
   });
@@ -361,7 +361,7 @@ const TooltipUserGuideExample: React.FC<ITooltipProps> = (props) => {
   );
 };
 
-const TooltipInfoExample: React.FC<ITooltipProps> = (props) => {
+const TooltipInfoExample: FC<ITooltipProps> = (props) => {
   return (
     <div
       style={{

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { CSSTransition } from 'react-transition-group';
 import cx from 'clsx';
 import { css } from '@emotion/css';
@@ -13,9 +12,20 @@ import {
 } from '@floating-ui/react-dom';
 
 import styles from './Tooltip.module.scss';
+import {
+  ReactNode,
+  FC,
+  useRef,
+  useState,
+  useEffect,
+  Children,
+  isValidElement,
+  cloneElement,
+  MouseEvent,
+} from 'react';
 
 export interface ITooltipProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
   theme?: 'invert' | 'important' | undefined;
   placement?: Placement;
@@ -28,7 +38,7 @@ export interface ITooltipProps {
   triggerOnClick?: boolean;
   arrowOffsetY?: number;
   arrowOffsetX?: number;
-  triggerRenderer: () => React.ReactNode;
+  triggerRenderer: () => ReactNode;
   referenceElement?: VirtualElement;
   onOpen?: () => void;
   onClose?: () => void;
@@ -40,7 +50,7 @@ const sleep = (milliseconds: number) => {
 
 const baseClass = 'tooltip';
 
-export const Tooltip: React.FC<ITooltipProps> = (props) => {
+export const Tooltip: FC<ITooltipProps> = (props) => {
   const {
     triggerRenderer,
     referenceElement,
@@ -62,9 +72,9 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
   } = props;
 
   const isManaged = isVisible !== undefined;
-  const arrowRef = React.useRef<HTMLDivElement | null>(null);
-  const [visible, setVisibility] = React.useState(isVisible);
-  const isHovered = React.useRef(false);
+  const arrowRef = useRef<HTMLDivElement | null>(null);
+  const [visible, setVisibility] = useState(isVisible);
+  const isHovered = useRef(false);
 
   const {
     x,
@@ -85,22 +95,22 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
     placement: placement,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     referenceElement && reference(referenceElement);
   }, [reference, referenceElement]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setVisibility(isVisible);
   }, [isVisible]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     document.addEventListener('keydown', handleCloseAction);
     return () => {
       document.removeEventListener('keydown', handleCloseAction);
     };
   }, []);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {
       return;
     }
@@ -178,9 +188,9 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {React.Children.map(children, (child) => {
-        if (React.isValidElement(child)) {
-          return React.cloneElement(child, {
+      {Children.map(children, (child) => {
+        if (isValidElement(child)) {
+          return cloneElement(child, {
             handleCloseAction,
             theme,
             ...child.props,

--- a/packages/react-components/src/components/Tooltip/UserGuide.tsx
+++ b/packages/react-components/src/components/Tooltip/UserGuide.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ModalPortalProps } from '../Modal/';
 import { ITooltipProps, Tooltip } from './Tooltip';
 import SpotlightOverlay from './SpotlightOverlay';
@@ -6,6 +5,7 @@ import cx from 'clsx';
 import styles from './Tooltip.module.scss';
 import { ClientRectObject } from '@floating-ui/core';
 import VirtualReference from './virtualElementReference';
+import { FC, useState, useEffect } from 'react';
 
 const spotlightPadding = 8;
 const baseClass = 'guide-tooltip';
@@ -23,7 +23,7 @@ interface IUserGuide
     ITooltipProps,
     Omit<ModalPortalProps, 'children'> {}
 
-export const UserGuide: React.FC<IUserGuide> = (props) => {
+export const UserGuide: FC<IUserGuide> = (props) => {
   const {
     className,
     parentElementName,
@@ -31,12 +31,10 @@ export const UserGuide: React.FC<IUserGuide> = (props) => {
     shouldSlide = true,
   } = props;
 
-  const [parentElement, setParentElement] = React.useState<Element | null>(
-    null
-  );
+  const [parentElement, setParentElement] = useState<Element | null>(null);
 
-  const [rect, setRect] = React.useState<DOMRect | null>(null);
-  const [isSliding, setIsSliding] = React.useState<boolean>(shouldSlide);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const [isSliding, setIsSliding] = useState<boolean>(shouldSlide);
 
   const handleViewportChange = () => {
     if (parentElement) {
@@ -50,7 +48,7 @@ export const UserGuide: React.FC<IUserGuide> = (props) => {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (parentElement !== null) {
       window.addEventListener('resize', handleViewportChange);
       window.addEventListener('scroll', handleViewportChange);
@@ -62,14 +60,14 @@ export const UserGuide: React.FC<IUserGuide> = (props) => {
     }
   }, [parentElement, parentElementName]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (parentElementName) {
       const element = document.querySelector(parentElementName);
       setParentElement(element);
     }
   }, [parentElementName]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     parentElement &&
       setRect(
         virtualReference(

--- a/packages/react-components/src/components/Tooltip/UserGuideStep.tsx
+++ b/packages/react-components/src/components/Tooltip/UserGuideStep.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
 import { Icon } from '../Icon';
 import { Close } from '@livechat/design-system-icons/react/material';
 import { Button } from '../Button';
 import { getIconType } from './helpers';
 import styles from './Tooltip.module.scss';
+import { FC, useEffect, MouseEvent } from 'react';
 
 const baseClass = 'tooltip';
 
-export const UserGuideStep: React.FC<{
+export const UserGuideStep: FC<{
   header: string;
   text: string;
   image?: {
@@ -19,7 +19,7 @@ export const UserGuideStep: React.FC<{
   closeWithX?: boolean;
   theme?: string;
   handleClickPrimary: () => void;
-  handleCloseAction?: (ev: KeyboardEvent | React.MouseEvent) => void;
+  handleCloseAction?: (ev: KeyboardEvent | MouseEvent) => void;
 }> = ({
   header,
   text,
@@ -31,7 +31,7 @@ export const UserGuideStep: React.FC<{
   handleCloseAction,
   handleClickPrimary,
 }) => {
-  React.useEffect(() => {
+  useEffect(() => {
     if (handleCloseAction) {
       document.addEventListener('keydown', handleCloseAction);
 

--- a/packages/react-components/src/components/Typography/Heading.tsx
+++ b/packages/react-components/src/components/Typography/Heading.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { createElement, FC } from 'react';
 
 import styles from './Typography.module.scss';
 
@@ -21,14 +21,14 @@ interface IProps {
   className?: string;
 }
 
-export const Heading: React.FC<IProps> = ({
+export const Heading: FC<IProps> = ({
   as,
   size = 'md',
   children,
   className,
   ...props
 }) => {
-  return React.createElement(
+  return createElement(
     as || SIZE_TO_ELEMENT_MAP[size],
     { className: cx(styles[`heading-${size}`], className), ...props },
     children

--- a/packages/react-components/src/components/Typography/Text.tsx
+++ b/packages/react-components/src/components/Typography/Text.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'clsx';
+import { createElement, FC } from 'react';
 
 import styles from './Typography.module.scss';
 
@@ -17,7 +17,7 @@ interface IProps {
   strike?: boolean;
 }
 
-export const Text: React.FC<IProps> = ({
+export const Text: FC<IProps> = ({
   as = 'p',
   size = 'md',
   caps = false,
@@ -30,7 +30,7 @@ export const Text: React.FC<IProps> = ({
 }) => {
   const baseClassPrefix = caps ? 'caps' : `paragraph-${size}`;
 
-  return React.createElement(
+  return createElement(
     as,
     {
       className: cx(

--- a/packages/react-components/src/components/UploadBar/UploadBar.stories.tsx
+++ b/packages/react-components/src/components/UploadBar/UploadBar.stories.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { ComponentMeta } from '@storybook/react';
 
 import { UploadBar as UploadBarComponent } from './UploadBar';
@@ -7,6 +6,7 @@ import noop from '../../utils/noop';
 import { FileUploadProgress } from '../FileUploadProgress';
 import { ProgressStatus } from 'components/Progress/constants';
 import { PdfIcon } from '../../utils/PdfIcon';
+import { FC, useState } from 'react';
 
 const files = [
   {
@@ -61,8 +61,8 @@ export default {
   },
 } as ComponentMeta<typeof UploadBarComponent>;
 
-export const UploadBarWithSingleElement: React.FC = () => {
-  const [status, setStatus] = React.useState<'normal' | 'success' | 'error'>(
+export const UploadBarWithSingleElement: FC = () => {
+  const [status, setStatus] = useState<'normal' | 'success' | 'error'>(
     'normal'
   );
 
@@ -93,8 +93,8 @@ export const UploadBarWithSingleElement: React.FC = () => {
   );
 };
 
-export const UploadBarWithMultipleElements: React.FC = () => {
-  const [status, setStatus] = React.useState<'normal' | 'success' | 'error'>(
+export const UploadBarWithMultipleElements: FC = () => {
+  const [status, setStatus] = useState<'normal' | 'success' | 'error'>(
     'normal'
   );
 

--- a/packages/react-components/src/components/UploadBar/UploadBar.tsx
+++ b/packages/react-components/src/components/UploadBar/UploadBar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import cx from 'clsx';
 import {
   Check as CheckIcon,
@@ -17,6 +16,7 @@ import { ProgressCircle } from '../Progress';
 
 import styles from './UploadBar.module.scss';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { ReactNode, FC, useState } from 'react';
 
 const baseClass = 'upload-bar';
 const wrapperHeaderClass = `${baseClass}__wrapper__header`;
@@ -29,7 +29,7 @@ export interface UploadBarProps {
   isExpanded?: boolean;
   errorMessage?: string;
   status?: ProgressStatus;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   size?: ProgressSize;
   mode?: 'single' | 'multiple';
   onCloseButtonClick?: () => void;
@@ -62,7 +62,7 @@ const getHeaderIcon = (status: ProgressStatus, progressValue: number) => {
   );
 };
 
-export const UploadBar: React.FC<UploadBarProps> = ({
+export const UploadBar: FC<UploadBarProps> = ({
   children,
   className,
   progressValue,
@@ -76,7 +76,7 @@ export const UploadBar: React.FC<UploadBarProps> = ({
   onCloseButtonClick,
   onRetryButtonClick,
 }) => {
-  const [expanded, setExpanded] = React.useState(isExpanded || false);
+  const [expanded, setExpanded] = useState(isExpanded || false);
   const withError = status === 'error';
   const withSuccess = status === 'success';
   const mergedClassNames = cx(styles[baseClass], className, {

--- a/packages/react-components/src/stories/components/ColorTokens.tsx
+++ b/packages/react-components/src/stories/components/ColorTokens.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { DesignToken } from '../../themes/design-token';
 import { Text } from '../../components/Typography';
+import { FC, Fragment } from 'react';
 
 interface TokensGroup {
   background: string[];
@@ -98,10 +98,10 @@ const CONTENT = {
   },
 };
 
-export const ColorTokensPallete: React.FC = () => (
-  <React.Fragment>
+export const ColorTokensPallete: FC = () => (
+  <Fragment>
     {Object.entries(CONTENT).map(([section, { heading, content }]) => (
-      <React.Fragment key={section}>
+      <Fragment key={section}>
         <h2>{heading}</h2>
         <Text as="p">{content}</Text>
         <ul style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr' }}>
@@ -129,7 +129,7 @@ export const ColorTokensPallete: React.FC = () => (
             </li>
           ))}
         </ul>
-      </React.Fragment>
+      </Fragment>
     ))}
-  </React.Fragment>
+  </Fragment>
 );

--- a/packages/react-components/src/stories/components/IconsShowcase.tsx
+++ b/packages/react-components/src/stories/components/IconsShowcase.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';
+import { ReactElement } from 'react';
 import { Icon, IconSource } from '../../components/Icon';
 import './iconsShowcase.css';
 
@@ -10,7 +9,7 @@ export type IconsMap = {
 
 const Icons = MaterialIcons as IconsMap;
 
-export const IconsShowcase = (): React.ReactElement => {
+export const IconsShowcase = (): ReactElement => {
   const iconsGrid = Object.keys(Icons).map((item) => {
     const iconSource = Icons[item];
     return (

--- a/packages/react-components/src/stories/components/Spacing.tsx
+++ b/packages/react-components/src/stories/components/Spacing.tsx
@@ -1,8 +1,7 @@
-import * as React from 'react';
-
+import { ReactElement } from 'react';
 import './Spacing.css';
 
-export const Spacing = (): React.ReactElement => {
+export const Spacing = (): ReactElement => {
   return (
     <div>
       <table>

--- a/packages/react-components/src/stories/components/SpacingExamples.tsx
+++ b/packages/react-components/src/stories/components/SpacingExamples.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-
+import { ReactElement } from 'react';
 import { Input } from '../../components/Input';
 
 import styles from './SpacingExamples.module.scss';
@@ -7,7 +6,7 @@ import { StoryDescriptor } from './StoryDescriptor';
 
 const baseClass = 'input';
 
-export const SpacingExamples = (): React.ReactElement => {
+export const SpacingExamples = (): ReactElement => {
   return (
     <div>
       <StoryDescriptor title="Spacing 0">

--- a/packages/react-components/src/stories/components/StoryDescriptor.tsx
+++ b/packages/react-components/src/stories/components/StoryDescriptor.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import { FC } from 'react';
 
 type StoryDescriptorProps = {
   title: string;
 };
 
-export const StoryDescriptor: React.FC<StoryDescriptorProps> = ({
+export const StoryDescriptor: FC<StoryDescriptorProps> = ({
   title,
   children,
 }) => (

--- a/packages/react-components/src/stories/components/TablerIconsShowcase.tsx
+++ b/packages/react-components/src/stories/components/TablerIconsShowcase.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
-
 import * as TablerIcons from '@livechat/design-system-icons/react/tabler';
+import { ReactElement } from 'react';
 import { Icon, IconSource } from '../../components/Icon';
 import './iconsShowcase.css';
 
@@ -10,7 +9,7 @@ export type IconsMap = {
 
 const Icons = TablerIcons as IconsMap;
 
-export const TablerIconsShowcase = (): React.ReactElement => {
+export const TablerIconsShowcase = (): ReactElement => {
   const iconsGrid = Object.keys(Icons).map((item) => {
     const iconSource = Icons[item];
     return (

--- a/packages/react-components/src/utils/PdfIcon.tsx
+++ b/packages/react-components/src/utils/PdfIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import { FC } from 'react';
 
-export const PdfIcon: React.FC = () => (
+export const PdfIcon: FC = () => (
   <div>
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/react-components/tsconfig.json
+++ b/packages/react-components/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "baseUrl": "src",
     "paths": {
       "test-utils": ["test/utils.ts"]


### PR DESCRIPTION
Resolves: #379

## Description
Currently, across all components, we use hooks with React.x prefix. It makes code noisier than it should; This PR fixes that

## Storybook
https://feature-379--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
