### PR TITLE
Replacing leftIcon, rightIcon, avatar props with leftNode and rightNode

### DIFF
--- a/packages/react-components/src/components/Tag/Tag.mdx
+++ b/packages/react-components/src/components/Tag/Tag.mdx
@@ -15,7 +15,9 @@ import * as Stories from './Tag.stories';
 #### Example implementation
 
 ```jsx
-<Tag>Example tag</Tag>
+<Tag leftNode={<Icon source={TablerIcons.Apple} size="small" />}>
+  Example tag
+</Tag>
 ```
 
 ## Component API <a id="ComponentAPI" />

--- a/packages/react-components/src/components/Tag/Tag.module.scss
+++ b/packages/react-components/src/components/Tag/Tag.module.scss
@@ -162,8 +162,8 @@
   }
 
   &__content {
-    text-wrap: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }

--- a/packages/react-components/src/components/Tag/Tag.module.scss
+++ b/packages/react-components/src/components/Tag/Tag.module.scss
@@ -93,6 +93,7 @@
   }
 
   &--outline {
+    border-width: 1px;
     border-style: solid;
     background-color: transparent;
 

--- a/packages/react-components/src/components/Tag/Tag.module.scss
+++ b/packages/react-components/src/components/Tag/Tag.module.scss
@@ -117,6 +117,16 @@
     color: var(--color-black);
   }
 
+  &--with-node {
+    &.tag--medium {
+      padding-left: var(--spacing-1);
+    }
+
+    &.tag--large {
+      padding-left: var(--spacing-2);
+    }
+  }
+
   &--dismissible {
     &.tag--medium {
       padding-right: var(--spacing-1);

--- a/packages/react-components/src/components/Tag/Tag.module.scss
+++ b/packages/react-components/src/components/Tag/Tag.module.scss
@@ -162,7 +162,7 @@
   }
 
   &__content {
-    text-wrap: none;
+    text-wrap: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/packages/react-components/src/components/Tag/Tag.module.scss
+++ b/packages/react-components/src/components/Tag/Tag.module.scss
@@ -117,16 +117,6 @@
     color: var(--color-black);
   }
 
-  &--with-icon {
-    &.tag--medium {
-      padding-left: var(--spacing-1);
-    }
-
-    &.tag--large {
-      padding-left: var(--spacing-2);
-    }
-  }
-
   &--dismissible {
     &.tag--medium {
       padding-right: var(--spacing-1);
@@ -137,20 +127,15 @@
     }
   }
 
-  &__icon {
+  &__node {
+    display: flex;
+    align-items: center;
     margin-right: var(--spacing-1);
 
     &--right {
       margin-right: 0;
       margin-left: var(--spacing-1);
     }
-  }
-
-  &__avatar {
-    margin-right: var(--spacing-1);
-    border-radius: 50%;
-    width: 20px;
-    height: 20px;
   }
 
   &__remove {
@@ -167,7 +152,7 @@
   }
 
   &__content {
-    text-wrap: nowrap;
+    text-wrap: none;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/packages/react-components/src/components/Tag/Tag.spec.tsx
+++ b/packages/react-components/src/components/Tag/Tag.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import * as MaterialIcons from '@livechat/design-system-icons/react/material';
 import * as TablerIcons from '@livechat/design-system-icons/react/tabler';
 
 import { render, userEvent, vi } from 'test-utils';

--- a/packages/react-components/src/components/Tag/Tag.spec.tsx
+++ b/packages/react-components/src/components/Tag/Tag.spec.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
 import * as MaterialIcons from '@livechat/design-system-icons/react/material';
+import * as TablerIcons from '@livechat/design-system-icons/react/tabler';
 
 import { render, userEvent, vi } from 'test-utils';
 
 import noop from '../../utils/noop';
+import { Icon } from '../Icon';
 
 import { Tag } from './Tag';
 
@@ -74,18 +76,23 @@ describe('<Tag> component', () => {
     expect(container.firstChild).toHaveStyle(`border-color: #ff0000`);
   });
 
-  it('should show avatar when both avatar and icon are provided', () => {
-    const { getByTestId, queryByTestId } = render(
-      <Tag
-        {...props}
-        avatar="http://test.img"
-        leftIcon={MaterialIcons.AddCircle}
-      >
+  it('should show left and right nodes when provided', () => {
+    const icon = <Icon source={TablerIcons.Apple} size="small" />;
+    const { getByTestId, queryByTestId, rerender } = render(
+      <Tag {...props}>tag1</Tag>
+    );
+
+    expect(queryByTestId('lc-tag-right-node')).not.toBeInTheDocument();
+    expect(queryByTestId('lc-tag-left-node')).not.toBeInTheDocument();
+
+    rerender(
+      <Tag {...props} leftNode={icon} rightNode={icon}>
         tag1
       </Tag>
     );
-    expect(getByTestId('lc-tag-avatar')).toBeDefined();
-    expect(queryByTestId('lc-tag-icon')).not.toBeInTheDocument();
+
+    expect(getByTestId('lc-tag-right-node')).toBeDefined();
+    expect(getByTestId('lc-tag-left-node')).toBeDefined();
   });
 
   it('should call remove method on remove button press', () => {

--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -4,35 +4,36 @@ import * as TablerIcons from '@livechat/design-system-icons/react/tabler';
 import { ComponentMeta } from '@storybook/react';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
+import { Icon } from '../Icon';
 
 import { Tag, TagProps } from './Tag';
 
-const iterator = Object.keys(TablerIcons);
-
-const iconOptions = {
-  options: iterator,
-  mapping: TablerIcons,
-  control: {
-    type: 'select',
-    labels: iterator,
-  },
-};
+const exampleIcon = <Icon source={TablerIcons.Smiles} size="small" />;
+const exampleAvatar = (
+  <img
+    style={{ borderRadius: '50%', width: '20px', height: '20px' }}
+    src={
+      'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=200'
+    }
+    alt="tag-avatar"
+    data-testid="lc-tag-avatar"
+  />
+);
 
 export default {
   title: 'Components/Tag',
   component: Tag,
-  argTypes: {
-    icon: iconOptions,
-    leftIcon: iconOptions,
-    rightIcon: iconOptions,
-  },
 } as ComponentMeta<typeof Tag>;
 
 export const Default = ({
   children,
   ...args
 }: TagProps): React.ReactElement => {
-  return <Tag {...args}>{children}</Tag>;
+  return (
+    <Tag {...args} leftNode={args.leftNode} rightNode={args.rightNode}>
+      {children}
+    </Tag>
+  );
 };
 
 Default.args = {
@@ -40,23 +41,20 @@ Default.args = {
   outline: false,
   size: 'medium',
   children: 'Example tag',
-  dismissible: false,
+  dismissible: true,
+  leftNode: <Icon source={TablerIcons.Apple} size="small" />,
+  rightNode: <Icon source={TablerIcons.Android} size="small" />,
 } as TagProps;
-
-const avatar =
-  'https://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=200';
 
 export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
   return (
     <div>
       <StoryDescriptor title="Default">
         <Tag kind="default">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="default">
+        <Tag leftNode={args.leftNode} kind="default">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="default">
-          {children}
-        </Tag>
+        <Tag kind="default">{children}</Tag>
         <Tag kind="default" dismissible>
           {children}
         </Tag>
@@ -65,10 +63,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="default" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="default" outline>
+        <Tag leftNode={args.leftNode} kind="default" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="default" outline>
+        <Tag leftNode={exampleAvatar} kind="default" outline>
           {children}
         </Tag>
         <Tag kind="default" outline dismissible>
@@ -77,10 +75,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Info">
         <Tag kind="info">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="info">
+        <Tag leftNode={args.leftNode} kind="info">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="info">
+        <Tag leftNode={exampleAvatar} kind="info">
           {children}
         </Tag>
         <Tag kind="info" dismissible>
@@ -91,10 +89,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="info" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="info" outline>
+        <Tag leftNode={args.leftNode} kind="info" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="info" outline>
+        <Tag leftNode={exampleAvatar} kind="info" outline>
           {children}
         </Tag>
         <Tag kind="info" outline dismissible>
@@ -103,10 +101,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Warning">
         <Tag kind="warning">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="warning">
+        <Tag leftNode={args.leftNode} kind="warning">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="warning">
+        <Tag leftNode={exampleAvatar} kind="warning">
           {children}
         </Tag>
         <Tag kind="warning" dismissible>
@@ -117,10 +115,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="warning" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="warning" outline>
+        <Tag leftNode={args.leftNode} kind="warning" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="warning" outline>
+        <Tag leftNode={exampleAvatar} kind="warning" outline>
           {children}
         </Tag>
         <Tag kind="warning" outline dismissible>
@@ -129,10 +127,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Success">
         <Tag kind="success">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="success">
+        <Tag leftNode={args.leftNode} kind="success">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="success">
+        <Tag leftNode={exampleAvatar} kind="success">
           {children}
         </Tag>
         <Tag kind="success" dismissible>
@@ -143,10 +141,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="success" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="success" outline>
+        <Tag leftNode={args.leftNode} kind="success" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="success" outline>
+        <Tag leftNode={exampleAvatar} kind="success" outline>
           {children}
         </Tag>
         <Tag kind="success" outline dismissible>
@@ -155,10 +153,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Error">
         <Tag kind="error">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="error">
+        <Tag leftNode={args.leftNode} kind="error">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="error">
+        <Tag leftNode={exampleAvatar} kind="error">
           {children}
         </Tag>
         <Tag kind="error" dismissible>
@@ -169,10 +167,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="error" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="error" outline>
+        <Tag leftNode={args.leftNode} kind="error" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="error" outline>
+        <Tag leftNode={exampleAvatar} kind="error" outline>
           {children}
         </Tag>
         <Tag kind="error" outline dismissible>
@@ -181,10 +179,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Purple">
         <Tag kind="purple">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="purple">
+        <Tag leftNode={args.leftNode} kind="purple">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="purple">
+        <Tag leftNode={exampleAvatar} kind="purple">
           {children}
         </Tag>
         <Tag kind="purple" dismissible>
@@ -195,10 +193,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="purple" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="purple" outline>
+        <Tag leftNode={args.leftNode} kind="purple" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="purple" outline>
+        <Tag leftNode={exampleAvatar} kind="purple" outline>
           {children}
         </Tag>
         <Tag kind="purple" outline dismissible>
@@ -207,10 +205,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Black">
         <Tag kind="black">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} kind="black">
+        <Tag leftNode={args.leftNode} kind="black">
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="black">
+        <Tag leftNode={exampleAvatar} kind="black">
           {children}
         </Tag>
         <Tag kind="black" dismissible>
@@ -221,10 +219,10 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
         <Tag kind="black" outline>
           {children}
         </Tag>
-        <Tag leftIcon={args.leftIcon} kind="black" outline>
+        <Tag leftNode={args.leftNode} kind="black" outline>
           {children}
         </Tag>
-        <Tag avatar={avatar} kind="black" outline>
+        <Tag leftNode={exampleAvatar} kind="black" outline>
           {children}
         </Tag>
         <Tag kind="black" outline dismissible>
@@ -236,7 +234,8 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
 };
 Kinds.args = {
   children: 'Example tag',
-  leftIcon: TablerIcons.Smiles,
+  leftNode: exampleIcon,
+  rightNode: exampleIcon,
 };
 
 export const Sizes = ({ children, ...args }: TagProps): React.ReactElement => {
@@ -244,21 +243,21 @@ export const Sizes = ({ children, ...args }: TagProps): React.ReactElement => {
     <div>
       <StoryDescriptor title="Small">
         <Tag size="small">{children}</Tag>
-        <Tag leftIcon={args.leftIcon} size="small" dismissible>
+        <Tag leftNode={args.leftNode} size="small" dismissible>
           {children}
         </Tag>
       </StoryDescriptor>
       <StoryDescriptor title="Medium">
         <Tag>{children}</Tag>
-        <Tag leftIcon={args.leftIcon} rightIcon={args.rightIcon} dismissible>
+        <Tag leftNode={args.leftNode} rightNode={args.rightNode} dismissible>
           {children}
         </Tag>
       </StoryDescriptor>
       <StoryDescriptor title="Large">
         <Tag size="large">{children}</Tag>
         <Tag
-          leftIcon={args.leftIcon}
-          rightIcon={args.rightIcon}
+          leftNode={args.leftNode}
+          rightNode={args.rightNode}
           size="large"
           dismissible
         >
@@ -270,6 +269,6 @@ export const Sizes = ({ children, ...args }: TagProps): React.ReactElement => {
 };
 Sizes.args = {
   children: 'Example tag',
-  leftIcon: TablerIcons.Smiles,
-  rightIcon: TablerIcons.Smiles,
+  leftNode: exampleIcon,
+  rightNode: exampleIcon,
 };

--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -55,9 +55,11 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
           {children}
         </Tag>
         <Tag kind="default">{children}</Tag>
-        <Tag kind="default" dismissible>
-          {children}
-        </Tag>
+        <div style={{ maxWidth: '150px', display: 'flex' }}>
+          <Tag kind="default" dismissible>
+            Example tag with long name
+          </Tag>
+        </div>
       </StoryDescriptor>
       <StoryDescriptor title="Default with outline">
         <Tag kind="default" outline>

--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -55,11 +55,9 @@ export const Kinds = ({ children, ...args }: TagProps): React.ReactElement => {
           {children}
         </Tag>
         <Tag kind="default">{children}</Tag>
-        <div style={{ maxWidth: '150px', display: 'flex' }}>
-          <Tag kind="default" dismissible>
-            Example tag with long name
-          </Tag>
-        </div>
+        <Tag kind="default" dismissible style={{ maxWidth: '150px' }}>
+          Example tag with long name
+        </Tag>
       </StoryDescriptor>
       <StoryDescriptor title="Default with outline">
         <Tag kind="default" outline>

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -89,7 +89,7 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
     {
       [styles[`${baseClass}--dismissible`]]: dismissible,
       [styles[`${baseClass}--outline`]]: outline,
-      [styles[`${baseClass}--with-icon`]]: !!leftNode || !!rightNode,
+      [styles[`${baseClass}--with-node`]]: !!leftNode || !!rightNode,
       [styles[`${baseClass}--${getCustomTextClass(customColor)}`]]:
         !!customColor,
     }

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -89,6 +89,7 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
     {
       [styles[`${baseClass}--dismissible`]]: dismissible,
       [styles[`${baseClass}--outline`]]: outline,
+      [styles[`${baseClass}--with-icon`]]: !!leftNode || !!rightNode,
       [styles[`${baseClass}--${getCustomTextClass(customColor)}`]]:
         !!customColor,
     }

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -4,7 +4,7 @@ import { Close } from '@livechat/design-system-icons/react/tabler';
 import cx from 'clsx';
 import { getContrast } from 'polished';
 
-import { Icon, IconSize, IconSource } from '../Icon';
+import { Icon, IconSize } from '../Icon';
 import { Text } from '../Typography';
 
 import styles from './Tag.module.scss';
@@ -48,18 +48,13 @@ export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   onRemove?(): void;
   /**
-   * Pass the icon to show it on the left
+   * React node element to show on the left
    */
-  leftIcon?: IconSource;
+  leftNode?: React.ReactElement;
   /**
-   * Pass the icon to show it on the right
+   * React node element to show on the right
    */
-  rightIcon?: IconSource;
-  /**
-  /**
-   * Pass the image source to show it as avatar
-   */
-  avatar?: string;
+  rightNode?: React.ReactElement;
 }
 
 const getCustomTextClass = (customColor?: string) => {
@@ -81,9 +76,8 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
   kind = 'default',
   onRemove,
   outline = false,
-  leftIcon,
-  rightIcon,
-  avatar,
+  leftNode,
+  rightNode,
   customColor,
   ...restProps
 }) => {
@@ -95,7 +89,6 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
     {
       [styles[`${baseClass}--dismissible`]]: dismissible,
       [styles[`${baseClass}--outline`]]: outline,
-      [styles[`${baseClass}--with-icon`]]: !!leftIcon || !!avatar,
       [styles[`${baseClass}--${getCustomTextClass(customColor)}`]]:
         !!customColor,
     }
@@ -137,36 +130,24 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
       as="div"
       size="md"
     >
-      {avatar && (
-        <img
-          className={styles[`${baseClass}__avatar`]}
-          src={avatar}
-          alt="tag-avatar"
-          data-testid="lc-tag-avatar"
-        />
-      )}{' '}
-      {/*TODO replace with Avatar component*/}
-      {leftIcon && !avatar && (
-        <Icon
-          data-testid="lc-tag-left-icon"
-          className={styles[`${baseClass}__icon`]}
-          source={leftIcon}
-          size="small"
-          customColor={getIconCustomColor()}
-        />
+      {leftNode && (
+        <div
+          data-testid="lc-tag-left-node"
+          className={styles[`${baseClass}__node`]}
+          style={{ color: getIconCustomColor() }}
+        >
+          {leftNode}
+        </div>
       )}
       <div className={styles[`${baseClass}__content`]}>{children}</div>
-      {rightIcon && (
-        <Icon
-          data-testid="lc-tag-right-icon"
-          className={cx(
-            styles[`${baseClass}__icon`],
-            styles[`${baseClass}__icon--right`]
-          )}
-          source={rightIcon}
-          size="small"
-          customColor={getIconCustomColor()}
-        />
+      {rightNode && (
+        <div
+          data-testid="lc-tag-right-node"
+          className={cx(styles[`${baseClass}__node--right`])}
+          style={{ color: getIconCustomColor() }}
+        >
+          {rightNode}
+        </div>
       )}
       {dismissible && (
         <button


### PR DESCRIPTION
## Description
Replacing leftIcon, rightIcon, avatar props with leftNode and rightNode

## Storybook

https://feature-tag-additional-nodes--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
