### PR TITLE
634: Checkbox mask size issue on Safari and Firefox

### DIFF
--- a/packages/react-components/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/react-components/src/components/Checkbox/Checkbox.module.scss
@@ -34,15 +34,14 @@
       display: inline-block;
       position: absolute;
       transition: opacity 0.2 ease;
-      content: '';
       opacity: 0;
       z-index: 1;
       background-color: var(--content-invert-primary);
       width: 24px;
       height: 24px;
-      -webkit-mask: url('./check.svg') no-repeat 50% 50%;
+      content: '';
       mask: url('./check.svg') no-repeat 50% 50%;
-      mask-size: cover;
+      mask: url('./check.svg') no-repeat 50% 50%;
     }
 
     &:checked::after {

--- a/packages/react-components/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/react-components/src/components/Checkbox/Checkbox.module.scss
@@ -34,13 +34,13 @@
       display: inline-block;
       position: absolute;
       transition: opacity 0.2 ease;
+      content: '';
       opacity: 0;
       z-index: 1;
       background-color: var(--content-invert-primary);
       width: 24px;
       height: 24px;
-      content: '';
-      mask: url('./check.svg') no-repeat 50% 50%;
+      -webkit-mask: url('./check.svg') no-repeat 50% 50%;
       mask: url('./check.svg') no-repeat 50% 50%;
     }
 


### PR DESCRIPTION
Resolves: #634 
## Description
Removing `mask-size: cover` property to fix the Checkbox mask on Safari and Firefox browsers

## Storybook
https://feature-634--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
