### PR TITLE
Switch - fix for controlled component mode

### DIFF
--- a/packages/react-components/src/components/Switch/Switch.spec.tsx
+++ b/packages/react-components/src/components/Switch/Switch.spec.tsx
@@ -7,14 +7,22 @@ import loaderStyles from '../Loader/Loader.module.scss';
 import { Switch } from './Switch';
 
 describe('Switch', () => {
-  it('should call onChange without changing state when custom handler is passed', () => {
+  it('should not change internal state when controlled (on) prop is passed', () => {
+    const { getByRole } = render(<Switch on={true} />);
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toEqual(true);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toEqual(true);
+  });
+
+  it('should call onChange and change internal state when no controlled (on) prop is passed', () => {
     const toggleFn = vi.fn();
     const { getByRole } = render(<Switch onChange={toggleFn} />);
     const checkbox = getByRole('checkbox') as HTMLInputElement;
     expect(checkbox.checked).toEqual(false);
     fireEvent.click(checkbox);
     expect(toggleFn).toHaveBeenCalled();
-    expect(checkbox.checked).toEqual(false);
+    expect(checkbox.checked).toEqual(true);
   });
 
   it('should change state to checked (on) when user clicks on unchecked (off) switch', () => {
@@ -25,12 +33,12 @@ describe('Switch', () => {
     expect(checkbox.checked).toEqual(true);
   });
 
-  it('should change state to unchecked (off) when user clicks on checked (on) switch', () => {
+  it('should not change state to unchecked (off) when user clicks on checked (on) switch', () => {
     const { getByRole } = render(<Switch on={true} />);
     const checkbox = getByRole('checkbox') as HTMLInputElement;
     expect(checkbox.checked).toEqual(true);
     fireEvent.click(checkbox);
-    expect(checkbox.checked).toEqual(false);
+    expect(checkbox.checked).toEqual(true);
   });
 
   it('should be checked (on) if defaultOn is set to true', () => {

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { LockBlackFilled as LockIcon } from '@livechat/design-system-icons/react/tabler';
 import cx from 'clsx';
 
-import noop from '../../utils/noop';
 import { Icon, IconSize } from '../Icon';
 import { Loader } from '../Loader';
 
@@ -63,27 +62,23 @@ export const Switch: React.FC<SwitchProps> = ({
   disabled = false,
   name = baseClass,
   on,
-  onChange = noop,
+  onChange,
   size = 'large',
   state = 'regular',
   innerRef,
   ariaLabel,
   ...props
 }) => {
+  const isControlled = on !== undefined;
   const [checked, setChecked] = React.useState(() =>
-    on !== undefined ? on : defaultOn
+    isControlled ? on : defaultOn
   );
-
-  React.useEffect(() => {
-    if (on !== undefined) {
-      setChecked(on);
-    }
-  }, [on]);
+  const controllingValue = isControlled ? on : checked;
 
   const isLoading = state === 'loading';
   const isLocked = state === 'locked';
   const iconSize: IconSize = size === 'large' ? 'small' : 'xsmall';
-  const toggleStyles = checked ? 'on' : 'off';
+  const toggleStyles = controllingValue ? 'on' : 'off';
   const shouldBehaveAsDisabled = disabled || isLoading || isLocked;
   const availabilityStyles = shouldBehaveAsDisabled ? 'disabled' : 'enabled';
   const mergedClassNames = cx(
@@ -93,14 +88,12 @@ export const Switch: React.FC<SwitchProps> = ({
   );
 
   const handleChange = (e: React.FormEvent) => {
-    const hasOnChangePassed = onChange !== noop;
-    if (hasOnChangePassed) {
-      onChange(e, checked);
+    onChange?.(e, !controllingValue);
 
-      return;
+    if (!isControlled) {
+      e.stopPropagation();
+      setChecked((prevEnabled) => !prevEnabled);
     }
-    e.stopPropagation();
-    setChecked((prevEnabled) => !prevEnabled);
   };
 
   return (
@@ -112,7 +105,7 @@ export const Switch: React.FC<SwitchProps> = ({
           styles[`${baseClass}__input--${availabilityStyles}`]
         )}
         onChange={handleChange}
-        checked={checked}
+        checked={controllingValue}
         name={name}
         ref={innerRef}
         disabled={shouldBehaveAsDisabled}


### PR DESCRIPTION
## Description
In controlled mode (when the on prop is passed) the component does not alter its internal state when being pressed.

## Storybook

https://feature-switch-fix--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
