### PR TITLE
#710 - Popover - Fix for missing token value used as background color

### DIFF
--- a/packages/react-components/src/themes/dark.scss
+++ b/packages/react-components/src/themes/dark.scss
@@ -270,4 +270,5 @@ $surface-secondary-active: #3a3a40;
   --picker-list-option-background-hover: #{$surface-secondary-hover};
   --picker-list-option-background-focus: #{$surface-secondary-hover};
   --picker-list-option-background-active: #{$surface-secondary-active};
+  --popover-background: #{$surface-secondary-default};
 }

--- a/packages/react-components/src/themes/legacy.scss
+++ b/packages/react-components/src/themes/legacy.scss
@@ -268,4 +268,5 @@ $surface-primary-active: #ebf1f4;
   --picker-list-option-background-hover: #{$surface-primary-hover};
   --picker-list-option-background-focus: #{$surface-primary-hover};
   --picker-list-option-background-active: #{$surface-primary-active};
+  --popover-background: #{$surface-primary-default};
 }

--- a/packages/react-components/src/themes/light.scss
+++ b/packages/react-components/src/themes/light.scss
@@ -266,4 +266,5 @@ $surface-primary-active: #eeeeef;
   --picker-list-option-background-hover: #{$surface-primary-hover};
   --picker-list-option-background-focus: #{$surface-primary-hover};
   --picker-list-option-background-active: #{$surface-primary-active};
+  --popover-background: #{$surface-primary-default};
 }


### PR DESCRIPTION
Resolves: #710 

## Description
Fix for missing `--popover-background` token values in all themes.

## Storybook

https://feature-710--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-popover--default

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
