### PR TITLE
Modify `getInitials` so it ignores middle names

### DIFF
--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -40,6 +40,10 @@ describe('getInitials', () => {
     expect(getInitials('John Doe Robert Stan Kavinsky', 3)).toBe('JSK');
   });
 
+  it('should handle change to upper-case', () => {
+    expect(getInitials('john doe')).toBe('JD');
+  });
+
   it('should handle empty input', () => {
     expect(getInitials('')).toBe('');
   });

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -24,28 +24,32 @@ describe('getBackgroundColor', () => {
 });
 
 describe('getInitials', () => {
-  it('should return initials for a full name', () => {
-    expect(getInitials('John Doe')).toBe('JD');
-  });
-
-  it('should return initials for a single name', () => {
+  it('should return the first letter of a single word name', () => {
     expect(getInitials('John')).toBe('J');
   });
 
-  it('should handle empty names', () => {
+  it('should return the first and last initials for a two word name', () => {
+    expect(getInitials('John Doe')).toBe('JD');
+  });
+
+  it('should return the first and last initials for a multi-word name', () => {
+    expect(getInitials('John Michael Doe')).toBe('JD');
+  });
+
+  it('should return the first, second last, and last initials for a multi-word name, ignoring the middle names', () => {
+    expect(getInitials('John Doe Robert Stan Kavinsky', 3)).toBe('JSK');
+  });
+
+  it('should handle empty input', () => {
     expect(getInitials('')).toBe('');
   });
 
-  it('should limit the initials to the given count', () => {
-    expect(getInitials('John Robert Doe Kavinsky', 3)).toBe('JRD');
+  it('should handle undefined input', () => {
+    expect(getInitials(undefined)).toBe('');
   });
 
-  it('should limit the initials based on default limit of 2', () => {
-    expect(getInitials('John Robert Doe Kavinsky')).toBe('JR');
-  });
-
-  it('should convert initials to upper case', () => {
-    expect(getInitials('john doe')).toBe('JD');
+  it('should handle count less than 1', () => {
+    expect(getInitials('John Doe', 0)).toBe('');
   });
 });
 

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -36,6 +36,10 @@ describe('getInitials', () => {
     expect(getInitials('John Michael Doe')).toBe('JD');
   });
 
+  it('should handle multiple spaces', () => {
+    expect(getInitials('John   Michael   Doe')).toBe('JD');
+  });
+
   it('should return the first, second last, and last initials for a multi-word name, ignoring the middle names', () => {
     expect(getInitials('John Doe Robert Stan Kavinsky', 3)).toBe('JSK');
   });

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.ts
@@ -18,12 +18,27 @@ export function getBackgroundColor(initials: string): string | undefined {
 }
 
 export function getInitials(name = '', count = 2): string {
-  return name
-    .split(' ')
-    .map((el) => el.charAt(0))
-    .join('')
-    .substring(0, count)
-    .toUpperCase();
+  const nameArray = name.split(' ');
+
+  if (count < 1) return '';
+
+  // If the name has fewer words than count, return initials for all the words
+  if (nameArray.length <= count) {
+    return nameArray
+      .map((el) => el.charAt(0))
+      .join('')
+      .toUpperCase();
+  }
+
+  // Take the first initial from the first name
+  const initials = [nameArray[0].charAt(0)];
+
+  // Take the remaining initials from the last (count - 1) names
+  for (let i = nameArray.length - count + 1; i < nameArray.length; i++) {
+    initials.push(nameArray[i].charAt(0));
+  }
+
+  return initials.join('').toUpperCase();
 }
 
 export function getFontColor(color: string): string {

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.ts
@@ -18,7 +18,7 @@ export function getBackgroundColor(initials: string): string | undefined {
 }
 
 export function getInitials(name = '', count = 2): string {
-  const nameArray = name.split(' ');
+  const nameArray = name.split(/\s+/);
 
   if (count < 1) return '';
 


### PR DESCRIPTION
Resolves: [Slack thread](https://text.slack.com/archives/C05G7GS1HB9/p1693574106413869?thread_ts=1691501762.305939&cid=C05G7GS1HB9)

## Description
Modify `getInitials` so it ignores middle names according to global text.com requirements.

## Storybook

https://613a8e945a5665003a05113b-laebkcbtql.chromatic.com/?path=/docs/components-avatar--docs

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
