### PR TITLE
rewrite the Checkbox component to input

### DIFF
--- a/packages/react-components/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/react-components/src/components/Checkbox/Checkbox.module.scss
@@ -9,7 +9,14 @@
     width: 100%;
   }
 
-  &__square {
+  &__text {
+    flex: 1 0 auto;
+    margin-left: 8px;
+    color: var(--content-basic-primary);
+  }
+
+  &__input {
+    appearance: none;
     box-sizing: border-box;
     display: flex;
     position: relative;
@@ -21,44 +28,28 @@
     background-color: var(--surface-primary-default);
     width: 16px;
     height: 16px;
-  }
 
-  &__checkmark {
-    transition: all 0.2s ease;
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  &--selected {
-    &:hover {
-      .checkbox__input:checked + .checkbox__square {
-        border-color: var(--action-primary-hover);
-        background-color: var(--action-primary-hover);
-      }
+    &::after {
+      display: inline-block;
+      position: absolute;
+      transition: opacity 0.2 ease;
+      opacity: 0;
+      z-index: 1;
+      background-color: var(--color-white);
+      width: 24px;
+      height: 24px;
+      content: '';
+      clip-path: path(
+        'M9 16.2001L5.5 12.7001C5.11 12.3101 4.49 12.3101 4.1 12.7001C3.71 13.0901 3.71 13.7101 4.1 14.1001L8.29 18.2901C8.68 18.6801 9.31 18.6801 9.7 18.2901L20.3 7.70007C20.69 7.31007 20.69 6.69007 20.3 6.30007C19.91 5.91007 19.29 5.91007 18.9 6.30007L9 16.2001Z'
+      );
+      scale: 0.5;
     }
 
-    .checkbox__square {
-      border-color: var(--action-primary-default);
-      background-color: var(--action-primary-default);
-    }
-
-    .checkbox__checkmark {
+    &:checked::after {
       opacity: 1;
     }
-  }
 
-  &__text {
-    flex: 1 0 auto;
-    margin-left: 8px;
-    color: var(--content-basic-primary);
-  }
-
-  &__input {
-    display: none;
-    width: 100%;
-    height: 100%;
-
-    &:checked + .checkbox__square {
+    &:checked {
       border-color: var(--color-action-default);
       background-color: var(--color-action-default);
 
@@ -68,15 +59,13 @@
     }
 
     &:focus {
-      + .checkbox__square {
-        box-shadow: 0 0 1px 2px rgb(66 132 245 / 70%); // TODO use shadow token
-      }
+      box-shadow: 0 0 1px 2px rgb(66 132 245 / 70%); // TODO use shadow token
     }
   }
 
   &--disabled {
     .checkbox {
-      &__square {
+      &__input {
         opacity: 0.4;
         border-color: var(--border-disabled);
         background-color: var(--surface-basic-disabled);
@@ -93,7 +82,7 @@
   }
 
   &__helper {
-    margin-left: 24px;
+    margin-left: 32px;
     cursor: default;
   }
 }

--- a/packages/react-components/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/react-components/src/components/Checkbox/Checkbox.module.scss
@@ -63,6 +63,20 @@
     }
   }
 
+  &--selected {
+    &:hover {
+      .checkbox__input:checked+.checkbox__square {
+        border-color: var(--action-primary-hover);
+        background-color: var(--action-primary-hover);
+      }
+    }
+
+    .checkbox__square {
+      border-color: var(--action-primary-default);
+      background-color: var(--action-primary-default);
+    }
+  }
+
   &--disabled {
     .checkbox {
       &__input {

--- a/packages/react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,4 @@
 import cx from 'clsx';
-import { Check } from '@livechat/design-system-icons/react/material';
-
-import { Icon } from '../Icon';
 import { Text } from '../Typography';
 import { FieldDescription } from '../FieldDescription';
 

--- a/packages/react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.tsx
@@ -29,24 +29,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         })}
       >
         <label className={styles[`${baseClass}__label`]}>
-          <div>
-            <input
-              {...restInputProps}
-              ref={ref}
-              checked={checked}
-              disabled={disabled}
-              className={styles[`${baseClass}__input`]}
-              type="checkbox"
-            />
-            <div className={styles[`${baseClass}__square`]}>
-              <Icon
-                source={Check}
-                kind="inverted"
-                size="xsmall"
-                className={styles[`${baseClass}__checkmark`]}
-              />
-            </div>
-          </div>
+          <input
+            {...restInputProps}
+            ref={ref}
+            checked={checked}
+            disabled={disabled}
+            className={styles[`${baseClass}__input`]}
+            type="checkbox"
+          />
           {children && (
             <Text as="div" size="md" className={styles[`${baseClass}__text`]}>
               {children}


### PR DESCRIPTION
Resolves: #510 

Note that introducing this would be a breaking change - the internals would change and some of DS' consumers' tests will break.

## Description
The Checkbox component being a `div` makes it less accessible and less usable through the keyboard. It isn't plug-and-play; introducing it into our app broke a couple of functionalities that were previously there. As such, I've tried rewriting the component to a native `input` element. I'd also suggest splitting the component into two parts: `Checkbox` and `LabeledCheckbox`; the first one would contain only the checkbox itself, while the latter would have the whole package (just like `Checkbox` does now. This would simplify testing greatly as we wouldn't need to dive into the div and label that's otherwise there.

I'd appreciate your help on the matter; this is my first contribution to DS, and I'm fairly new to FE altogether.

## Storybook
https://feature-510--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests - green
- [x] Storybook cases - they work as they did previously
- [x] Design review - design is 1:1 with the old one
- [ ] Functional (QA) review

**Optional:**

- [x] Accessibility cases (keyboard control, correct HTML markup, etc.) - this solution is much better in terms of keyboard navigability and follows ARIA rules for accessible interactive elements.
