### PR TITLE
fix(ActionMenu): Change divider position after element with this flag

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
@@ -101,12 +101,12 @@ $base-class: 'action-menu';
       }
 
       &--with-divider {
-        margin-top: var(--spacing-2);
+        margin-bottom: var(--spacing-2);
 
-        &::before {
+        &::after {
           position: absolute;
-          top: -4.5px;
           right: -8px;
+          bottom: -4.5px;
           left: -8px;
           background-color: var(--border-basic-secondary);
           height: 1px;

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -65,6 +65,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
           },
           {
             key: 'two',
+            withDivider: true,
             element: (
               <ActionMenuItem>
                 <RadioButton checked={radioButtonValue === 'two'}>
@@ -90,7 +91,6 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
           },
           {
             key: 'four',
-            withDivider: true,
             element: (
               <ActionMenuItem
                 rightNode={

--- a/packages/react-components/src/components/ActionMenu/constants.tsx
+++ b/packages/react-components/src/components/ActionMenu/constants.tsx
@@ -45,6 +45,7 @@ export const exampleOptions = [
       <ActionMenuItem leftNode={<Icon source={Block} />}>Block</ActionMenuItem>
     ),
     disabled: true,
+    withDivider: true,
     onClick: noop,
   },
   {
@@ -55,6 +56,5 @@ export const exampleOptions = [
       </ActionMenuItem>
     ),
     onClick: noop,
-    withDivider: true,
   },
 ];


### PR DESCRIPTION
## Description
Change styles for divider, now it will be displayed after element with this flag set.

## Storybook

https://feature-action-menu-divider-fix--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-actionmenu--keep-open-on-item-click

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
