### PR TITLE
#807 - ActionMenu - Group header styles change, improved logic for keyboard control

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
@@ -114,21 +114,6 @@ $base-class: 'action-menu';
           cursor: not-allowed;
         }
       }
-
-      &--active {
-        background-color: var(--picker-list-option-background-active);
-
-        &::after {
-          position: absolute;
-          left: -8px;
-          border-top-right-radius: var(--radius-3);
-          border-bottom-right-radius: var(--radius-3);
-          background: var(--action-primary-default);
-          width: 3px;
-          height: 36px;
-          content: '';
-        }
-      }
     }
   }
 }

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
@@ -11,7 +11,7 @@ $base-class: 'action-menu';
       cursor: pointer;
     }
 
-    &:focus {
+    &:focus-visible {
       outline: 2px solid var(--action-primary-default);
       outline-offset: 0;
     }
@@ -53,15 +53,8 @@ $base-class: 'action-menu';
         content: '';
       }
 
-      &:nth-of-type(1)::before {
-        position: absolute;
-        top: calc(var(--spacing-2) * -1);
-        right: -8px;
-        left: -8px;
-        z-index: -1;
-        background: var(--picker-list-group-background);
-        height: var(--spacing-2);
-        content: '';
+      &:nth-of-type(1) {
+        margin-top: calc(var(--spacing-2) * -1);
       }
     }
 
@@ -86,12 +79,11 @@ $base-class: 'action-menu';
         cursor: pointer;
       }
 
-      &:focus,
       &:active {
         background-color: var(--picker-list-option-background-active);
       }
 
-      &:focus {
+      &:focus-visible {
         outline: 2px solid var(--action-primary-default);
         outline-offset: -2px;
       }

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -24,6 +24,7 @@ export default {
 export const Default = (): React.ReactElement => (
   <div className="action-menu-preview">
     <ActionMenu
+      id="default-example"
       options={exampleOptions}
       triggerClassName="action-menu-button"
       triggerRenderer={<Icon source={MoreHoriz} kind="primary" />}
@@ -77,6 +78,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
   return (
     <div className="action-menu-preview">
       <ActionMenu
+        id="keep-open-example"
         activeOptionKeys={activeOptionsKeys}
         triggerClassName="action-menu-button"
         options={[

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -24,7 +24,6 @@ export default {
 export const Default = (): React.ReactElement => (
   <div className="action-menu-preview">
     <ActionMenu
-      id="default-example"
       options={exampleOptions}
       triggerClassName="action-menu-button"
       triggerRenderer={<Icon source={MoreHoriz} kind="primary" />}
@@ -43,7 +42,6 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
   return (
     <div className="action-menu-preview">
       <ActionMenu
-        id="keep-open-example"
         triggerClassName="action-menu-button"
         options={[
           {

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -39,47 +39,11 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
   const [switchTwoValue, setSwitchTwoValue] = React.useState(false);
   const [checkboxOneValue, setCheckboxOneValue] = React.useState(true);
   const [checkboxTwoValue, setCheckboxTwoValue] = React.useState(true);
-  const [activeOptionsKeys, setActiveOptionsKeys] = React.useState([
-    'one',
-    'three',
-    'five',
-    'six',
-  ]);
-
-  const handleOptionSelect = (
-    key: string,
-    type: string,
-    optionHandler: void
-  ) => {
-    const newActiveOptions = activeOptionsKeys;
-
-    if (type === 'radio') {
-      if (!activeOptionsKeys.includes(key)) {
-        const keyToRemove = key === 'one' ? 'two' : 'one';
-        const index = activeOptionsKeys.indexOf(keyToRemove);
-        newActiveOptions.splice(index, 1);
-        setActiveOptionsKeys([...newActiveOptions, key]);
-      }
-    }
-
-    if (type === 'switch' || type === 'checkbox') {
-      if (activeOptionsKeys.includes(key)) {
-        const index = activeOptionsKeys.indexOf(key);
-        newActiveOptions.splice(index, 1);
-        setActiveOptionsKeys([...newActiveOptions]);
-      } else {
-        activeOptionsKeys.push(key);
-      }
-    }
-
-    return optionHandler;
-  };
 
   return (
     <div className="action-menu-preview">
       <ActionMenu
         id="keep-open-example"
-        activeOptionKeys={activeOptionsKeys}
         triggerClassName="action-menu-button"
         options={[
           {
@@ -96,8 +60,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
                 </RadioButton>
               </ActionMenuItem>
             ),
-            onClick: () =>
-              handleOptionSelect('one', 'radio', setRadioButtonValue('one')),
+            onClick: () => setRadioButtonValue('one'),
           },
           {
             key: 'two',
@@ -108,8 +71,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
                 </RadioButton>
               </ActionMenuItem>
             ),
-            onClick: () =>
-              handleOptionSelect('two', 'radio', setRadioButtonValue('two')),
+            onClick: () => setRadioButtonValue('two'),
           },
           {
             key: 'three',
@@ -123,12 +85,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
                 Toggle label one
               </ActionMenuItem>
             ),
-            onClick: () =>
-              handleOptionSelect(
-                'three',
-                'switch',
-                setSwitchOneValue((s) => !s)
-              ),
+            onClick: () => setSwitchOneValue((s) => !s),
           },
           {
             key: 'four',
@@ -142,12 +99,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
                 Toggle label two
               </ActionMenuItem>
             ),
-            onClick: () =>
-              handleOptionSelect(
-                'four',
-                'switch',
-                setSwitchTwoValue((s) => !s)
-              ),
+            onClick: () => setSwitchTwoValue((s) => !s),
           },
           {
             key: 'group-2',
@@ -165,12 +117,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
                 }
               />
             ),
-            onClick: () =>
-              handleOptionSelect(
-                'five',
-                'checkbox',
-                setCheckboxOneValue((s) => !s)
-              ),
+            onClick: () => setCheckboxOneValue((s) => !s),
           },
           {
             key: 'six',
@@ -183,12 +130,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
                 }
               />
             ),
-            onClick: () =>
-              handleOptionSelect(
-                'six',
-                'checkbox',
-                setCheckboxTwoValue((s) => !s)
-              ),
+            onClick: () => setCheckboxTwoValue((s) => !s),
           },
         ]}
         triggerRenderer={<Icon source={MoreHoriz} kind="primary" />}

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -77,9 +77,10 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     indexRef.current = getIndex(val);
     const elements = ref.current?.children;
     const elementToFocus =
-      elements && (elements[indexRef.current].children[0] as HTMLButtonElement);
+      elements &&
+      (elements[indexRef.current]?.children[0] as HTMLButtonElement);
 
-    return elementToFocus && elementToFocus.focus();
+    return elementToFocus?.focus();
   };
 
   const onKeyDown = (e: KeyboardEvent) => {

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -12,6 +12,10 @@ import styles from './ActionMenu.module.scss';
 
 export interface ActionMenuProps {
   /**
+   * Set the unique id for every `ActionMenu` visible on the same view
+   */
+  id: string;
+  /**
    * The CSS class for menu container
    */
   className?: string;
@@ -48,6 +52,7 @@ export interface ActionMenuProps {
 const baseClass = 'action-menu';
 
 export const ActionMenu: React.FC<ActionMenuProps> = ({
+  id,
   className,
   triggerClassName,
   options,
@@ -81,13 +86,13 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     if (e.key === KeyCodes.arrowUp && indexRef.current > 0) {
       e.preventDefault();
       indexRef.current = getIndex(-1);
-      document.getElementById(`list-item-${indexRef.current}`)?.focus();
+      document.getElementById(`${id}-${indexRef.current}`)?.focus();
     }
 
     if (e.key === KeyCodes.arrowDown && indexRef.current + 1 < options.length) {
       e.preventDefault();
       indexRef.current = getIndex(+1);
-      document.getElementById(`list-item-${indexRef.current}`)?.focus();
+      document.getElementById(`${id}-${indexRef.current}`)?.focus();
     }
   };
 
@@ -105,7 +110,8 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     setIsVisible(true);
   };
 
-  const handleItemClick = (itemOnClick?: () => void) => {
+  const handleItemClick = (index: number, itemOnClick?: () => void) => {
+    indexRef.current = index;
     itemOnClick?.();
 
     if (!keepOpenOnClick) {
@@ -129,12 +135,12 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     return (
       <li key={option.key} role="none">
         <button
-          id={`list-item-${index}`}
+          id={`${id}-${index}`}
           data-testid={option.key}
           tabIndex={-1}
           key={option.key}
           disabled={option.disabled}
-          onClick={() => handleItemClick(option.onClick)}
+          onClick={() => handleItemClick(index, option.onClick)}
           role="menuitem"
           className={cx(styles[`${baseClass}__list__item`], {
             [styles[`${baseClass}__list__item--disabled`]]: option.disabled,
@@ -170,6 +176,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     >
       <ul
         {...props}
+        id={id}
         className={cx(styles[`${baseClass}__list`], className)}
         role="menu"
         aria-hidden={!isVisible}

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -59,7 +59,8 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   ...props
 }) => {
   const [isVisible, setIsVisible] = React.useState(openedOnInit);
-  const indexRef = React.useRef(-1);
+  const indexRef = React.useRef<number>(-1);
+  const ref = React.useRef<HTMLUListElement | null>(null);
 
   const getIndex = (val: number): number => {
     const currentValue = indexRef.current;
@@ -77,17 +78,24 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     return newValue;
   };
 
+  const focusElement = (val: number) => {
+    indexRef.current = getIndex(val);
+    const elements = ref.current?.children;
+    const elementToFocus =
+      elements && (elements[indexRef.current].children[0] as HTMLButtonElement);
+
+    return elementToFocus && elementToFocus.focus();
+  };
+
   const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === KeyCodes.arrowUp && indexRef.current > 0) {
       e.preventDefault();
-      indexRef.current = getIndex(-1);
-      document.getElementById(`${id}-${indexRef.current}`)?.focus();
+      focusElement(-1);
     }
 
     if (e.key === KeyCodes.arrowDown && indexRef.current + 1 < options.length) {
       e.preventDefault();
-      indexRef.current = getIndex(+1);
-      document.getElementById(`${id}-${indexRef.current}`)?.focus();
+      focusElement(+1);
     }
   };
 
@@ -173,6 +181,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
         className={cx(styles[`${baseClass}__list`], className)}
         role="menu"
         aria-hidden={!isVisible}
+        ref={ref}
       >
         {options.map(getOptionElement)}
       </ul>

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -12,10 +12,6 @@ import styles from './ActionMenu.module.scss';
 
 export interface ActionMenuProps {
   /**
-   * Set the unique id for every `ActionMenu` visible on the same view
-   */
-  id: string;
-  /**
    * The CSS class for menu container
    */
   className?: string;
@@ -48,7 +44,6 @@ export interface ActionMenuProps {
 const baseClass = 'action-menu';
 
 export const ActionMenu: React.FC<ActionMenuProps> = ({
-  id,
   className,
   triggerClassName,
   options,
@@ -138,7 +133,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     return (
       <li key={option.key} role="none">
         <button
-          id={`${id}-${index}`}
           data-testid={option.key}
           tabIndex={-1}
           key={option.key}
@@ -177,7 +171,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     >
       <ul
         {...props}
-        id={id}
         className={cx(styles[`${baseClass}__list`], className)}
         role="menu"
         aria-hidden={!isVisible}

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -43,10 +43,6 @@ export interface ActionMenuProps {
    * Menu will stay open after option click
    */
   keepOpenOnClick?: boolean;
-  /**
-   * Set the keys array for active elements
-   */
-  activeOptionKeys?: string[];
 }
 
 const baseClass = 'action-menu';
@@ -60,7 +56,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   placement = 'bottom-end',
   openedOnInit = false,
   keepOpenOnClick,
-  activeOptionKeys,
   ...props
 }) => {
   const [isVisible, setIsVisible] = React.useState(openedOnInit);
@@ -146,8 +141,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
             [styles[`${baseClass}__list__item--disabled`]]: option.disabled,
             [styles[`${baseClass}__list__item--with-divider`]]:
               option.withDivider,
-            [styles[`${baseClass}__list__item--active`]]:
-              activeOptionKeys?.includes(option.key),
           })}
         >
           {option.element}


### PR DESCRIPTION
Resolves: #807 

## Description
Changed the styles for the group header if that element is first on the menu list.
Added required `id` prop for component that will be used in the keyboard control logic. (this fixes the issue If there are multiple instantiations of that component in a single view).
Changed the styles for `focus` state, it will now work only for keyboard control.

## Storybook

https://feature-807--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-actionmenu--keep-open-on-item-click

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
