### PR TITLE
add type attribute to PickerTrigger

### DIFF
--- a/packages/react-components/src/components/Picker/components/PickerTrigger.tsx
+++ b/packages/react-components/src/components/Picker/components/PickerTrigger.tsx
@@ -71,6 +71,7 @@ export const PickerTrigger: React.FC<
       className={mergedClassNames}
       data-testid={testId}
       ref={setReference}
+      type="button"
       {...getReferenceProps()}
     >
       <div


### PR DESCRIPTION
Resolves: #947 

## Description
Add a type attribute to `PickerTrigger` to prevent it from submitting forms.
## Storybook

https://feature-947--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
