### PR TITLE
597: Tooltip - onOpen, onClose fixes

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
@@ -159,4 +159,46 @@ describe('<Tooltip> component', () => {
 
     cleanup();
   });
+
+  it('should call onOpen and onClose callbacks when visibility changes on hover action', async () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const { getByRole, queryByText } = render(
+      <Tooltip
+        triggerRenderer={() => <button>Open</button>}
+        triggerOnClick={false}
+        withFadeAnimation={false}
+        hoverOutDelayTimeout={0}
+        transitionDuration={0}
+        onOpen={onOpen}
+        onClose={onClose}
+      >
+        <div style={{ width: '100px' }}>Test</div>
+      </Tooltip>
+    );
+
+    const button = getByRole('button', { name: 'Open' });
+
+    act(() => {
+      fireEvent.mouseEnter(button);
+    });
+
+    expect(queryByText('Test')).toBeInTheDocument();
+    expect(onOpen).toBeCalledTimes(1);
+    expect(onClose).not.toBeCalled();
+
+    act(() => {
+      fireEvent.mouseOut(button);
+    });
+
+    await waitFor(
+      () => {
+        expect(queryByText('Test')).not.toBeInTheDocument();
+        expect(onClose).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 1000 }
+    );
+
+    cleanup();
+  });
 });

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -85,9 +85,7 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
     placement: placement,
   });
 
-  const setVisibilityWithCallback = (
-    newVisibility: boolean | undefined
-  ): void => {
+  const handleVisibilityChange = (newVisibility: boolean | undefined): void => {
     if (newVisibility) {
       onOpen?.();
     } else {
@@ -125,27 +123,27 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
     isHovered.current = false;
     void sleep(hoverOutDelayTimeout).then(() => {
       if (!isHovered.current) {
-        setVisibilityWithCallback(false);
+        handleVisibilityChange(false);
       }
     });
   };
 
   const handleOpen = () => {
     if (!isManaged) {
-      setVisibilityWithCallback(true);
+      handleVisibilityChange(true);
     }
   };
 
   const handleClose = () => {
     if (!isManaged) {
-      setVisibilityWithCallback(false);
+      handleVisibilityChange(false);
     }
   };
 
   const handleMouseEnter = () => {
     if (triggerOnClick || isManaged) return;
     isHovered.current = true;
-    setVisibilityWithCallback(true);
+    handleVisibilityChange(true);
   };
 
   const handleCloseAction = (event: KeyboardEvent | MouseEvent) => {

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -85,6 +85,17 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
     placement: placement,
   });
 
+  const setVisibilityWithCallback = (
+    newVisibility: boolean | undefined
+  ): void => {
+    if (newVisibility) {
+      onOpen?.();
+    } else {
+      onClose?.();
+    }
+    setVisibility(newVisibility);
+  };
+
   React.useEffect(() => {
     referenceElement && reference(referenceElement);
   }, [reference, referenceElement]);
@@ -114,29 +125,27 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
     isHovered.current = false;
     void sleep(hoverOutDelayTimeout).then(() => {
       if (!isHovered.current) {
-        setVisibility(false);
+        setVisibilityWithCallback(false);
       }
     });
   };
 
   const handleOpen = () => {
-    if (onOpen) onOpen();
     if (!isManaged) {
-      setVisibility(true);
+      setVisibilityWithCallback(true);
     }
   };
 
   const handleClose = () => {
-    if (onClose) onClose();
     if (!isManaged) {
-      setVisibility(false);
+      setVisibilityWithCallback(false);
     }
   };
 
   const handleMouseEnter = () => {
     if (triggerOnClick || isManaged) return;
     isHovered.current = true;
-    setVisibility(true);
+    setVisibilityWithCallback(true);
   };
 
   const handleCloseAction = (event: KeyboardEvent | MouseEvent) => {


### PR DESCRIPTION
Resolves: #597

## Description
Triggering onClose and onOpen callbacks when visibility changes on hover action

## Storybook
https://feature-597--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
