### PR TITLE
fix(Input): Fixes for typography component usage in Input, TagInput and Textarea

### DIFF
--- a/packages/react-components/src/components/Input/Input.tsx
+++ b/packages/react-components/src/components/Input/Input.tsx
@@ -92,24 +92,27 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       icon && type !== 'password' && icon.place === 'right';
 
     return (
-      <div className={mergedClassNames} aria-disabled={disabled} tab-index="0">
+      <Text
+        as="div"
+        className={mergedClassNames}
+        aria-disabled={disabled}
+        tab-index="0"
+      >
         {shouldRenderLeftIcon && renderIcon(icon, disabled)}
-        <Text as="div">
-          <input
-            {...inputProps}
-            ref={ref}
-            onFocus={(e) => {
-              setIsFocused(true);
-              onFocus?.(e);
-            }}
-            onBlur={(e) => {
-              setIsFocused(false);
-              onBlur?.(e);
-            }}
-            disabled={disabled}
-            type={type && !isPasswordVisible ? type : 'text'}
-          />
-        </Text>
+        <input
+          {...inputProps}
+          ref={ref}
+          onFocus={(e) => {
+            setIsFocused(true);
+            onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setIsFocused(false);
+            onBlur?.(e);
+          }}
+          disabled={disabled}
+          type={type && !isPasswordVisible ? type : 'text'}
+        />
         {shouldRenderRightIcon && renderIcon(icon, disabled)}
         {type === 'password' && (
           <Button
@@ -121,7 +124,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className={styles[`${baseClass}__visibility-button`]}
           />
         )}
-      </div>
+      </Text>
     );
   }
 );

--- a/packages/react-components/src/components/TagInput/TagInput.tsx
+++ b/packages/react-components/src/components/TagInput/TagInput.tsx
@@ -155,7 +155,7 @@ export const TagInput: React.FC<TagInputProps> = ({
 
   return (
     <>
-      <div className={mergedClassNames}>
+      <Text as="div" className={mergedClassNames}>
         {tags?.map((tag, index) => (
           <EditableTag
             index={index}
@@ -169,21 +169,19 @@ export const TagInput: React.FC<TagInputProps> = ({
             {tag}
           </EditableTag>
         ))}
-        <Text as="div">
-          <input
-            {...props}
-            id={id}
-            ref={inputRef}
-            className={inputClassNames}
-            placeholder={placeholder}
-            value={inputValue}
-            onChange={handleInputChange}
-            onKeyDown={handleInputKeyDown}
-            onPaste={handlePaste}
-            onBlur={handleBlur}
-          />
-        </Text>
-      </div>
+        <input
+          {...props}
+          id={id}
+          ref={inputRef}
+          className={inputClassNames}
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleInputKeyDown}
+          onPaste={handlePaste}
+          onBlur={handleBlur}
+        />
+      </Text>
       {error && <FieldError>{error}</FieldError>}
     </>
   );

--- a/packages/react-components/src/components/Textarea/Textarea.tsx
+++ b/packages/react-components/src/components/Textarea/Textarea.tsx
@@ -39,16 +39,14 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     };
 
     return (
-      <div className={mergedClassNames}>
-        <Text as="div">
-          <textarea
-            {...textareaProps}
-            ref={ref}
-            onFocus={handleOnFocus}
-            onBlur={handleOnBlur}
-          />
-        </Text>
-      </div>
+      <Text as="div" className={mergedClassNames}>
+        <textarea
+          {...textareaProps}
+          ref={ref}
+          onFocus={handleOnFocus}
+          onBlur={handleOnBlur}
+        />
+      </Text>
     );
   }
 );


### PR DESCRIPTION
<!--- Issue number will be inserted automatically -->
Resolves: #{issue-number}

## Description
Fix for wrong implemented typography component in the `Input`, `TagInput` and `Textarea`, that causes the unexpected reduction in input size inside the wrapper.
This changes fix that.

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-input-typography-fix--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue
