### PR TITLE
#789 #790 [Avatar] Return color based on text, not initials. Apply background color only in case of image type

### DIFF
--- a/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.spec.ts
@@ -5,15 +5,15 @@ import {
 } from './Avatar.helpers';
 
 describe('getBackgroundColor', () => {
-  it('should generate the same background color for the same initials', () => {
-    const color1 = getBackgroundColor('JD');
-    const color2 = getBackgroundColor('JD');
+  it('should generate the same background color for the same text', () => {
+    const color1 = getBackgroundColor('John Doe');
+    const color2 = getBackgroundColor('John Doe');
     expect(color1).toBe(color2);
   });
 
-  it('should generate different background colors for different initials', () => {
-    const color1 = getBackgroundColor('JD');
-    const color2 = getBackgroundColor('AB');
+  it('should generate different background colors for different text', () => {
+    const color1 = getBackgroundColor('John Doe');
+    const color2 = getBackgroundColor('Agatha Berg');
     expect(color1).not.toBe(color2);
   });
 

--- a/packages/react-components/src/components/Avatar/Avatar.helpers.ts
+++ b/packages/react-components/src/components/Avatar/Avatar.helpers.ts
@@ -5,12 +5,12 @@ const colors = Array.from(
   (_, i) => `--surface-avatar-${i + 1}`
 );
 
-export function getBackgroundColor(initials: string): string | undefined {
-  if (!initials) {
+export function getBackgroundColor(text?: string): string | undefined {
+  if (!text) {
     return;
   }
 
-  const index = initials
+  const index = text
     .split('')
     .reduce((acc, char) => acc + char.charCodeAt(0), 0);
 

--- a/packages/react-components/src/components/Avatar/Avatar.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.tsx
@@ -91,10 +91,13 @@ export const Avatar: React.FC<AvatarProps> = ({
   const shouldDisplayImage =
     type === 'image' && !!src && !shouldDisplayFallbackAvatar;
   const shouldDisplayInitials = type === 'text';
+
   const letterCount = ['xxxsmall', 'xxsmall', 'xsmall'].includes(size) ? 1 : 2;
   const initials = getInitials(text, letterCount);
-  const backgroundColor = color || getBackgroundColor(initials);
-  const fontColor = backgroundColor && getFontColor(backgroundColor);
+
+  const backgroundColor = color || getBackgroundColor(text);
+  const fontColor = backgroundColor ? getFontColor(backgroundColor) : undefined;
+  const backgroundStyle = shouldDisplayInitials ? { backgroundColor } : {};
 
   const mergedClassNames = cx({
     [styles[baseClass]]: true,
@@ -126,7 +129,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   }, [isImproperImageSetup]);
 
   return (
-    <div className={mergedClassNames} style={{ backgroundColor }}>
+    <div className={mergedClassNames} style={backgroundStyle}>
       {withRim && (
         <div
           data-testid={`${baseClass}__rim`}


### PR DESCRIPTION
Resolves: #789
Resolves: #790

## Description
It generally fixes minor issues with `Avatar` background:
- color applied based on text, not initials in order to prevent confusion of showing the same avatar in different sizes
- color applied only when of type `image` in order to prevent small-ish rim displayed

## Storybook

https://feature-789-and-790-avatar--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-avatar--sizes
## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
