### PR TITLE
fix(EmailTagInput): Passing props to TagInput component

### DIFF
--- a/packages/react-components/src/components/TagInput/EmailTagInput.tsx
+++ b/packages/react-components/src/components/TagInput/EmailTagInput.tsx
@@ -19,9 +19,11 @@ export const EmailTagInput: React.FC<EmailTagInputProps> = ({
   error,
   placeholder = defaultPlaceholder,
   size,
+  ...props
 }) => {
   return (
     <TagInput
+      {...props}
       id={id}
       tags={tags}
       error={error}

--- a/packages/react-components/src/components/TagInput/TagInput.tsx
+++ b/packages/react-components/src/components/TagInput/TagInput.tsx
@@ -53,6 +53,10 @@ export interface TagInputProps
    * Specify the input size
    */
   size?: 'medium' | 'large';
+  /**
+   * Set the input custom class
+   */
+  inputClassName?: string;
 }
 
 export const TagInput: React.FC<TagInputProps> = ({
@@ -63,12 +67,19 @@ export const TagInput: React.FC<TagInputProps> = ({
   error,
   placeholder,
   size = 'medium',
+  className,
+  inputClassName,
   ...props
 }) => {
-  const mergedClassNames = cx(styles[baseClass], {
-    [styles[`${baseClass}--error`]]: error,
-  });
+  const mergedClassNames = cx(
+    styles[baseClass],
+    {
+      [styles[`${baseClass}--error`]]: error,
+    },
+    className
+  );
   const inputClassNames = cx(
+    inputClassName,
     styles[`${baseClass}__input`],
     styles[`${baseClass}__input--${size}`]
   );


### PR DESCRIPTION
Resolves: #427 

## Description
- allowing passing additional props to TagInput; 
- adding inputClassName

## Storybook

https://feature-427--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
