### PR TITLE
#820 - Picker - Fix for keyboard control issue after filtering the list

### DIFF
--- a/packages/react-components/src/components/Picker/PickerList.tsx
+++ b/packages/react-components/src/components/Picker/PickerList.tsx
@@ -91,6 +91,10 @@ export const PickerList: React.FC<IPickerListProps> = ({
   React.useEffect(() => {
     if (indexRef.current > -1 && items.length > 0 && items[indexRef.current]) {
       setCurrentItemKey(items[indexRef.current].key);
+    } else {
+      indexRef.current = -1;
+      lastIndexRef.current = 0;
+      setCurrentItemKey(null);
     }
 
     if (isOpen) {


### PR DESCRIPTION
Resolves: #820 

## Description
The issue was caused by incorrectly handling the `currentItemKey`, which shows the currently focused element when using the keyboard control while filtering the list.

## Storybook

https://feature-820--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-picker--default

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
