### PR TITLE
feat(PromoBannerV2): vertical mode, class name props for content containers

### DIFF
--- a/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.module.scss
+++ b/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.module.scss
@@ -1,5 +1,28 @@
 $base-class: 'promo-banner-v2';
 
+@mixin verticalStyles {
+  flex-direction: column;
+
+  .#{$base-class}__content {
+    flex: 0 1 auto;
+    order: 2;
+    padding: var(--spacing-4) var(--spacing-5) var(--spacing-5);
+  }
+
+  .#{$base-class}__additional-content {
+    justify-content: left;
+    order: 1;
+    padding-top: var(--spacing-5);
+  }
+
+  .#{$base-class}__close {
+    position: absolute;
+    top: var(--spacing-3);
+    right: var(--spacing-3);
+    padding: 0;
+  }
+}
+
 .main-wrapper {
   container-type: inline-size;
   border-radius: var(--radius-3);
@@ -59,26 +82,11 @@ $base-class: 'promo-banner-v2';
     }
   }
 
+  &--vertical {
+    @include verticalStyles;
+  }
+
   @container (max-width: 559px) {
-    flex-direction: column;
-
-    .#{$base-class}__content {
-      flex: 0 1 auto;
-      order: 2;
-      padding: var(--spacing-4) var(--spacing-5) var(--spacing-5);
-    }
-
-    .#{$base-class}__additional-content {
-      justify-content: left;
-      order: 1;
-      padding-top: var(--spacing-5);
-    }
-
-    .#{$base-class}__close {
-      position: absolute;
-      top: var(--spacing-3);
-      right: var(--spacing-3);
-      padding: 0;
-    }
+    @include verticalStyles;
   }
 }

--- a/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.stories.tsx
+++ b/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.stories.tsx
@@ -5,7 +5,7 @@ import { Display, Heading } from '../Typography';
 
 import imageDefault from './assets/image2.png';
 import promoImage from './assets/promo-img.png';
-import { PromoBannerV2 } from './PromoBannerV2';
+import { IPromoBannerV2Props, PromoBannerV2 } from './PromoBannerV2';
 import './PromoBannerV2.stories.css';
 
 export default {
@@ -39,11 +39,8 @@ const defaultProps = {
   onClose: noop,
 };
 
-export const Default = (): React.ReactElement => (
-  <PromoBannerV2
-    {...defaultProps}
-    additionalContent={<img src={imageDefault} />}
-  >
+export const Default = (args: IPromoBannerV2Props): React.ReactElement => (
+  <PromoBannerV2 {...args} additionalContent={<img src={imageDefault} />}>
     <div style={{ marginBottom: 'var(--spacing-1)' }}>
       <Heading as="div" size="sm" className="promo-header">
         Title text up 2 lines
@@ -52,12 +49,17 @@ export const Default = (): React.ReactElement => (
     Description text up to 4 lines
   </PromoBannerV2>
 );
+Default.args = {
+  ...defaultProps,
+};
 
-export const WithStyledAdditionalContent = (): React.ReactElement => (
+export const WithStyledAdditionalContent = (
+  args: IPromoBannerV2Props
+): React.ReactElement => (
   <div>
     <div>
       <PromoBannerV2
-        {...defaultProps}
+        {...args}
         additionalContent={
           <div className="image-position">
             <img src={promoImage} />
@@ -87,6 +89,9 @@ export const WithStyledAdditionalContent = (): React.ReactElement => (
     </div>
   </div>
 );
+WithStyledAdditionalContent.args = {
+  ...defaultProps,
+};
 
 export const WithStyledMainContent = (): React.ReactElement => (
   <div style={{ maxWidth: 1100 }}>

--- a/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.tsx
+++ b/packages/react-components/src/components/PromoBannerV2/PromoBannerV2.tsx
@@ -36,6 +36,18 @@ export interface IPromoBannerV2Props {
     kind?: ButtonKind;
   };
   /**
+   * Set to true to display the banner vertically
+   */
+  vertical?: boolean;
+  /**
+   * Specify an optional className to be applied to the content node
+   */
+  contentClassName?: string;
+  /**
+   * Specify an optional className to be applied to the additional content node
+   */
+  additionalContentClassName?: string;
+  /**
    * Event handler for close button press
    */
   onClose?: () => void;
@@ -49,14 +61,22 @@ export const PromoBannerV2: React.FC<
   additionalContent,
   primaryButton,
   secondaryButton,
+  vertical,
+  contentClassName,
+  additionalContentClassName,
   onClose,
 }) => {
   const mergedClassNames = cx(styles[`main-wrapper`], className);
 
   return (
     <div role="banner" className={mergedClassNames}>
-      <div className={styles[baseClass]}>
-        <div className={styles[`${baseClass}__content`]}>
+      <div
+        className={cx(
+          styles[baseClass],
+          vertical && styles[`${baseClass}--vertical`]
+        )}
+      >
+        <div className={cx(styles[`${baseClass}__content`], contentClassName)}>
           {children}
           {(primaryButton || secondaryButton) && (
             <div className={styles[`${baseClass}__content__cta`]}>
@@ -81,7 +101,12 @@ export const PromoBannerV2: React.FC<
           )}
         </div>
         {additionalContent && (
-          <div className={styles[`${baseClass}__additional-content`]}>
+          <div
+            className={cx(
+              styles[`${baseClass}__additional-content`],
+              additionalContentClassName
+            )}
+          >
             {additionalContent}
           </div>
         )}


### PR DESCRIPTION
Resolves: #893 

## Description
Flag to enable vertical mode without container queries.
New props to pass own styles to content containers.

## Storybook

https://feature-893--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-promobannerv2--default

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
