### PR TITLE
573: Popover - fix for closeOnEsc prop

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -81,6 +81,19 @@ export const Popover: React.FC<IPopoverProps> = ({
   }, [visible]);
 
   React.useEffect(() => {
+    const handleHideOnEscape = (event: KeyboardEvent) => {
+      if (closeOnEsc && event.key === 'Escape') {
+        setVisibility(false);
+      }
+    };
+    document.addEventListener('keydown', handleHideOnEscape);
+
+    return () => {
+      document.removeEventListener('keydown', handleHideOnEscape);
+    };
+  }, [closeOnEsc]);
+
+  React.useEffect(() => {
     if (!refs.reference.current || !refs.floating.current) {
       return;
     }
@@ -105,19 +118,11 @@ export const Popover: React.FC<IPopoverProps> = ({
     }
   }
 
-  const handleHideOnEscape = (event: KeyboardEvent) => {
-    if (closeOnEsc && event.key === 'Escape') {
-      setVisibility(false);
-    }
-  };
-
   React.useEffect(() => {
     document.addEventListener('mousedown', handleDocumentClick);
-    document.addEventListener('keydown', handleHideOnEscape);
 
     return () => {
       document.removeEventListener('mousedown', handleDocumentClick);
-      document.removeEventListener('keydown', handleHideOnEscape);
     };
   }, []);
 


### PR DESCRIPTION
Resolves: #{issue-number}

## Description
Fixing issue when closeOnEsc was wrongly memorized in eventHandlers

## Storybook
https://feature-573--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
