### PR TITLE
Popover: replacing colour token

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.module.scss
+++ b/packages/react-components/src/components/Popover/Popover.module.scss
@@ -5,7 +5,7 @@
   z-index: $stacking-context-level-popover;
   border-radius: 4px;
   box-shadow: var(--shadow-pop-over);
-  background-color: var(--surface-primary-default);
+  background-color: var(--popover-background);
   min-width: 168px;
   max-width: 336px;
 


### PR DESCRIPTION
Resolves: #611 

## Description
Replacing Popover background color token with component-specific `--popover-background`.

## Storybook
https://feature-611--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self-review
- [ ] Unit & integration tests
- [ ] Storybook cases
- [ ] Design review
- [ ] Functional (QA) review

**Optional:**

- [ ] Accessibility cases (keyboard control, correct HTML markup, etc.)
