### PR TITLE
fix(DesignToken): adding missing colour token

### DIFF
--- a/packages/react-components/src/themes/design-token.ts
+++ b/packages/react-components/src/themes/design-token.ts
@@ -38,6 +38,8 @@ export const DesignToken = {
   SurfaceAccentEmphasisMinNegative: '--surface-accent-emphasis-min-negative',
   SurfaceAccentEmphasisMinWarning: '--surface-accent-emphasis-min-warning',
   SurfaceAccentEmphasisMinPositive: '--surface-accent-emphasis-min-positive',
+  SurfaceAccentEmphasisMediumPositive:
+    '--surface-accent-emphasis-medium-positive',
   SurfaceAccentEmphasisMinPurple: '--surface-accent-emphasis-min-purple',
   SurfaceInvertDefault: '--surface-invert-default', // deprecated
   SurfaceInvertPrimary: '--surface-invert-primary',


### PR DESCRIPTION
## Description
Adding missing color token SurfaceAccentEmphasisMediumPositive to DesignToken enum

## Storybook

https://feature-adding-missing-token--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
