### PR TITLE
#771 - Tag - Close icon size change for small component

### DIFF
--- a/packages/react-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/react-components/src/components/Tag/Tag.stories.tsx
@@ -249,15 +249,19 @@ export const Sizes = ({ children, ...args }: TagProps): React.ReactElement => {
       </StoryDescriptor>
       <StoryDescriptor title="Medium">
         <Tag>{children}</Tag>
-        <Tag leftNode={args.leftNode} rightNode={args.rightNode} dismissible>
+        <Tag
+          leftNode={<Icon source={TablerIcons.Smiles} />}
+          rightNode={<Icon source={TablerIcons.Smiles} />}
+          dismissible
+        >
           {children}
         </Tag>
       </StoryDescriptor>
       <StoryDescriptor title="Large">
         <Tag size="large">{children}</Tag>
         <Tag
-          leftNode={args.leftNode}
-          rightNode={args.rightNode}
+          leftNode={<Icon source={TablerIcons.Smiles} />}
+          rightNode={<Icon source={TablerIcons.Smiles} />}
           size="large"
           dismissible
         >

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -28,10 +28,6 @@ export interface TagProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   size?: 'small' | 'medium' | 'large';
   /**
-   * Specify the tag icon size if used
-   */
-  iconSize?: IconSize;
-  /**
    * Set the tag custom color
    */
   customColor?: string;
@@ -72,7 +68,6 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
   children,
   dismissible = false,
   size = 'medium',
-  iconSize = 'medium',
   kind = 'default',
   onRemove,
   outline = false,
@@ -94,6 +89,7 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
         !!customColor,
     }
   );
+  const closeIconSize = size === 'small' ? 'small' : 'medium';
 
   const getCustomColorStyles = () => {
     if (!customColor) {
@@ -160,7 +156,7 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
           <Icon
             data-dismiss-icon
             source={Close}
-            size={iconSize}
+            size={closeIconSize}
             customColor={getIconCustomColor()}
           />
         </button>

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -4,7 +4,7 @@ import { Close } from '@livechat/design-system-icons/react/tabler';
 import cx from 'clsx';
 import { getContrast } from 'polished';
 
-import { Icon, IconSize } from '../Icon';
+import { Icon } from '../Icon';
 import { Text } from '../Typography';
 
 import styles from './Tag.module.scss';


### PR DESCRIPTION
Resolves: #771 

## Description
Change close icon size for `small` version of component.
This does not apply to icons because their size is controlled on the consumer side.

## Storybook

https://feature-771--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-tag--sizes

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
