### PR TITLE
570: Tooltip - disabling clicks on tooltip during animations

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -200,6 +200,7 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
   function renderFloatingComponent() {
     if (withFadeAnimation) {
       const enter = css`
+        pointer-events: none;
         opacity: 0;
       `;
 
@@ -208,6 +209,10 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
         transition-property: opacity;
         transition-duration: ${transitionDuration}ms;
         transition-delay: ${transitionDelay}ms;
+      `;
+
+      const enterDone = css`
+        pointer-events: initial;
       `;
 
       const exit = css`
@@ -231,6 +236,7 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
           timeout={timeout}
           classNames={{
             enter: enter,
+            enterDone: enterDone,
             enterActive: enterActive,
             exit: exit,
             exitActive: exitActive,


### PR DESCRIPTION
Resolves: #570 

## Description
Disabling pointer-events to avoid tooltip element blocking other DOM elements during long transition-delay animation.

## Storybook
https://feature-570--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
