### PR TITLE
#728 - Tooltip - Change default button kinds for Interactive and User Guide

### DIFF
--- a/packages/react-components/src/components/Alert/Alert.tsx
+++ b/packages/react-components/src/components/Alert/Alert.tsx
@@ -129,14 +129,14 @@ export const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
         {(primaryButton || secondaryButton) && (
           <div className={styles[`${baseClass}__content__cta`]}>
             {primaryButton && (
-              <Button kind="primary" onClick={primaryButton.handleClick}>
+              <Button kind="high-contrast" onClick={primaryButton.handleClick}>
                 {primaryButton.label}
               </Button>
             )}
             {secondaryButton && (
               <Button
                 className={styles[`${baseClass}__content__cta__link`]}
-                kind="link"
+                kind="text"
                 onClick={secondaryButton.handleClick}
               >
                 {secondaryButton.label}

--- a/packages/react-components/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/react-components/src/components/Tooltip/Tooltip.module.scss
@@ -148,6 +148,7 @@ $base-class: 'tooltip';
 
   &-footer {
     display: flex;
+    justify-content: space-between;
     margin: var(--spacing-4) 0 0;
 
     &-secondary {

--- a/packages/react-components/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/react-components/src/components/Tooltip/Tooltip.module.scss
@@ -148,8 +148,15 @@ $base-class: 'tooltip';
 
   &-footer {
     display: flex;
-    justify-content: space-between;
     margin: var(--spacing-4) 0 0;
+
+    &-secondary {
+      margin-left: var(--spacing-4);
+
+      &-invert {
+        color: var(--content-invert-primary);
+      }
+    }
 
     &--user-guide-step {
       align-items: center;

--- a/packages/react-components/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/react-components/src/components/Tooltip/Tooltip.module.scss
@@ -159,6 +159,10 @@ $base-class: 'tooltip';
       }
     }
 
+    &--interactive {
+      justify-content: flex-start;
+    }
+
     &--user-guide-step {
       align-items: center;
     }

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -165,12 +165,10 @@ export const TooltipInteractive = (): React.ReactElement => (
         primaryButton={{
           handleClick: noop,
           label: 'Primary Button',
-          kind: 'primary',
         }}
         secondaryButton={{
           handleClick: noop,
           label: 'Secondary',
-          kind: 'secondary',
         }}
       />
     </Tooltip>

--- a/packages/react-components/src/components/Tooltip/components/Info.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Info.tsx
@@ -7,6 +7,7 @@ import { Button } from '../../Button';
 import { Icon } from '../../Icon';
 import { getIconType } from '../helpers';
 import styles from '../Tooltip.module.scss';
+import { TooltipTheme } from '../types';
 
 const baseClass = 'tooltip';
 
@@ -14,7 +15,7 @@ export const Info: React.FC<{
   header?: string;
   text: string;
   closeWithX?: boolean;
-  theme?: string;
+  theme?: TooltipTheme;
   handleCloseAction?: (ev: React.MouseEvent) => void;
 }> = ({ header, text, closeWithX, theme, handleCloseAction }) => {
   return (

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Close } from '@livechat/design-system-icons/react/material';
+import cx from 'clsx';
 
 import { Button, ButtonKind } from '../../Button';
 import { Icon } from '../../Icon';
@@ -38,43 +39,60 @@ export const Interactive: React.FC<{
   handleCloseAction,
   primaryButton,
   secondaryButton,
-}) => (
-  <div className={styles[`${baseClass}__interactive`]}>
-    {closeWithX && (
-      <Button
-        className={styles[`${baseClass}-close`]}
-        size="compact"
-        kind="plain"
-        onClick={handleCloseAction}
-        icon={
-          <Icon source={Close} kind={theme ? getIconType(theme) : 'primary'} />
-        }
-      />
-    )}
-    {image && (
-      <div className={styles[`${baseClass}-image-container`]}>
-        <img
-          className={styles[`${baseClass}-image`]}
-          src={image.src}
-          alt={image.alt}
+}) => {
+  const getDefaultPrimaryButtonKind = (theme?: 'invert' | 'important') => {
+    if (theme === 'invert') {
+      return 'secondary';
+    }
+
+    return 'high-contrast';
+  };
+
+  return (
+    <div className={styles[`${baseClass}__interactive`]}>
+      {closeWithX && (
+        <Button
+          className={styles[`${baseClass}-close`]}
+          size="compact"
+          kind="plain"
+          onClick={handleCloseAction}
+          icon={
+            <Icon
+              source={Close}
+              kind={theme ? getIconType(theme) : 'primary'}
+            />
+          }
         />
+      )}
+      {image && (
+        <div className={styles[`${baseClass}-image-container`]}>
+          <img
+            className={styles[`${baseClass}-image`]}
+            src={image.src}
+            alt={image.alt}
+          />
+        </div>
+      )}
+      {header && <div className={styles[`${baseClass}-header`]}>{header}</div>}
+      <div className={styles[`${baseClass}-text`]}>{text}</div>
+      <div className={styles[`${baseClass}-footer`]}>
+        <Button
+          kind={primaryButton.kind || getDefaultPrimaryButtonKind(theme)}
+          onClick={primaryButton.handleClick}
+        >
+          {primaryButton.label}
+        </Button>
+        <Button
+          className={cx(styles[`${baseClass}-footer-secondary`], {
+            [styles[`${baseClass}-footer-secondary-invert`]]:
+              theme === 'invert',
+          })}
+          kind={secondaryButton.kind || 'text'}
+          onClick={secondaryButton.handleClick}
+        >
+          {secondaryButton.label}
+        </Button>
       </div>
-    )}
-    {header && <div className={styles[`${baseClass}-header`]}>{header}</div>}
-    <div className={styles[`${baseClass}-text`]}>{text}</div>
-    <div className={styles[`${baseClass}-footer`]}>
-      <Button
-        kind={primaryButton.kind || 'primary'}
-        onClick={primaryButton.handleClick}
-      >
-        {primaryButton.label}
-      </Button>
-      <Button
-        kind={secondaryButton.kind || 'secondary'}
-        onClick={secondaryButton.handleClick}
-      >
-        {secondaryButton.label}
-      </Button>
     </div>
-  </div>
-);
+  );
+};

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -75,7 +75,12 @@ export const Interactive: React.FC<{
       )}
       {header && <div className={styles[`${baseClass}-header`]}>{header}</div>}
       <div className={styles[`${baseClass}-text`]}>{text}</div>
-      <div className={styles[`${baseClass}-footer`]}>
+      <div
+        className={cx(
+          styles[`${baseClass}-footer`],
+          styles[`${baseClass}-footer--interactive`]
+        )}
+      >
         <Button
           kind={primaryButton.kind || getDefaultPrimaryButtonKind(theme)}
           onClick={primaryButton.handleClick}

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { Close } from '@livechat/design-system-icons/react/material';
 import cx from 'clsx';
 
-import { Button, ButtonKind } from '../../Button';
+import { Button } from '../../Button';
 import { Icon } from '../../Icon';
 import { getIconType } from '../helpers';
 import styles from '../Tooltip.module.scss';
+import { TooltipButton, TooltipTheme } from '../types';
 
 const baseClass = 'tooltip';
 
@@ -18,18 +19,10 @@ export const Interactive: React.FC<{
     alt: string;
   };
   closeWithX?: boolean;
-  theme?: 'invert' | 'important';
+  theme?: TooltipTheme;
   handleCloseAction?: (ev: React.MouseEvent) => void;
-  primaryButton: {
-    handleClick: () => void;
-    label: string;
-    kind?: ButtonKind;
-  };
-  secondaryButton: {
-    handleClick: () => void;
-    label: string;
-    kind?: ButtonKind;
-  };
+  primaryButton: TooltipButton;
+  secondaryButton: TooltipButton;
 }> = ({
   header,
   text,
@@ -40,7 +33,7 @@ export const Interactive: React.FC<{
   primaryButton,
   secondaryButton,
 }) => {
-  const getDefaultPrimaryButtonKind = (theme?: 'invert' | 'important') => {
+  const getDefaultPrimaryButtonKind = (theme?: TooltipTheme) => {
     if (theme === 'invert') {
       return 'secondary';
     }

--- a/packages/react-components/src/components/Tooltip/components/UserGuide/UserGuideStep.tsx
+++ b/packages/react-components/src/components/Tooltip/components/UserGuide/UserGuideStep.tsx
@@ -80,7 +80,7 @@ export const UserGuideStep: React.FC<{
         <span className={styles[`${baseClass}-step`]}>
           Step {currentStep} of {stepMax}
         </span>
-        <Button kind="primary" onClick={handleClickPrimary}>
+        <Button kind="high-contrast" onClick={handleClickPrimary}>
           Primary button
         </Button>
       </div>

--- a/packages/react-components/src/components/Tooltip/components/UserGuide/UserGuideStep.tsx
+++ b/packages/react-components/src/components/Tooltip/components/UserGuide/UserGuideStep.tsx
@@ -7,6 +7,7 @@ import { Button } from '../../../Button';
 import { Icon } from '../../../Icon';
 import { getIconType } from '../../helpers';
 import styles from '../../Tooltip.module.scss';
+import { TooltipTheme } from '../../types';
 
 const baseClass = 'tooltip';
 
@@ -20,7 +21,7 @@ export const UserGuideStep: React.FC<{
   currentStep: number;
   stepMax: number;
   closeWithX?: boolean;
-  theme?: string;
+  theme?: TooltipTheme;
   handleClickPrimary: () => void;
   handleCloseAction?: (ev: KeyboardEvent | React.MouseEvent) => void;
 }> = ({

--- a/packages/react-components/src/components/Tooltip/helpers.ts
+++ b/packages/react-components/src/components/Tooltip/helpers.ts
@@ -1,6 +1,8 @@
 import { IconKind } from '../Icon';
 
-export function getIconType(theme: string): IconKind {
+import { TooltipTheme } from './types';
+
+export function getIconType(theme: TooltipTheme): IconKind {
   switch (theme) {
     case 'invert':
       return 'inverted';

--- a/packages/react-components/src/components/Tooltip/types.ts
+++ b/packages/react-components/src/components/Tooltip/types.ts
@@ -2,10 +2,20 @@ import * as React from 'react';
 
 import { Placement, VirtualElement } from '@floating-ui/react-dom';
 
+import { ButtonKind } from '../Button';
+
+export type TooltipTheme = 'invert' | 'important' | undefined;
+
+export type TooltipButton = {
+  handleClick: () => void;
+  label: string;
+  kind?: ButtonKind;
+};
+
 export interface ITooltipProps {
   children?: React.ReactNode;
   className?: string;
-  theme?: 'invert' | 'important' | undefined;
+  theme?: TooltipTheme;
   placement?: Placement;
   isVisible?: boolean;
   withFadeAnimation?: boolean;


### PR DESCRIPTION
Resolves: #728 

## Description
Change default button kinds for Interactive and User Guide.

## Storybook

https://feature-728--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-tooltip--tooltip-interactive

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
