### PR TITLE
573: reacting properly on closeOnEsc prop change

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -106,29 +106,20 @@ export const Popover: React.FC<IPopoverProps> = ({
   }
 
   const handleHideOnEscape = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
+    if (closeOnEsc && event.key === 'Escape') {
       setVisibility(false);
     }
   };
 
   React.useEffect(() => {
     document.addEventListener('mousedown', handleDocumentClick);
+    document.addEventListener('keydown', handleHideOnEscape);
 
     return () => {
       document.removeEventListener('mousedown', handleDocumentClick);
+      document.removeEventListener('keydown', handleHideOnEscape);
     };
   }, []);
-
-  React.useEffect(() => {
-    if (closeOnEsc) {
-      document.addEventListener('keydown', handleHideOnEscape);
-    }
-    return () => {
-      if (closeOnEsc) {
-        document.removeEventListener('keydown', handleHideOnEscape);
-      }
-    };
-  }, [closeOnEsc]);
 
   const mergedClassNames = cx(cssStyles['popover'], className, {
     [cssStyles['popover--visible']]: visible,

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -113,14 +113,22 @@ export const Popover: React.FC<IPopoverProps> = ({
 
   React.useEffect(() => {
     document.addEventListener('mousedown', handleDocumentClick);
+
+    return () => {
+      document.removeEventListener('mousedown', handleDocumentClick);
+    };
+  }, []);
+
+  React.useEffect(() => {
     if (closeOnEsc) {
       document.addEventListener('keydown', handleHideOnEscape);
     }
     return () => {
-      document.removeEventListener('keydown', handleHideOnEscape);
-      document.removeEventListener('mousedown', handleDocumentClick);
+      if (closeOnEsc) {
+        document.removeEventListener('keydown', handleHideOnEscape);
+      }
     };
-  }, []);
+  }, [closeOnEsc]);
 
   const mergedClassNames = cx(cssStyles['popover'], className, {
     [cssStyles['popover--visible']]: visible,


### PR DESCRIPTION
Resolves: #573
## Description
Adding closeOnEsc to the dependencies array of a hook to properly react on prop changes

## Storybook
https://feature-573--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
