### PR TITLE
fix(DesignToken): adding missing color token

### DIFF
--- a/packages/react-components/src/themes/design-token.ts
+++ b/packages/react-components/src/themes/design-token.ts
@@ -40,6 +40,8 @@ export const DesignToken = {
   SurfaceAccentEmphasisMinPositive: '--surface-accent-emphasis-min-positive',
   SurfaceAccentEmphasisMediumPositive:
     '--surface-accent-emphasis-medium-positive',
+  SurfaceAccentEmphasisMediumNegative:
+    '--surface-accent-emphasis-medium-negative',
   SurfaceAccentEmphasisMinPurple: '--surface-accent-emphasis-min-purple',
   SurfaceInvertDefault: '--surface-invert-default', // deprecated
   SurfaceInvertPrimary: '--surface-invert-primary',


### PR DESCRIPTION


Resolves: #{issue-number}

## Description
Adding missing color token SurfaceAccentEmphasisMediumNegative in the enum.

## Storybook

https://feature-adding-missing-token--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x]  Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
