### PR TITLE
feat(Tooltip): Added flag to set the position strategy

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -11,6 +11,7 @@ import {
   useDismiss,
   useRole,
   useTransitionStyles,
+  UseFloatingOptions,
 } from '@floating-ui/react';
 import cx from 'clsx';
 
@@ -65,6 +66,10 @@ export interface ActionMenuProps {
    * Optional handler called on menu open
    */
   onOpen?: () => void;
+  /**
+   * Set the type of CSS position property to use
+   */
+  floatingStrategy?: UseFloatingOptions['strategy'];
 }
 
 const baseClass = 'action-menu';
@@ -81,6 +86,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   visible,
   onClose,
   onOpen,
+  floatingStrategy = 'absolute',
   ...props
 }) => {
   const isControlled = visible !== undefined;
@@ -103,6 +109,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     middleware: [offset(4), flip(flipOptions)],
     placement: placement,
     open: currentlyVisible,
+    strategy: floatingStrategy,
     onOpenChange: handleMenuStateChange,
     whileElementsMounted: autoUpdate,
   });

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -11,7 +11,7 @@ import {
   useDismiss,
   useRole,
   useTransitionStyles,
-  UseFloatingOptions,
+  Strategy,
 } from '@floating-ui/react';
 import cx from 'clsx';
 
@@ -68,8 +68,9 @@ export interface ActionMenuProps {
   onOpen?: () => void;
   /**
    * Set the type of CSS position property to use
+   * https://floating-ui.com/docs/usefloating#strategy
    */
-  floatingStrategy?: UseFloatingOptions['strategy'];
+  floatingStrategy?: Strategy;
 }
 
 const baseClass = 'action-menu';
@@ -86,7 +87,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   visible,
   onClose,
   onOpen,
-  floatingStrategy = 'absolute',
+  floatingStrategy,
   ...props
 }) => {
   const isControlled = visible !== undefined;

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -35,7 +35,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   closeOnEsc = true,
   useDismissHookProps,
   useClickHookProps,
-  floatingStrategy = 'absolute',
+  floatingStrategy,
 }) => {
   const [visible, setVisible] = React.useState(openedOnInit);
   const isControlled = isVisible !== undefined;

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -35,6 +35,7 @@ export const Popover: React.FC<IPopoverProps> = ({
   closeOnEsc = true,
   useDismissHookProps,
   useClickHookProps,
+  floatingStrategy = 'absolute',
 }) => {
   const [visible, setVisible] = React.useState(openedOnInit);
   const isControlled = isVisible !== undefined;
@@ -57,6 +58,7 @@ export const Popover: React.FC<IPopoverProps> = ({
     onOpenChange: handleVisibilityChange,
     middleware: [offset(offsetSize), flip(flipOptions), shift()],
     placement: placement,
+    strategy: floatingStrategy,
     whileElementsMounted: autoUpdate,
   });
 

--- a/packages/react-components/src/components/Popover/types.ts
+++ b/packages/react-components/src/components/Popover/types.ts
@@ -5,7 +5,7 @@ import {
   UseClickProps,
   UseDismissProps,
   FlipOptions,
-  UseFloatingOptions,
+  Strategy,
 } from '@floating-ui/react';
 
 export interface IPopoverProps {
@@ -66,6 +66,7 @@ export interface IPopoverProps {
   useClickHookProps?: UseClickProps;
   /**
    * Set the type of CSS position property to use
+   * https://floating-ui.com/docs/usefloating#strategy
    */
-  floatingStrategy?: UseFloatingOptions['strategy'];
+  floatingStrategy?: Strategy;
 }

--- a/packages/react-components/src/components/Popover/types.ts
+++ b/packages/react-components/src/components/Popover/types.ts
@@ -5,6 +5,7 @@ import {
   UseClickProps,
   UseDismissProps,
   FlipOptions,
+  UseFloatingOptions,
 } from '@floating-ui/react';
 
 export interface IPopoverProps {
@@ -63,4 +64,8 @@ export interface IPopoverProps {
    * https://floating-ui.com/docs/useclick
    */
   useClickHookProps?: UseClickProps;
+  /**
+   * Set the type of CSS position property to use
+   */
+  floatingStrategy?: UseFloatingOptions['strategy'];
 }

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -55,6 +55,7 @@ export const Tooltip: React.FC<ITooltipProps> = ({
   arrowOffsetY,
   arrowOffsetX,
   closeOnTriggerBlur = false,
+  floatingStrategy = 'absolute',
 }) => {
   const isControlled = isVisible !== undefined;
   const [visible, setVisible] = React.useState(false);
@@ -109,6 +110,7 @@ export const Tooltip: React.FC<ITooltipProps> = ({
     ],
     placement: placement,
     open: currentlyVisible,
+    strategy: floatingStrategy,
     onOpenChange: handleMenuStateChange,
     whileElementsMounted: autoUpdate,
   });

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -55,7 +55,7 @@ export const Tooltip: React.FC<ITooltipProps> = ({
   arrowOffsetY,
   arrowOffsetX,
   closeOnTriggerBlur = false,
-  floatingStrategy = 'absolute',
+  floatingStrategy,
 }) => {
   const isControlled = isVisible !== undefined;
   const [visible, setVisible] = React.useState(false);

--- a/packages/react-components/src/components/Tooltip/types.ts
+++ b/packages/react-components/src/components/Tooltip/types.ts
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import { Placement, VirtualElement, UseDismissProps } from '@floating-ui/react';
+import {
+  Placement,
+  VirtualElement,
+  UseDismissProps,
+  UseFloatingOptions,
+} from '@floating-ui/react';
 
 import { ButtonKind } from '../Button';
 
@@ -121,4 +126,8 @@ export interface ITooltipProps {
    * Be default, moving the curson from trigger to tooltip will keep it open.
    */
   closeOnTriggerBlur?: boolean;
+  /**
+   * Set the type of CSS position property to use
+   */
+  floatingStrategy?: UseFloatingOptions['strategy'];
 }

--- a/packages/react-components/src/components/Tooltip/types.ts
+++ b/packages/react-components/src/components/Tooltip/types.ts
@@ -4,7 +4,7 @@ import {
   Placement,
   VirtualElement,
   UseDismissProps,
-  UseFloatingOptions,
+  Strategy,
 } from '@floating-ui/react';
 
 import { ButtonKind } from '../Button';
@@ -128,6 +128,7 @@ export interface ITooltipProps {
   closeOnTriggerBlur?: boolean;
   /**
    * Set the type of CSS position property to use
+   * https://floating-ui.com/docs/usefloating#strategy
    */
-  floatingStrategy?: UseFloatingOptions['strategy'];
+  floatingStrategy?: Strategy;
 }


### PR DESCRIPTION
Resolves: #899 

## Description
This change should give the possibility to solve the issues with rendering floating elements inside containers with `overflow: hidden` style, by using the `floatingStrategy` flag, that can set the position of floating element to `fixed`.
This change includes `Tooltip`, `ActionMenu` and `Popover` components.

## Storybook

https://feature-899--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-tooltip--default

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
