### PR TITLE
#566 - ActionMenu - Option to prevent closing when option is selected

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.spec.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.spec.tsx
@@ -77,4 +77,32 @@ describe('<ActionMenu> component', () => {
     userEvent.click(getByText('Option two'));
     expect(onClick).toBeCalled();
   });
+
+  it('should keep menu open after option click if keepOpenOnClick is true', () => {
+    const onClick = vi.fn();
+    const { getByTestId, getByText } = renderComponent({
+      ...defaultProps,
+      keepOpenOnClick: true,
+      options: [
+        {
+          key: 'one',
+          element: 'Option one',
+          onClick: noop,
+        },
+        {
+          key: 'two',
+          element: 'Option two',
+          onClick: onClick,
+        },
+      ],
+    });
+    const trigger = getByTestId('action-menu-trigger-button');
+
+    userEvent.click(trigger);
+    userEvent.click(getByText('Option two'));
+    expect(getByTestId('action-menu-test')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    );
+  });
 });

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -5,6 +5,8 @@ import { ActionMenu } from './ActionMenu';
 import { ActionMenuItem } from './ActionMenuItem';
 import { exampleOptions } from './constants';
 import './ActionMenu.stories.css';
+import { RadioButton } from '../RadioButton';
+import { Switch } from '../Switch';
 
 export default {
   title: 'Components/ActionMenu',
@@ -23,3 +25,71 @@ export const Default = (): JSX.Element => (
     />
   </div>
 );
+
+export const KeepOpenOnItemClick = (): JSX.Element => {
+  const [checkboxValue, setCheckboxValue] = React.useState('one');
+  const [switchOneValue, setSwitchOneValue] = React.useState(false);
+  const [switchTwoValue, setSwitchTwoValue] = React.useState(false);
+
+  return (
+    <div className="action-menu-preview">
+      <ActionMenu
+        options={[
+          {
+            key: 'one',
+            element: (
+              <ActionMenuItem>
+                <RadioButton checked={checkboxValue === 'one'}>
+                  Radio label one
+                </RadioButton>
+              </ActionMenuItem>
+            ),
+            onClick: () => setCheckboxValue('one'),
+          },
+          {
+            key: 'two',
+            element: (
+              <ActionMenuItem>
+                <RadioButton checked={checkboxValue === 'two'}>
+                  Radio label two
+                </RadioButton>
+              </ActionMenuItem>
+            ),
+            onClick: () => setCheckboxValue('two'),
+          },
+          {
+            key: 'three',
+            withDivider: true,
+            element: (
+              <ActionMenuItem
+                rightNode={
+                  <Switch on={switchOneValue} state="regular" size="medium" />
+                }
+              >
+                Toggle label one
+              </ActionMenuItem>
+            ),
+            onClick: () => setSwitchOneValue((s) => !s),
+          },
+          {
+            key: 'four',
+            withDivider: true,
+            element: (
+              <ActionMenuItem
+                rightNode={
+                  <Switch on={switchTwoValue} state="regular" size="medium" />
+                }
+              >
+                Toggle label two
+              </ActionMenuItem>
+            ),
+            onClick: () => setSwitchTwoValue((s) => !s),
+          },
+        ]}
+        triggerRenderer={<Icon source={MoreHoriz} kind="primary" />}
+        openedOnInit
+        keepOpenOnClick
+      />
+    </div>
+  );
+};

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -92,7 +92,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   const handleItemClick = (itemOnClick: () => void) => {
     itemOnClick();
 
-    if (keepOpenOnClick !== true) {
+    if (!keepOpenOnClick) {
       setIsVisible(false);
     }
   };

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -101,7 +101,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     <Popover
       isVisible={isVisible}
       placement={placement}
-      onClose={() => setIsVisible(false)}
       triggerRenderer={() => (
         <button
           data-testid="action-menu-trigger-button"

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -32,6 +32,10 @@ export interface ActionMenuProps {
    * Will open menu on component initialization
    */
   openedOnInit?: boolean;
+  /**
+   * Menu will stay open after option click
+   */
+  keepOpenOnClick?: boolean;
 }
 
 const baseClass = 'action-menu';
@@ -42,6 +46,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   triggerRenderer,
   placement = 'bottom-end',
   openedOnInit = false,
+  keepOpenOnClick,
   ...props
 }) => {
   const [isVisible, setIsVisible] = React.useState(openedOnInit);
@@ -86,7 +91,10 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
 
   const handleItemClick = (itemOnClick: () => void) => {
     itemOnClick();
-    setIsVisible(false);
+
+    if (keepOpenOnClick !== true) {
+      setIsVisible(false);
+    }
   };
 
   return (

--- a/packages/react-components/src/components/RadioButton/RadioButton.module.scss
+++ b/packages/react-components/src/components/RadioButton/RadioButton.module.scss
@@ -1,5 +1,6 @@
 .radio-button {
-  display: inline-block;
+  display: flex;
+  flex-flow: column;
 
   &:focus {
     .radio-button__circle {


### PR DESCRIPTION
Resolves: #566 

## Description
Added optional prop that will prevent closing the menu after the item click. It can be used to put the form-like elements to the menu like radio buttons or switch.
I also adjusted the `Radio button` styles to fit the design if implemented inside the menu.

## Storybook

https://feature-566--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-actionmenu--keep-open-on-item-click

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
