### PR TITLE
Avatar background color handling based on initials

### DIFF
--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -6,14 +6,14 @@ import {
 
 describe('getBackgroundColor', () => {
   it('should generate the same background color for the same initials', () => {
-    const color1 = getBackgroundColor('John Doe');
-    const color2 = getBackgroundColor('John Doe');
+    const color1 = getBackgroundColor('JD');
+    const color2 = getBackgroundColor('JD');
     expect(color1).toBe(color2);
   });
 
   it('should generate different background colors for different initials', () => {
-    const color1 = getBackgroundColor('John Doe');
-    const color2 = getBackgroundColor('Jane Doe');
+    const color1 = getBackgroundColor('JD');
+    const color2 = getBackgroundColor('AB');
     expect(color1).not.toBe(color2);
   });
 

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -37,7 +37,11 @@ describe('getInitials', () => {
   });
 
   it('should limit the initials to the given count', () => {
-    expect(getInitials('John Robert Doe', 3)).toBe('JRD');
+    expect(getInitials('John Robert Doe Kavinsky', 3)).toBe('JRD');
+  });
+
+  it('should limit the initials based on default limit of 2', () => {
+    expect(getInitials('John Robert Doe Kavinsky')).toBe('JR');
   });
 
   it('should convert initials to upper case', () => {
@@ -45,9 +49,9 @@ describe('getInitials', () => {
   });
 });
 
-let originalGetComputedStyle: Window['getComputedStyle'];
-
 describe('getFontColor', () => {
+  let originalGetComputedStyle: Window['getComputedStyle'];
+
   beforeAll(() => {
     originalGetComputedStyle = window.getComputedStyle;
 

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -1,0 +1,94 @@
+import {
+  getFontColor,
+  getInitials,
+  getBackgroundColor,
+} from './Avatar.helpers';
+
+describe('getBackgroundColor', () => {
+  it('should generate the same background color for the same initials', () => {
+    const color1 = getBackgroundColor('John Doe');
+    const color2 = getBackgroundColor('John Doe');
+    expect(color1).toBe(color2);
+  });
+
+  it('should generate different background colors for different initials', () => {
+    const color1 = getBackgroundColor('John Doe');
+    const color2 = getBackgroundColor('Jane Doe');
+    expect(color1).not.toBe(color2);
+  });
+
+  it('should handle empty initials and return undefined', () => {
+    const color = getBackgroundColor('');
+    expect(color).toBeUndefined();
+  });
+});
+
+describe('getInitials', () => {
+  it('should return initials for a full name', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+  });
+
+  it('should return initials for a single name', () => {
+    expect(getInitials('John')).toBe('J');
+  });
+
+  it('should handle empty names', () => {
+    expect(getInitials('')).toBe('');
+  });
+
+  it('should limit the initials to the given count', () => {
+    expect(getInitials('John Robert Doe', 3)).toBe('JRD');
+  });
+
+  it('should convert initials to upper case', () => {
+    expect(getInitials('john doe')).toBe('JD');
+  });
+});
+
+let originalGetComputedStyle: Window['getComputedStyle'];
+
+describe('getFontColor', () => {
+  beforeAll(() => {
+    originalGetComputedStyle = window.getComputedStyle;
+
+    (window.getComputedStyle as any) = function () {
+      return {
+        getPropertyValue(variableName: string) {
+          if (variableName === '--some-color-variable') return '#000000';
+          if (variableName === '--another-color-variable') return '#FFFFFF';
+          return '';
+        },
+      };
+    };
+  });
+
+  afterAll(() => {
+    window.getComputedStyle = originalGetComputedStyle;
+  });
+
+  it('should return white for dark background', () => {
+    expect(getFontColor('#000000')).toEqual('var(--color-white)');
+  });
+
+  it('should return black for light background', () => {
+    expect(getFontColor('#FFFFFF')).toEqual('var(--color-black)');
+  });
+
+  it('should resolve CSS variables and return appropriate color', () => {
+    expect(getFontColor('var(--some-color-variable)')).toEqual(
+      'var(--color-white)'
+    );
+  });
+
+  it('should handle another CSS variables and return appropriate color', () => {
+    expect(getFontColor('var(--another-color-variable)')).toEqual(
+      'var(--color-black)'
+    );
+  });
+
+  it('should handle CSS variables that do not exist and throw error', () => {
+    expect(getFontColor('var(--nonexistent-variable)')).toEqual(
+      'var(--color-black)'
+    );
+  });
+});

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.ts
@@ -1,5 +1,22 @@
 import { getContrast } from 'polished';
 
+const colors = Array.from(
+  { length: 10 },
+  (_, i) => `--surface-avatar-${i + 1}`
+);
+
+export function getBackgroundColor(initials: string): string | undefined {
+  if (!initials) {
+    return;
+  }
+
+  const index = initials
+    .split('')
+    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+
+  return `var(${colors[index % colors.length]})`;
+}
+
 export function getInitials(name = '', count = 2): string {
   return name
     .split(' ')
@@ -10,7 +27,20 @@ export function getInitials(name = '', count = 2): string {
 }
 
 export function getFontColor(color: string): string {
-  return getContrast(color, '#FFFFFF') > 4.5
+  let actualColor = color;
+
+  if (color.startsWith('var(--') && color.endsWith(')')) {
+    const variableName = color.slice(4, -1);
+
+    const rootStyles = window.getComputedStyle(document.documentElement);
+    actualColor = rootStyles.getPropertyValue(variableName).trim();
+  }
+
+  if (!actualColor) {
+    return 'var(--color-black)';
+  }
+
+  return getContrast(actualColor, '#FFFFFF') > 3
     ? 'var(--color-white)'
     : 'var(--color-black)';
 }

--- a/packages/react-components/src/components/Avatar/Avatar.spec.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.spec.tsx
@@ -10,26 +10,7 @@ const renderComponent = (props: AvatarProps) => {
 
 const baseClass = 'avatar';
 
-let originalGetComputedStyle: Window['getComputedStyle'];
-
 describe('<Avatar> component', () => {
-  beforeAll(() => {
-    originalGetComputedStyle = window.getComputedStyle;
-
-    (window.getComputedStyle as any) = function () {
-      return {
-        getPropertyValue(variableName: string) {
-          if (variableName.startsWith('--surface-avatar')) return '#8609ff';
-          return '';
-        },
-      };
-    };
-  });
-
-  afterAll(() => {
-    window.getComputedStyle = originalGetComputedStyle;
-  });
-
   it('should allow for custom CSS class', () => {
     const customClass = 'custom-class';
     const { container } = renderComponent({

--- a/packages/react-components/src/components/Avatar/Avatar.spec.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.spec.tsx
@@ -10,7 +10,26 @@ const renderComponent = (props: AvatarProps) => {
 
 const baseClass = 'avatar';
 
+let originalGetComputedStyle: Window['getComputedStyle'];
+
 describe('<Avatar> component', () => {
+  beforeAll(() => {
+    originalGetComputedStyle = window.getComputedStyle;
+
+    (window.getComputedStyle as any) = function () {
+      return {
+        getPropertyValue(variableName: string) {
+          if (variableName.startsWith('--surface-avatar')) return '#8609ff';
+          return '';
+        },
+      };
+    };
+  });
+
+  afterAll(() => {
+    window.getComputedStyle = originalGetComputedStyle;
+  });
+
   it('should allow for custom CSS class', () => {
     const customClass = 'custom-class';
     const { container } = renderComponent({

--- a/packages/react-components/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.stories.tsx
@@ -97,10 +97,24 @@ export const Colors = (): React.ReactElement => (
     <StoryDescriptor title="Light">
       <Avatar type="text" text={defaultName} color="#faf8ff" />
       <Avatar type="text" text={defaultName} color="#eba3a3" />
+      <Avatar type="text" text={defaultName} color="var(--surface-avatar-3)" />
     </StoryDescriptor>
     <StoryDescriptor title="Dark">
       <Avatar type="text" text={defaultName} color="#424d57" />
       <Avatar type="text" text={defaultName} color="#6b5aba" />
+      <Avatar type="text" text={defaultName} color="var(--surface-avatar-1)" />
+    </StoryDescriptor>
+    <StoryDescriptor title="Default based on initials">
+      <Avatar type="text" text={'Albert'} />
+      <Avatar type="text" text={'Barbara'} />
+      <Avatar type="text" text={'Carl'} />
+      <Avatar type="text" text={'Diana'} />
+      <Avatar type="text" text={'Edward'} />
+      <Avatar type="text" text={'Francesca'} />
+      <Avatar type="text" text={'George'} />
+      <Avatar type="text" text={'Hannah'} />
+      <Avatar type="text" text={'Ivan'} />
+      <Avatar type="text" text={'Jessica'} />
     </StoryDescriptor>
   </>
 );

--- a/packages/react-components/src/components/Avatar/Avatar.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.tsx
@@ -5,7 +5,11 @@ import cx from 'clsx';
 
 import { Icon } from '../Icon';
 
-import { getFontColor, getInitials } from './Avatar.helpers';
+import {
+  getBackgroundColor,
+  getFontColor,
+  getInitials,
+} from './Avatar.helpers';
 
 import styles from './Avatar.module.scss';
 
@@ -89,7 +93,8 @@ export const Avatar: React.FC<AvatarProps> = ({
   const shouldDisplayInitials = type === 'text';
   const letterCount = ['xxxsmall', 'xxsmall', 'xsmall'].includes(size) ? 1 : 2;
   const initials = getInitials(text, letterCount);
-  const fontColor = color && getFontColor(color);
+  const backgroundColor = color || getBackgroundColor(initials);
+  const fontColor = backgroundColor && getFontColor(backgroundColor);
 
   const mergedClassNames = cx({
     [styles[baseClass]]: true,
@@ -121,7 +126,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   }, [isImproperImageSetup]);
 
   return (
-    <div className={mergedClassNames} style={{ backgroundColor: color }}>
+    <div className={mergedClassNames} style={{ backgroundColor }}>
       {withRim && (
         <div
           data-testid={`${baseClass}__rim`}


### PR DESCRIPTION
Resolves: [Slack thread](https://text.slack.com/archives/C05G7GS1HB9/p1691501762305939)

## Description
It was decided that background color of the `Avatar` should have a default value if it uses `text` `type`. It uses a basic algorithm that makes sure that a set of 10 colors are used, and for the exact same initials the color will be always the same.

❗️ `Attention:` This change brings some sort of breaking change as it will apply new color in for avatars using `text` `type` without `color` provided. By default it was `grey`.

I've also enabled the possibility of using `CSS variable` for `color` prop as earlier it was impossible due to contrast calculation requiring direct values. It was solved by using `window.getComputedStyle`

<img width="425" alt="image" src="https://github.com/livechat/design-system/assets/8076673/10f67044-0fce-441b-8929-299419309150">

## Storybook

https://feature-avatar-default-backgrounds--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-avatar--colors

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
