### PR TITLE
Fixing non-text content styling. Tooltip type exporting.

### DIFF
--- a/packages/react-components/src/components/Modal/Modal.tsx
+++ b/packages/react-components/src/components/Modal/Modal.tsx
@@ -42,6 +42,8 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const mergedClassNames = cx(styles[baseClass], className);
 
+  const isTextContent = typeof children === 'string';
+
   const onCloseButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -85,7 +87,7 @@ export const Modal: React.FC<ModalProps> = ({
           fullSpaceContent && styles[`${baseClass}__body--full-space`]
         )}
       >
-        <Text as="div">{children}</Text>
+        {isTextContent ? <Text as="div">{children}</Text> : children}
       </div>
       {footer && <div className={styles[`${baseClass}__footer`]}>{footer}</div>}
     </ModalBase>

--- a/packages/react-components/src/components/Modal/StoriesComponents.tsx
+++ b/packages/react-components/src/components/Modal/StoriesComponents.tsx
@@ -20,9 +20,11 @@ export const ModalFullSpaceContent: React.FC = () => {
           Modal header
         </Heading>
         <div className="full-space-text">
-          Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet
-          sint. Velit officia consequat duis enim velit mollit. Exercitation
-          veniam consequat sunt nostrud amet.
+          <Text size="md">
+            Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet
+            sint. Velit officia consequat duis enim velit mollit. Exercitation
+            veniam consequat sunt nostrud amet.
+          </Text>
         </div>
         <div className="full-space-buttons">
           <Button

--- a/packages/react-components/src/components/Modal/StoriesComponents.tsx
+++ b/packages/react-components/src/components/Modal/StoriesComponents.tsx
@@ -20,7 +20,7 @@ export const ModalFullSpaceContent: React.FC = () => {
           Modal header
         </Heading>
         <div className="full-space-text">
-          <Text size="md">
+          <Text size="md" as="div">
             Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet
             sint. Velit officia consequat duis enim velit mollit. Exercitation
             veniam consequat sunt nostrud amet.

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -5,6 +5,7 @@ import { ComponentMeta } from '@storybook/react';
 
 import { Button } from '../Button';
 import { Icon } from '../Icon';
+import { Text } from '../Typography';
 
 import { Popover as PopoverComponent, IPopoverProps } from './Popover';
 
@@ -77,7 +78,7 @@ export const Default = (args: IPopoverProps): React.ReactElement => (
             borderRadius: '4px',
           }}
         >
-          Popover content
+          <Text>Popover content</Text>
         </div>
       </div>
     </PopoverComponent>

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -57,6 +57,7 @@ export const Popover: React.FC<IPopoverProps> = ({
 }) => {
   const [visible, setVisibility] = React.useState(false);
   const prevVisibleState = React.useRef(false);
+  const isTextContent = typeof children === 'string';
 
   const {
     x,
@@ -147,7 +148,7 @@ export const Popover: React.FC<IPopoverProps> = ({
           left: x !== null && x !== undefined ? x : '',
         }}
       >
-        <Text as="div">{children}</Text>
+        {isTextContent ? <Text as="div">{children}</Text> : children}
       </div>
     </>
   );

--- a/packages/react-components/src/components/Toast/Toast.tsx
+++ b/packages/react-components/src/components/Toast/Toast.tsx
@@ -62,6 +62,7 @@ export const Toast: React.FC<React.PropsWithChildren<ToastProps>> = ({
     styles[`${baseClass}--${kind}`],
     className
   );
+  const isTextContent = typeof children === 'string';
 
   const onActionClick = (action: ToastAction) => {
     if (action && action.closesOnClick && onClose) {
@@ -79,7 +80,7 @@ export const Toast: React.FC<React.PropsWithChildren<ToastProps>> = ({
         <Icon {...iconConfig[kind]} size="medium" />
       </div>
       <div className={styles[`${baseClass}__content`]}>
-        <Text as="div">{children}</Text>
+        {isTextContent ? <Text as="div">{children}</Text> : children}
       </div>
       {(action || removable) && (
         <div className={styles[`${baseClass}__actions`]}>

--- a/packages/react-components/src/components/Toast/ToastWrapper.stories.tsx
+++ b/packages/react-components/src/components/Toast/ToastWrapper.stories.tsx
@@ -29,7 +29,7 @@ ToastWrapper.args = {
     {
       id: '1',
       kind: 'success',
-      content: <div>First toast with DOM element as content</div>,
+      content: 'First toast with DOM element as content',
     },
     {
       id: '2',

--- a/packages/react-components/src/components/Tooltip/index.ts
+++ b/packages/react-components/src/components/Tooltip/index.ts
@@ -1,3 +1,4 @@
 export { Tooltip } from './Tooltip';
 export { Simple, Info, Interactive, Reports } from './components';
 export { UserGuide } from './components/UserGuide';
+export type { ITooltipProps } from './types';


### PR DESCRIPTION
## Description
Fixes for non-text content of Modal, Toast, Popover components
Fix for Tooltip type export

## Storybook

https://feature-fixes-for-components-content--613a8e945a5665003a05113b.chromatic.com/{link-related-to-the-story}

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
