### PR TITLE
fix(Button): Fixing only-icon Button padding

### DIFF
--- a/packages/react-components/src/components/Button/Button.module.scss
+++ b/packages/react-components/src/components/Button/Button.module.scss
@@ -18,11 +18,11 @@ $base-class: 'btn';
   }
 
   &--compact {
-    @include size.button-size($base-class, 6px 16px, 32px, 32px);
+    @include size.button-size($base-class, 6px, 16px, 32px, 32px);
   }
 
   &--large {
-    @include size.button-size($base-class, 11px 16px, 44px, 44px);
+    @include size.button-size($base-class, 11px, 16px, 44px, 44px);
   }
 
   &--basic {

--- a/packages/react-components/src/components/Button/styles/size.scss
+++ b/packages/react-components/src/components/Button/styles/size.scss
@@ -2,8 +2,4 @@
   padding: $padding-v $padding-h;
   min-width: $min-width;
   height: $height;
-
-  &.#{$base-class}--icon-only {
-    padding: 6px;
-  }
 }

--- a/packages/react-components/src/components/Button/styles/size.scss
+++ b/packages/react-components/src/components/Button/styles/size.scss
@@ -1,9 +1,9 @@
-@mixin button-size($base-class, $padding, $min-width, $height) {
-  padding: $padding;
+@mixin button-size($base-class, $padding-v, $padding-h, $min-width, $height) {
+  padding: $padding-v $padding-h;
   min-width: $min-width;
   height: $height;
 
   &.#{$base-class}--icon-only {
-    padding: $padding - 2;
+    padding: 6px;
   }
 }


### PR DESCRIPTION
Resolves: #896

## Description
Fixing only-icon Button padding

## Storybook

https://feature-896--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
