### PR TITLE
Avoid redundand calls of onOpen and onClose callbacks

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
@@ -201,4 +201,40 @@ describe('<Tooltip> component', () => {
 
     cleanup();
   });
+
+  it('should not call onOpen callback redundantly when hovering from trigger element to tooltip', () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const { getByRole, queryByText } = render(
+      <Tooltip
+        triggerRenderer={() => <button>Open</button>}
+        triggerOnClick={false}
+        withFadeAnimation={false}
+        hoverOutDelayTimeout={0}
+        transitionDuration={0}
+        onOpen={onOpen}
+        onClose={onClose}
+      >
+        <div style={{ width: '100px' }}>Test</div>
+      </Tooltip>
+    );
+
+    const button = getByRole('button', { name: 'Open' });
+
+    act(() => {
+      fireEvent.mouseEnter(button);
+    });
+
+    expect(queryByText('Test')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.mouseEnter(queryByText('Test') as HTMLElement);
+      fireEvent.mouseEnter(button);
+    });
+
+    expect(onOpen).toBeCalledTimes(1);
+    expect(onClose).not.toBeCalled();
+
+    cleanup();
+  });
 });

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -87,9 +87,9 @@ export const Tooltip: React.FC<ITooltipProps> = (props) => {
 
   const handleVisibilityChange = (newVisibility: boolean | undefined): void => {
     if (newVisibility) {
-      onOpen?.();
+      !visible && onOpen?.();
     } else {
-      onClose?.();
+      visible && onClose?.();
     }
     setVisibility(newVisibility);
   };


### PR DESCRIPTION
Resolves: #613 

## Description
- Fix redundand calls of `onOpen` & `onClose` callbacks

## Storybook
https://feature-613--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [x] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
