### PR TITLE
DS-273: adding openedOnInit prop; passthrough of the data-testid prop to trigger element

### DIFF
--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -77,6 +77,14 @@ export interface IPickerProps {
    */
   hideClearButton?: boolean;
   /**
+   * Will open picker on component initialization
+   */
+  openedOnInit?: boolean;
+  /**
+   * Test id passed to the picker trigger element
+   */
+  ['data-testid']?: string;
+  /**
    * Callback called after item selection
    */
   onSelect: (selectedItems: IPickerListItem[] | null) => void;
@@ -97,10 +105,11 @@ export const Picker: React.FC<IPickerProps> = ({
   type = 'single',
   searchDisabled = false,
   hideClearButton,
+  openedOnInit = false,
   onSelect,
   ...props
 }) => {
-  const [isListOpen, setIsListOpen] = React.useState<boolean>(false);
+  const [isListOpen, setIsListOpen] = React.useState<boolean>(openedOnInit);
   const [searchPhrase, setSearchPhrase] = React.useState<string | null>(null);
   const triggerRef = React.useRef<HTMLDivElement>(null);
 
@@ -231,9 +240,10 @@ export const Picker: React.FC<IPickerProps> = ({
   }, [selected]);
 
   return (
-    <div ref={triggerRef} className={mergedClassNames} {...props}>
+    <div ref={triggerRef} className={mergedClassNames} id={props.id}>
       <div className={styles[`${baseClass}__container`]}>
         <Trigger
+          testId={props['data-testid']}
           isSearchDisabled={searchDisabled}
           isError={error}
           isOpen={isListOpen}

--- a/packages/react-components/src/components/Picker/Trigger.tsx
+++ b/packages/react-components/src/components/Picker/Trigger.tsx
@@ -24,6 +24,7 @@ export interface ITriggerProps {
   hideClearButton?: boolean;
   onTrigger: (e: React.MouseEvent | KeyboardEvent) => void;
   onClear: () => void;
+  testId?: string;
 }
 
 export const Trigger: React.FC<React.PropsWithChildren<ITriggerProps>> = ({
@@ -39,6 +40,7 @@ export const Trigger: React.FC<React.PropsWithChildren<ITriggerProps>> = ({
   hideClearButton,
   onTrigger,
   onClear,
+  testId,
 }) => {
   const triggerRef = React.useRef<HTMLDivElement>(null);
   const mergedClassNames = cx(
@@ -91,6 +93,7 @@ export const Trigger: React.FC<React.PropsWithChildren<ITriggerProps>> = ({
       className={mergedClassNames}
       onClick={handleTriggerClick}
       tabIndex={0}
+      data-testid={testId}
     >
       <div className={styles[`${baseClass}__content`]}>{children}</div>
       <div


### PR DESCRIPTION
Resolves: [DS-273](https://livechatinc.atlassian.net/browse/DS-273)

## Description
Adding openedOnInit prop; passthrough of the data-testid prop to trigger element

## Storybook
https://feature-DS-273--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)


[DS-273]: https://livechatinc.atlassian.net/browse/DS-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ