### PR TITLE
feat[DetailsCard): Added rightNode to pass own element to the label

### DIFF
--- a/packages/react-components/src/components/DetailsCard/DetailsCard.module.scss
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.module.scss
@@ -64,8 +64,18 @@ $base-class: 'details-card';
       margin-right: 36px;
     }
 
+    &__left-node,
+    &__right-node {
+      display: flex;
+    }
+
     &__left-node {
       margin-right: var(--spacing-2);
+    }
+
+    &__right-node {
+      margin-right: var(--spacing-2);
+      margin-left: var(--spacing-2);
     }
 
     &__text {

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.stories.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.stories.tsx
@@ -9,6 +9,7 @@ import { Button } from '../Button';
 import { DetailsCardInfo } from '../DetailsCardInfo';
 import { Icon } from '../Icon';
 import { PromoBannerV2 } from '../PromoBannerV2';
+import { Switch } from '../Switch';
 import { Tag } from '../Tag';
 import { Heading } from '../Typography';
 
@@ -71,6 +72,7 @@ export const ExampleUsage = (): React.ReactElement => {
       </DetailsCard>
       <DetailsCard
         leftNode={<Icon source={ChipCopilotColored} />}
+        rightNode={<Switch size="compact" />}
         label="With Info components"
         withDivider
         openOnInit

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -15,9 +15,13 @@ export interface IDetailsCardProps {
    */
   className?: string;
   /**
-   * Additional element for the label
+   * Additional element for the label on the left
    */
   leftNode?: React.ReactNode;
+  /**
+   * Additional element for the label on the right
+   */
+  rightNode?: React.ReactNode;
   /**
    * Set the label
    */
@@ -46,6 +50,7 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
   children,
   className,
   leftNode,
+  rightNode,
   label,
   withDivider,
   fullSpaceContent,
@@ -89,6 +94,11 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
           <Heading size="xs" className={styles[`${baseClass}__label__text`]}>
             {label}
           </Heading>
+          {rightNode && (
+            <div className={styles[`${baseClass}__label__right-node`]}>
+              {rightNode}
+            </div>
+          )}
         </div>
         {!hideLabelOnOpen && (
           <Icon


### PR DESCRIPTION
## Description
Added `rightNode` to put own element in the right side of the label.

## Storybook

https://feature-details-card-right-node--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-detailscard--example-usage

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
