### PR TITLE
fix(PromoBannerV2): moving className prop to parent element

### DIFF
--- a/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.module.scss
+++ b/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.module.scss
@@ -2,15 +2,16 @@ $base-class: 'promo-banner-v2';
 
 .main-wrapper {
   container-type: inline-size;
+  border-radius: var(--radius-3);
+  background-color: var(--surface-accent-emphasis-low-info);
+  color: var(--content-basic-primary);
 }
 
 .#{$base-class} {
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
-  border-radius: var(--radius-3);
-  background-color: var(--surface-accent-emphasis-low-info);
-  color: var(--content-basic-primary);
+  height: 100%;
 
   &__content {
     display: flex;

--- a/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.tsx
+++ b/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.tsx
@@ -51,11 +51,11 @@ export const PromoBannerV2: React.FC<
   secondaryButton,
   onClose,
 }) => {
-  const mergedClassNames = cx(styles[baseClass], className);
+  const mergedClassNames = cx(styles[`main-wrapper`], className);
 
   return (
-    <div className={styles[`main-wrapper`]}>
-      <div role="banner" className={mergedClassNames}>
+    <div role="banner" className={mergedClassNames}>
+      <div className={styles[baseClass]}>
         <div className={styles[`${baseClass}__content`]}>
           {children}
           {(primaryButton || secondaryButton) && (


### PR DESCRIPTION
Resolves: #840 

## Description
Moving `className` prop to parent element in PromoBannerV2 component.

## Storybook

https://feature-840--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
