### PR TITLE
[Avatar] - Fix for moving avatar when rim is visible

### DIFF
--- a/packages/react-components/src/components/Avatar/Avatar.module.scss
+++ b/packages/react-components/src/components/Avatar/Avatar.module.scss
@@ -205,21 +205,6 @@ $base-class: 'avatar';
     border-radius: 4px;
   }
 
-  &--with-rim.#{$base-class}--xxxsmall,
-  &--with-rim.#{$base-class}--xxsmall,
-  &--with-rim.#{$base-class}--xsmall {
-    margin: 3px;
-  }
-
-  &--with-rim.#{$base-class}--small,
-  &--with-rim.#{$base-class}--medium,
-  &--with-rim.#{$base-class}--large,
-  &--with-rim.#{$base-class}--xlarge,
-  &--with-rim.#{$base-class}--xxlarge,
-  &--with-rim.#{$base-class}--xxxlarge {
-    margin: 5px;
-  }
-
   &--xxxsmall {
     width: 16px;
     height: 16px;


### PR DESCRIPTION
## Description
Removed margin when rim is visible.

## Storybook

https://feature/avatar-with-rim-fix--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-avatar--sizes-with-rim

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
