### PR TITLE
feat(DetailsCard): Dynamic set max-height of expanded element based on content, added onClick prop to pass own handler on label click

### DIFF
--- a/packages/react-components/src/components/DetailsCard/DetailsCard.module.scss
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.module.scss
@@ -115,12 +115,10 @@ $base-class: 'details-card';
   &__content-wrapper {
     transition: all 0.2s ease;
     opacity: 0;
-    max-height: 0;
     overflow: hidden;
 
     &--open {
       opacity: 1;
-      max-height: 500px;
     }
   }
 

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.spec.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.spec.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { vi } from 'vitest';
+
 import { render, userEvent } from 'test-utils';
 
 import { DetailsCard, IDetailsCardProps } from './DetailsCard';
@@ -60,5 +62,16 @@ describe('<DetailsCard> component', () => {
     const button = getByRole('button');
 
     expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should call onClick handler on label click', () => {
+    const handler = vi.fn();
+    const { getByRole } = renderComponent({
+      ...defaultProps,
+      onClick: handler,
+    });
+    const button = getByRole('button');
+    userEvent.click(button);
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -69,15 +69,19 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
 
   const handleButtonClick = () => setIsOpen((prevValue) => !prevValue);
 
-  const resizeObserver = new ResizeObserver(() => {
-    if (divRef.current && size !== divRef.current.offsetHeight) {
-      setSize(divRef.current.offsetHeight);
-    }
-  });
-
   React.useEffect(() => {
-    if (divRef.current) {
+    const hasIOSupport = !!window.IntersectionObserver;
+
+    if (divRef.current && hasIOSupport) {
+      const resizeObserver = new ResizeObserver(() => {
+        if (divRef.current && size !== divRef.current.offsetHeight) {
+          setSize(divRef.current.offsetHeight);
+        }
+      });
+
       resizeObserver.observe(divRef.current);
+
+      return () => resizeObserver.disconnect();
     }
   }, [divRef]);
 

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -64,7 +64,7 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
 }) => {
   const [isOpen, setIsOpen] = React.useState(openOnInit);
   const [size, setSize] = React.useState(0);
-  const divRef = React.useRef<HTMLDivElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
   const mergedClassNames = cx(
     styles[baseClass],
     withDivider && styles[`${baseClass}--with-divider`],
@@ -80,18 +80,18 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
   React.useEffect(() => {
     const hasIOSupport = !!window.IntersectionObserver;
 
-    if (divRef.current && hasIOSupport) {
+    if (contentRef.current && hasIOSupport) {
       const resizeObserver = new ResizeObserver(() => {
-        if (divRef.current && size !== divRef.current.offsetHeight) {
-          setSize(divRef.current.offsetHeight);
+        if (contentRef.current && size !== contentRef.current.offsetHeight) {
+          setSize(contentRef.current.offsetHeight);
         }
       });
 
-      resizeObserver.observe(divRef.current);
+      resizeObserver.observe(contentRef.current);
 
       return () => resizeObserver.disconnect();
     }
-  }, [divRef]);
+  }, [contentRef]);
 
   return (
     <div className={mergedClassNames}>
@@ -169,7 +169,7 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
           }}
         >
           <div
-            ref={divRef}
+            ref={contentRef}
             className={cx(
               styles[`${baseClass}__content`],
               fullSpaceContent && styles[`${baseClass}__content--full-space`],

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -58,6 +58,8 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
   hideLabelOnOpen,
 }) => {
   const [isOpen, setIsOpen] = React.useState(openOnInit);
+  const [size, setSize] = React.useState(0);
+  const divRef = React.useRef<HTMLDivElement>(null);
   const mergedClassNames = cx(
     styles[baseClass],
     withDivider && styles[`${baseClass}--with-divider`],
@@ -66,6 +68,12 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
   const isMainButtonHidden = hideLabelOnOpen && isOpen;
 
   const handleButtonClick = () => setIsOpen((prevValue) => !prevValue);
+
+  React.useEffect(() => {
+    if (divRef.current) {
+      setSize(divRef.current.offsetHeight);
+    }
+  }, [divRef]);
 
   return (
     <div className={mergedClassNames}>
@@ -132,20 +140,26 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
           data-testid="details-card-floating-button"
         />
       )}
-      <div
-        className={cx(
-          styles[`${baseClass}__content-wrapper`],
-          isOpen && styles[`${baseClass}__content-wrapper--open`]
-        )}
-      >
+      <div>
         <div
           className={cx(
-            styles[`${baseClass}__content`],
-            fullSpaceContent && styles[`${baseClass}__content--full-space`],
-            hideLabelOnOpen && styles[`${baseClass}__content--spacing`]
+            styles[`${baseClass}__content-wrapper`],
+            isOpen && styles[`${baseClass}__content-wrapper--open`]
           )}
+          style={{
+            maxHeight: isOpen ? size : 0,
+          }}
         >
-          {children}
+          <div
+            ref={divRef}
+            className={cx(
+              styles[`${baseClass}__content`],
+              fullSpaceContent && styles[`${baseClass}__content--full-space`],
+              hideLabelOnOpen && styles[`${baseClass}__content--spacing`]
+            )}
+          >
+            {children}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -42,6 +42,10 @@ export interface IDetailsCardProps {
    * Set to hide the label on card open
    */
   hideLabelOnOpen?: boolean;
+  /**
+   * Callback function called when the card label is clicked
+   */
+  onClick?: () => void;
 }
 
 const baseClass = 'details-card';
@@ -56,6 +60,7 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
   fullSpaceContent,
   openOnInit = false,
   hideLabelOnOpen,
+  onClick,
 }) => {
   const [isOpen, setIsOpen] = React.useState(openOnInit);
   const [size, setSize] = React.useState(0);
@@ -67,7 +72,10 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
   );
   const isMainButtonHidden = hideLabelOnOpen && isOpen;
 
-  const handleButtonClick = () => setIsOpen((prevValue) => !prevValue);
+  const handleButtonClick = () => {
+    setIsOpen((prevValue) => !prevValue);
+    onClick?.();
+  };
 
   React.useEffect(() => {
     const hasIOSupport = !!window.IntersectionObserver;

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -73,7 +73,7 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
     if (divRef.current) {
       setSize(divRef.current.offsetHeight);
     }
-  }, [divRef]);
+  }, [divRef, isOpen]);
 
   return (
     <div className={mergedClassNames}>

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -69,11 +69,17 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
 
   const handleButtonClick = () => setIsOpen((prevValue) => !prevValue);
 
-  React.useEffect(() => {
-    if (divRef.current) {
+  const resizeObserver = new ResizeObserver(() => {
+    if (divRef.current && size !== divRef.current.offsetHeight) {
       setSize(divRef.current.offsetHeight);
     }
-  }, [divRef, isOpen]);
+  });
+
+  React.useEffect(() => {
+    if (divRef.current) {
+      resizeObserver.observe(divRef.current);
+    }
+  }, [divRef]);
 
   return (
     <div className={mergedClassNames}>


### PR DESCRIPTION
Resolves: #{issue-number}

## Description
Set `max-height` of content container, based on size of passed element.
Addes `onClick` prop, to pass own handler which will be executed on label click.

## Storybook

https://feature-details-card-height-improve--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-detailscard--example-usage

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
