### PR TITLE
fix(components): Adding aria-label to close buttons in components

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -77,6 +77,10 @@ export interface ActionMenuProps {
    * https://floating-ui.com/docs/usefloating#strategy
    */
   floatingStrategy?: Strategy;
+  /**
+   * Test id passed to the wrapper element
+   */
+  ['data-testid']?: string;
 }
 
 const baseClass = 'action-menu';
@@ -95,6 +99,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   onOpen,
   floatingStrategy,
   selectedOptions,
+  ['data-testid']: testId = 'action-menu-trigger-button',
   ...props
 }) => {
   const isControlled = visible !== undefined;
@@ -252,7 +257,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     <>
       <div
         aria-label="Toggle menu"
-        data-testid="action-menu-trigger-button"
+        data-testid={testId}
         ref={refs.setReference}
         {...getReferenceProps()}
         className={triggerClassName}

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -17,17 +17,14 @@ import { Check } from '@livechat/design-system-icons';
 import cx from 'clsx';
 
 import { KeyCodes } from '../../utils/keyCodes';
+import { ComponentCoreProps } from '../../utils/types';
 import { Icon } from '../Icon';
 
 import { IActionMenuOption } from './types';
 
 import styles from './ActionMenu.module.scss';
 
-export interface ActionMenuProps {
-  /**
-   * The CSS class for menu container
-   */
-  className?: string;
+export interface ActionMenuProps extends ComponentCoreProps {
   /**
    * The CSS class for trigger container
    */
@@ -77,10 +74,6 @@ export interface ActionMenuProps {
    * https://floating-ui.com/docs/usefloating#strategy
    */
   floatingStrategy?: Strategy;
-  /**
-   * Test id passed to the wrapper element
-   */
-  ['data-testid']?: string;
 }
 
 const baseClass = 'action-menu';
@@ -99,7 +92,6 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   onOpen,
   floatingStrategy,
   selectedOptions,
-  ['data-testid']: testId = 'action-menu-trigger-button',
   ...props
 }) => {
   const isControlled = visible !== undefined;
@@ -257,7 +249,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
     <>
       <div
         aria-label="Toggle menu"
-        data-testid={testId}
+        data-testid="action-menu-trigger-button"
         ref={refs.setReference}
         {...getReferenceProps()}
         className={triggerClassName}

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -251,6 +251,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   return (
     <>
       <div
+        aria-label="Toggle menu"
         data-testid="action-menu-trigger-button"
         ref={refs.setReference}
         {...getReferenceProps()}

--- a/packages/react-components/src/components/Alert/Alert.tsx
+++ b/packages/react-components/src/components/Alert/Alert.tsx
@@ -10,6 +10,7 @@ import {
 import cx from 'clsx';
 import debounce from 'lodash.debounce';
 
+import { ComponentCoreProps } from '../../utils/types';
 import { Button } from '../Button';
 import { Icon, IconSource, IconKind } from '../Icon';
 import { Text } from '../Typography';
@@ -18,11 +19,7 @@ import styles from './Alert.module.scss';
 
 type AlertKind = 'info' | 'warning' | 'success' | 'error';
 
-export interface AlertProps {
-  /**
-   * The CSS class for container
-   */
-  className?: string;
+export interface AlertProps extends ComponentCoreProps {
   /**
    * Specify the kind of Alert
    */
@@ -45,10 +42,6 @@ export interface AlertProps {
    * The optional event handler for close button
    */
   onClose?: () => void;
-  /**
-   * Test id passed to the wrapper element
-   */
-  ['data-testid']?: string;
 }
 
 const IconConfig: Record<AlertKind, { source: IconSource; kind: IconKind }> = {

--- a/packages/react-components/src/components/Alert/Alert.tsx
+++ b/packages/react-components/src/components/Alert/Alert.tsx
@@ -45,6 +45,10 @@ export interface AlertProps {
    * The optional event handler for close button
    */
   onClose?: () => void;
+  /**
+   * Test id passed to the wrapper element
+   */
+  ['data-testid']?: string;
 }
 
 const IconConfig: Record<AlertKind, { source: IconSource; kind: IconKind }> = {

--- a/packages/react-components/src/components/Alert/Alert.tsx
+++ b/packages/react-components/src/components/Alert/Alert.tsx
@@ -153,6 +153,7 @@ export const Alert: React.FC<React.PropsWithChildren<AlertProps>> = ({
       </div>
       {onClose && (
         <Button
+          aria-label="Close alert"
           type="button"
           className={styles[`${baseClass}__close-icon`]}
           size="compact"

--- a/packages/react-components/src/components/Avatar/Avatar.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Person as PersonIcon } from '@livechat/design-system-icons';
 import cx from 'clsx';
 
+import { ComponentCoreProps } from '../../utils/types';
 import { Icon } from '../Icon';
 
 import {
@@ -27,15 +28,11 @@ type AvatarSize =
 type AvatarStatus = 'available' | 'unavailable' | 'unknown';
 type AvatarType = 'image' | 'text';
 
-export interface AvatarProps {
+export interface AvatarProps extends ComponentCoreProps {
   /**
    * Alternate text for an image avatar
    */
   alt?: string;
-  /**
-   * The CSS class for container
-   */
-  className?: string;
   /**
    * Specify the background color
    */
@@ -68,10 +65,6 @@ export interface AvatarProps {
    * Displays rim
    */
   withRim?: boolean;
-  /**
-   * Test id passed to the wrapper element
-   */
-  ['data-testid']?: string;
 }
 
 const baseClass = 'avatar';

--- a/packages/react-components/src/components/Avatar/Avatar.tsx
+++ b/packages/react-components/src/components/Avatar/Avatar.tsx
@@ -68,6 +68,10 @@ export interface AvatarProps {
    * Displays rim
    */
   withRim?: boolean;
+  /**
+   * Test id passed to the wrapper element
+   */
+  ['data-testid']?: string;
 }
 
 const baseClass = 'avatar';
@@ -83,6 +87,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   text,
   type,
   withRim = false,
+  ...props
 }) => {
   const isImproperImageSetup = type === 'image' && !src;
   const [shouldDisplayFallbackAvatar, setShouldDisplayFallbackAvatar] =
@@ -129,7 +134,7 @@ export const Avatar: React.FC<AvatarProps> = ({
   }, [isImproperImageSetup]);
 
   return (
-    <div className={mergedClassNames} style={backgroundStyle}>
+    <div className={mergedClassNames} style={backgroundStyle} {...props}>
       {withRim && (
         <div
           data-testid={`${baseClass}__rim`}

--- a/packages/react-components/src/components/Modal/components/ModalCloseButton.tsx
+++ b/packages/react-components/src/components/Modal/components/ModalCloseButton.tsx
@@ -18,7 +18,9 @@ export const ModalCloseButton: React.FC<ModalCloseButtonProps> = ({
   onClick,
 }) => (
   <Button
+    type="button"
     kind="plain"
+    aria-label="Close modal"
     title="Close modal"
     className={cx(
       styles['modal-base__close'],

--- a/packages/react-components/src/components/Picker/types.ts
+++ b/packages/react-components/src/components/Picker/types.ts
@@ -4,6 +4,7 @@ import { Strategy, UseClickProps, UseDismissProps } from '@floating-ui/react';
 import { VirtuosoProps } from 'react-virtuoso';
 
 import { Size } from '../../utils';
+import { ComponentCoreProps } from '../../utils/types';
 import { IconSource } from '../Icon';
 
 export interface IPickerListItem {
@@ -23,7 +24,7 @@ export interface IPickerListItem {
 
 export type PickerType = 'single' | 'multi';
 
-export interface IPickerProps {
+export interface IPickerProps extends ComponentCoreProps {
   /**
    * Specify the custom id
    */
@@ -88,10 +89,6 @@ export interface IPickerProps {
    * Will open picker on component initialization
    */
   openedOnInit?: boolean;
-  /**
-   * Test id passed to the picker trigger element
-   */
-  ['data-testid']?: string;
   /**
    * Callback called after item selection
    */

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -150,6 +150,7 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
           title="Remove"
           onClick={onRemove}
           type="button"
+          aria-label="Remove tag"
           className={styles[`${baseClass}__remove`]}
         >
           <Icon

--- a/packages/react-components/src/components/Tooltip/components/Info.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Info.tsx
@@ -22,6 +22,8 @@ export const Info: React.FC<{
     <div className={className}>
       {closeWithX && (
         <button
+          type="button"
+          aria-label="Close tooltip"
           className={styles[`${baseClass}-close`]}
           onClick={handleCloseAction}
         >

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -45,6 +45,8 @@ export const Interactive: React.FC<{
     <div className={styles[`${baseClass}__interactive`]}>
       {closeWithX && (
         <button
+          type="button"
+          aria-label="Close tooltip"
           className={styles[`${baseClass}-close`]}
           onClick={handleCloseAction}
         >

--- a/packages/react-components/src/components/Tooltip/components/UserGuide/UserGuideStep.tsx
+++ b/packages/react-components/src/components/Tooltip/components/UserGuide/UserGuideStep.tsx
@@ -49,6 +49,8 @@ export const UserGuideStep: React.FC<{
     <div className={styles[`${baseClass}__user-guide-step`]}>
       {closeWithX && (
         <button
+          type="button"
+          aria-label="Close tooltip"
           className={styles[`${baseClass}-close`]}
           onClick={handleCloseAction}
         >

--- a/packages/react-components/src/utils/constants.ts
+++ b/packages/react-components/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export type Size = 'compact' | 'medium' | 'large';

--- a/packages/react-components/src/utils/index.ts
+++ b/packages/react-components/src/utils/index.ts
@@ -1,2 +1,2 @@
-export type { Size } from './constants';
+export type { Size } from './types';
 export { getDesignTokenWithOpacity } from './getDesignTokenWithOpacity';

--- a/packages/react-components/src/utils/types.ts
+++ b/packages/react-components/src/utils/types.ts
@@ -1,0 +1,12 @@
+export type Size = 'compact' | 'medium' | 'large';
+
+export interface ComponentCoreProps {
+  /**
+   * The CSS class name
+   */
+  className?: string;
+  /**
+   * Test id passed to the wrapper element
+   */
+  'data-testid'?: string;
+}


### PR DESCRIPTION
## Description
Adding aria-label to close buttons in components

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-close-buttons-aria--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
