### PR TITLE
#768 - Picker - Fix for TS error when input is empty and no item is selected

### DIFF
--- a/packages/react-components/src/components/Picker/PickerList.tsx
+++ b/packages/react-components/src/components/Picker/PickerList.tsx
@@ -75,7 +75,7 @@ export const PickerList: React.FC<IPickerListProps> = ({
 
     if (
       e.key === KeyCodes.enter &&
-      !!items[indexRef.current] &&
+      items[indexRef.current] &&
       !items[indexRef.current].disabled
     ) {
       e.preventDefault();

--- a/packages/react-components/src/components/Picker/PickerList.tsx
+++ b/packages/react-components/src/components/Picker/PickerList.tsx
@@ -73,7 +73,11 @@ export const PickerList: React.FC<IPickerListProps> = ({
       setCurrentItemKey(items[indexRef.current].key);
     }
 
-    if (e.key === KeyCodes.enter && !items[indexRef.current].disabled) {
+    if (
+      e.key === KeyCodes.enter &&
+      !!items[indexRef.current] &&
+      !items[indexRef.current].disabled
+    ) {
       e.preventDefault();
 
       if (items[indexRef.current].key === SELECT_ALL_OPTION_KEY) {


### PR DESCRIPTION
Resolves: #768 

## Description
Fix for the issue described in the task.
It was caused by the event listener for key down when the list is opened. By capturing the `enter` key, executed logic causes to throw the error, because it wants to refer to the selected item from the list, where there is any item selected.

## Storybook

https://feature-768--613a8e945a5665003a05113b.chromatic.com/?path=/docs/components-picker--docs

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
