### PR TITLE
fix(Modal): Possibility to scroll down the overlay if modal is larger than window

### DIFF
--- a/packages/react-components/src/components/Modal/Modal.module.scss
+++ b/packages/react-components/src/components/Modal/Modal.module.scss
@@ -2,7 +2,6 @@
   display: flex;
   position: relative;
   flex-direction: column;
-  margin: 10px;
   margin: auto;
   border-radius: var(--radius-3);
   box-shadow: 0 20px 60px 0 rgb(0 0 0 / 30%);
@@ -18,18 +17,10 @@
 
   &__overlay {
     display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
-    justify-content: center;
-    z-index: 13000;
     background-color: var(--surface-other-overlay);
-    width: 100%;
-    height: 100%;
 
     &--visible {
       display: flex;
-      overflow-y: auto;
     }
 
     &--labelled {

--- a/packages/react-components/src/components/Modal/Modal.module.scss
+++ b/packages/react-components/src/components/Modal/Modal.module.scss
@@ -1,3 +1,5 @@
+@import '../../utils/StackingContextLevel';
+
 .modal-base {
   display: flex;
   position: relative;
@@ -17,6 +19,7 @@
 
   &__overlay {
     display: none;
+    z-index: $stacking-context-level-modal;
     background-color: var(--surface-other-overlay);
 
     &--visible {

--- a/packages/react-components/src/components/Modal/Modal.module.scss
+++ b/packages/react-components/src/components/Modal/Modal.module.scss
@@ -3,12 +3,13 @@
   position: relative;
   flex-direction: column;
   margin: 10px;
+  margin: auto;
   border-radius: var(--radius-3);
   box-shadow: 0 20px 60px 0 rgb(0 0 0 / 30%);
   background-color: var(--surface-primary-default);
   padding: var(--spacing-6) var(--spacing-7);
   max-width: 100%;
-  max-height: 100%;
+  height: fit-content;
   color: var(--content-basic-primary);
 
   &--full-space {
@@ -20,7 +21,6 @@
     position: fixed;
     top: 0;
     left: 0;
-    align-items: center;
     justify-content: center;
     z-index: 13000;
     background-color: var(--surface-other-overlay);
@@ -29,6 +29,7 @@
 
     &--visible {
       display: flex;
+      overflow-y: auto;
     }
 
     &--labelled {

--- a/packages/react-components/src/components/Modal/components/ModalBase.tsx
+++ b/packages/react-components/src/components/Modal/components/ModalBase.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { FloatingOverlay } from '@floating-ui/react';
 import cx from 'clsx';
 
 import { KeyCodes } from '../../../utils/keyCodes';
@@ -69,7 +70,7 @@ export const ModalBase: React.FC<React.PropsWithChildren<ModalBaseProps>> = ({
   };
 
   return (
-    <div
+    <FloatingOverlay
       data-testid="lc-modal-overlay"
       onMouseDown={onOverlayClick}
       className={cx(
@@ -86,6 +87,6 @@ export const ModalBase: React.FC<React.PropsWithChildren<ModalBaseProps>> = ({
       >
         {children}
       </div>
-    </div>
+    </FloatingOverlay>
   );
 };

--- a/packages/react-components/src/utils/StackingContextLevel.scss
+++ b/packages/react-components/src/utils/StackingContextLevel.scss
@@ -1,7 +1,7 @@
 /**
  * Definition of z-index values to be used across application.
  */
-
+$stacking-context-level-modal: 10000;
 $stacking-context-level-tooltip: 3000;
 $stacking-context-level-dropdown: 2000;
 $stacking-context-level-popover: 1000;


### PR DESCRIPTION
## Description
Implementation of `FloatingOverlay` component from `floating-ui` as our modals overlay. It will allow to scroll down the whole overlay if the modal size is larger than user window.

## Storybook
https://feature-modal-overflow-scroll--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-modal--modal

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
