### PR TITLE
426: DevEx Improvements in Input and Tag Input components

### DIFF
--- a/packages/react-components/src/components/Input/Input.spec.tsx
+++ b/packages/react-components/src/components/Input/Input.spec.tsx
@@ -38,33 +38,37 @@ describe('<Input> component', () => {
   });
 
   it('should have disabled class and input should be disabled if "disabled" prop is set', () => {
-    const { container, getByTestId } = render(<Input disabled />);
+    const { container, getByRole } = render(<Input disabled />);
     expect(container.firstChild).toHaveClass(styles['input--disabled']);
     expect(container.firstChild).toHaveAttribute('aria-disabled', 'true');
-    expect(getByTestId('input')).toHaveAttribute('disabled');
+    expect(getByRole('textbox')).toHaveAttribute('disabled');
   });
 
   it('should have custom placeholder text if it is set', () => {
-    const { getByTestId } = render(<Input placeholder="Custom placeholder" />);
-    expect(getByTestId('input')).toHaveAttribute(
+    const { getByRole } = render(<Input placeholder="Custom placeholder" />);
+    expect(getByRole('textbox')).toHaveAttribute(
       'placeholder',
       'Custom placeholder'
     );
   });
 
   it('should have text type input as default', () => {
-    const { getByTestId } = render(<Input />);
-    expect(getByTestId('input')).toHaveAttribute('type', 'text');
+    const { getByRole } = render(<Input />);
+    expect(getByRole('textbox')).toHaveAttribute('type', 'text');
   });
 
   it('should have password type input if type "password" is set', () => {
-    const { getByTestId } = render(<Input type="password" />);
-    expect(getByTestId('input')).toHaveAttribute('type', 'password');
+    const { getByTestId } = render(
+      <Input type="password" data-testid="password-input" />
+    );
+    expect(getByTestId('password-input')).toHaveAttribute('type', 'password');
   });
 
   it('should change the input type if show password icon is clicked', () => {
-    const { getByTestId, getByRole } = render(<Input type="password" />);
-    const input = getByTestId('input');
+    const { getByRole, getByTestId } = render(
+      <Input type="password" data-testid="password-input" />
+    );
+    const input = getByTestId('password-input');
     const button = getByRole('button');
 
     expect(input).toHaveAttribute('type', 'password');

--- a/packages/react-components/src/components/Input/Input.tsx
+++ b/packages/react-components/src/components/Input/Input.tsx
@@ -87,7 +87,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <div className={mergedClassNames} aria-disabled={disabled} tab-index="0">
         {shouldRenderLeftIcon && renderIcon(icon, disabled)}
         <input
-          data-testid="input"
           {...inputProps}
           ref={ref}
           onFocus={(e) => {

--- a/packages/react-components/src/components/TagInput/TagInput.tsx
+++ b/packages/react-components/src/components/TagInput/TagInput.tsx
@@ -17,7 +17,11 @@ const tagSeparatorKeys = [
 ];
 const tagRemoveKeys = [KeyCodes.backspace, KeyCodes.delete];
 
-export interface TagInputProps {
+export interface TagInputProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'onChange'
+  > {
   /**
    * Set the id for input
    */
@@ -56,6 +60,7 @@ export const TagInput: React.FC<TagInputProps> = ({
   error,
   placeholder,
   size = 'medium',
+  ...props
 }) => {
   const mergedClassNames = cx(styles[baseClass], {
     [styles[`${baseClass}--error`]]: error,
@@ -139,6 +144,7 @@ export const TagInput: React.FC<TagInputProps> = ({
           </EditableTag>
         ))}
         <input
+          {...props}
           id={id}
           ref={inputRef}
           className={inputClassNames}


### PR DESCRIPTION
Resolves: #426

## Description

- Passing HTMLInput elements to TagInput component
- Removing hardcoded data-testid prop from Input component

## Storybook
https://feature-426--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
