### PR TITLE
#787 [Picker] - ui fix for small container

### DIFF
--- a/packages/react-components/src/components/Picker/TriggerBody.module.scss
+++ b/packages/react-components/src/components/Picker/TriggerBody.module.scss
@@ -7,6 +7,10 @@ $base-class: 'picker-trigger-body';
   justify-content: flex-start;
   max-width: 100%;
 
+  &--single {
+    flex-wrap: nowrap;
+  }
+
   &__item-container {
     display: flex;
     flex-wrap: wrap;

--- a/packages/react-components/src/components/Picker/TriggerBody.tsx
+++ b/packages/react-components/src/components/Picker/TriggerBody.tsx
@@ -109,7 +109,11 @@ export const TriggerBody: React.FC<ITriggerBodyProps> = ({
   }
 
   return (
-    <div className={styles[baseClass]}>
+    <div
+      className={cx(styles[baseClass], {
+        [styles[`${baseClass}--single`]]: type === 'single',
+      })}
+    >
       <div className={styles[`${baseClass}__item-container`]}>
         {type === 'single'
           ? getSingleItem(items[0])


### PR DESCRIPTION
Resolves: #787 

## Description
Style fixes to prevent layout break for small container.

## Storybook

https://feature-787--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-picker--default

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
