### PR TITLE
[Avatar] Make dynamic background color generator publicly available

### DIFF
--- a/packages/react-components/src/components/Avatar/index.ts
+++ b/packages/react-components/src/components/Avatar/index.ts
@@ -1,2 +1,3 @@
 export { Avatar } from './Avatar';
+export { getBackgroundColor as generateAvatarColor } from './Avatar.helpers';
 export type { AvatarProps } from './Avatar';


### PR DESCRIPTION
Resolves: #804 

## Description

[getBackgroundColor](https://github.com/livechat/design-system/blob/b0087448fc525d2d86d441f2e745cc780dece094/packages/react-components/src/components/Avatar/Avatar.helpers.ts#L8) function should be publicly available, to be used for background colour calculation if needed. We need it for the customer background colour calculation in the Agent app.

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [ ] Add correct label
- [x] Assign pull request with the correct issue
