### PR TITLE
feat(DetailsCard): Custom component as card label

### DIFF
--- a/packages/react-components/src/components/DetailsCard/DetailsCard.module.scss
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.module.scss
@@ -36,10 +36,6 @@ $base-class: 'details-card';
       cursor: pointer;
     }
 
-    &--open {
-      padding-bottom: var(--spacing-5);
-    }
-
     &__icon {
       transition: all 0.2s ease;
 
@@ -78,7 +74,7 @@ $base-class: 'details-card';
       margin-left: var(--spacing-2);
     }
 
-    &__text {
+    &__content {
       margin: 0;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.stories.css
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.stories.css
@@ -15,15 +15,20 @@
 }
 
 .custom-label-avatar {
+  flex-shrink: 0;
   margin-right: var(--spacing-4);
 }
 
 .custom-label-content {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
-.custom-label-content-label-1 {
+.custom-label-content-label {
   margin: 0;
+  overflow: hidden;
   text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.stories.css
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.stories.css
@@ -7,3 +7,23 @@
   margin-bottom: var(--spacing-2);
   width: 48px;
 }
+
+.custom-label {
+  display: flex;
+  align-items: center;
+  height: 72px;
+}
+
+.custom-label-avatar {
+  margin-right: var(--spacing-4);
+}
+
+.custom-label-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.custom-label-content-label-1 {
+  margin: 0;
+  text-align: left;
+}

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.stories.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.stories.tsx
@@ -65,10 +65,10 @@ export const ExampleUsage = (): React.ReactElement => {
               shape="circle"
             />
             <div className="custom-label-content">
-              <Heading size="xs" className="custom-label-content-label-1">
+              <Heading size="xs" className="custom-label-content-label">
                 John Whale
               </Heading>
-              <span className="custom-label-content-label-2">
+              <span className="custom-label-content-label">
                 john.whale.porato@gmail.com
               </span>
             </div>

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.stories.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.stories.tsx
@@ -56,8 +56,24 @@ export const ExampleUsage = (): React.ReactElement => {
       }}
     >
       <DetailsCard
-        leftNode={<Icon source={ChipCopilotColored} />}
-        label="Simple text"
+        label={
+          <div className="custom-label">
+            <Avatar
+              className="custom-label-avatar"
+              type="text"
+              text="Test Avatar"
+              shape="circle"
+            />
+            <div className="custom-label-content">
+              <Heading size="xs" className="custom-label-content-label-1">
+                John Whale
+              </Heading>
+              <span className="custom-label-content-label-2">
+                john.whale.porato@gmail.com
+              </span>
+            </div>
+          </div>
+        }
         withDivider
       >
         <div>

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -25,7 +25,7 @@ export interface IDetailsCardProps {
   /**
    * Set the label
    */
-  label: string | React.ReactNode;
+  label: React.ReactNode;
   /**
    * Define if divider should be visible
    */

--- a/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
+++ b/packages/react-components/src/components/DetailsCard/DetailsCard.tsx
@@ -25,7 +25,7 @@ export interface IDetailsCardProps {
   /**
    * Set the label
    */
-  label: string;
+  label: string | React.ReactNode;
   /**
    * Define if divider should be visible
    */
@@ -71,6 +71,7 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
     className
   );
   const isMainButtonHidden = hideLabelOnOpen && isOpen;
+  const isTextContent = typeof label === 'string';
 
   const handleButtonClick = () => {
     setIsOpen((prevValue) => !prevValue);
@@ -117,9 +118,18 @@ export const DetailsCard: React.FC<IDetailsCardProps> = ({
               {leftNode}
             </div>
           )}
-          <Heading size="xs" className={styles[`${baseClass}__label__text`]}>
-            {label}
-          </Heading>
+          {isTextContent ? (
+            <Heading
+              size="xs"
+              className={styles[`${baseClass}__label__content`]}
+            >
+              {label}
+            </Heading>
+          ) : (
+            <div className={styles[`${baseClass}__label__content`]}>
+              {label}
+            </div>
+          )}
           {rightNode && (
             <div className={styles[`${baseClass}__label__right-node`]}>
               {rightNode}


### PR DESCRIPTION
## Description
Added possibility to pass own component as card label.

## Storybook

https://feature-details-card-custom-label--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-detailscard--example-usage

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
