### PR TITLE
#781 - [ActionMenu] - Fix for selecting items by keyboard logic

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -61,17 +61,20 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   const [isVisible, setIsVisible] = React.useState(openedOnInit);
   const indexRef = React.useRef(-1);
 
-  const getIndex = (val: number) => {
-    indexRef.current = indexRef.current + val;
+  const getIndex = (val: number): number => {
+    const currentValue = indexRef.current;
+    let newValue = indexRef.current + val;
 
-    while (
-      options[indexRef.current].disabled ||
-      options[indexRef.current].groupHeader
-    ) {
-      indexRef.current = indexRef.current + val;
+    while (options[newValue]?.disabled || options[newValue]?.groupHeader) {
+      newValue = newValue + val;
+
+      if (newValue === -1) {
+        newValue = currentValue;
+        break;
+      }
     }
 
-    return indexRef.current;
+    return newValue;
   };
 
   const onKeyDown = (e: KeyboardEvent) => {

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -63,10 +63,10 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
 
   const getIndex = (val: number): number => {
     const currentValue = indexRef.current;
-    let newValue = indexRef.current + val;
+    let newValue = currentValue + val;
 
     while (options[newValue]?.disabled || options[newValue]?.groupHeader) {
-      newValue = newValue + val;
+      newValue += val;
 
       if (newValue === -1) {
         newValue = currentValue;


### PR DESCRIPTION
Resolves: #781 

## Description
When the first element on the list was a header element, or disabled element, when using the arrow up to select an element the logic crushes the app, trying to check an element with a negative index number.
This fix will return the last correct index number, if previous elements from the list are blocked (disabled, header)

## Storybook

https://feature-781--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-actionmenu--keep-open-on-item-click

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
