### PR TITLE
feat(ActionMenu): Footer prop to display own element in the menu

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
@@ -131,5 +131,16 @@ $base-class: 'action-menu';
         margin-left: var(--spacing-2);
       }
     }
+
+    &--with-footer {
+      padding-bottom: var(--spacing-05);
+    }
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: space-between;
+    border-top: 1px solid var(--border-basic-secondary);
+    padding: var(--spacing-2);
   }
 }

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.spec.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.spec.tsx
@@ -6,15 +6,16 @@ import { render, userEvent, fireEvent } from 'test-utils';
 
 import noop from '../../utils/noop';
 
-import { ActionMenu, ActionMenuProps } from './ActionMenu';
+import { ActionMenu } from './ActionMenu';
 import { exampleOptions } from './constants';
+import { IActionMenuProps } from './types';
 
 const defaultProps = {
   options: exampleOptions,
   triggerRenderer: <div>Open menu</div>,
 };
 
-const renderComponent = (props: ActionMenuProps) => {
+const renderComponent = (props: IActionMenuProps) => {
   return render(<ActionMenu data-testid="action-menu-test" {...props} />);
 };
 

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { MoreHoriz } from '@livechat/design-system-icons';
+import { MoreHoriz, Add, Settings } from '@livechat/design-system-icons';
 
 import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
@@ -180,6 +180,28 @@ export const WithSelectedOptions = (): React.ReactElement => {
         }
         openedOnInit
         keepOpenOnClick
+      />
+    </div>
+  );
+};
+
+export const WithFooter = (): React.ReactElement => {
+  return (
+    <div className="action-menu-preview">
+      <ActionMenu
+        options={exampleOptions}
+        triggerRenderer={
+          <Button icon={<Icon source={MoreHoriz} kind="primary" />} />
+        }
+        openedOnInit
+        footer={
+          <>
+            <Button icon={<Icon source={Add} />} kind="plain">
+              New
+            </Button>
+            <Button icon={<Icon source={Settings} />} kind="text" />
+          </>
+        }
       />
     </div>
   );

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import {
   useFloating,
-  Placement,
   flip,
   offset,
   autoUpdate,
@@ -11,74 +10,21 @@ import {
   useDismiss,
   useRole,
   useTransitionStyles,
-  Strategy,
 } from '@floating-ui/react';
 import { Check } from '@livechat/design-system-icons';
 import cx from 'clsx';
 
 import { KeyCodes } from '../../utils/keyCodes';
-import { ComponentCoreProps } from '../../utils/types';
 import { Icon } from '../Icon';
+import { Text } from '../Typography';
 
-import { IActionMenuOption } from './types';
+import { IActionMenuOption, IActionMenuProps } from './types';
 
 import styles from './ActionMenu.module.scss';
 
-export interface ActionMenuProps extends ComponentCoreProps {
-  /**
-   * The CSS class for trigger container
-   */
-  triggerClassName?: string;
-  /**
-   * Array of menu options
-   */
-  options: IActionMenuOption[];
-  /**
-   * Array of selected menu options keys
-   */
-  selectedOptions?: string[];
-  /**
-   * Trigger element
-   */
-  triggerRenderer: React.ReactElement;
-  /**
-   * The menu placement
-   */
-  placement?: Placement;
-  /**
-   * Will open menu on component initialization
-   */
-  openedOnInit?: boolean;
-  /**
-   * Menu will stay open after option click
-   */
-  keepOpenOnClick?: boolean;
-  /**
-   * Set the menu placement to keep it in view
-   */
-  flipOptions?: Parameters<typeof flip>[0];
-  /**
-   * Set to control the menu visibility
-   */
-  visible?: boolean;
-  /**
-   * Optional handler called on menu close
-   */
-  onClose?: () => void;
-  /**
-   * Optional handler called on menu open
-   */
-  onOpen?: () => void;
-  /**
-   * Set the type of CSS position property to use
-   * https://floating-ui.com/docs/usefloating#strategy
-   */
-  floatingStrategy?: Strategy;
-}
-
 const baseClass = 'action-menu';
 
-export const ActionMenu: React.FC<ActionMenuProps> = ({
+export const ActionMenu: React.FC<IActionMenuProps> = ({
   className,
   triggerClassName,
   options,
@@ -92,6 +38,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
   onOpen,
   floatingStrategy,
   selectedOptions,
+  footer,
   ...props
 }) => {
   const isControlled = visible !== undefined;
@@ -270,12 +217,23 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
         >
           <ul
             {...props}
-            className={cx(styles[`${baseClass}__list`], className)}
+            className={cx(
+              styles[`${baseClass}__list`],
+              {
+                [styles[`${baseClass}__list--with-footer`]]: footer,
+              },
+              className
+            )}
             role="menu"
             ref={ref}
           >
             {options.map(getOptionElement)}
           </ul>
+          {footer && (
+            <Text size="sm" as="div" className={styles[`${baseClass}__footer`]}>
+              {footer}
+            </Text>
+          )}
         </div>
       )}
     </>

--- a/packages/react-components/src/components/ActionMenu/types.ts
+++ b/packages/react-components/src/components/ActionMenu/types.ts
@@ -1,5 +1,9 @@
 import * as React from 'react';
 
+import { Placement, flip, Strategy } from '@floating-ui/react';
+
+import { ComponentCoreProps } from '../../utils/types';
+
 export interface IActionMenuOption {
   key: string;
   element: React.ReactNode;
@@ -7,4 +11,60 @@ export interface IActionMenuOption {
   disabled?: boolean;
   withDivider?: boolean;
   onClick?: () => void;
+}
+
+export interface IActionMenuProps extends ComponentCoreProps {
+  /**
+   * The CSS class for trigger container
+   */
+  triggerClassName?: string;
+  /**
+   * Array of menu options
+   */
+  options: IActionMenuOption[];
+  /**
+   * Array of selected menu options keys
+   */
+  selectedOptions?: string[];
+  /**
+   * Trigger element
+   */
+  triggerRenderer: React.ReactElement;
+  /**
+   * The menu placement
+   */
+  placement?: Placement;
+  /**
+   * Will open menu on component initialization
+   */
+  openedOnInit?: boolean;
+  /**
+   * Menu will stay open after option click
+   */
+  keepOpenOnClick?: boolean;
+  /**
+   * Set the menu placement to keep it in view
+   */
+  flipOptions?: Parameters<typeof flip>[0];
+  /**
+   * Set to control the menu visibility
+   */
+  visible?: boolean;
+  /**
+   * Optional handler called on menu close
+   */
+  onClose?: () => void;
+  /**
+   * Optional handler called on menu open
+   */
+  onOpen?: () => void;
+  /**
+   * Set the type of CSS position property to use
+   * https://floating-ui.com/docs/usefloating#strategy
+   */
+  floatingStrategy?: Strategy;
+  /**
+   * Optional footer element
+   */
+  footer?: React.ReactNode;
 }


### PR DESCRIPTION
## Description
New prop `footer` that allows to pass own element, which will be displayed under the menu items list.

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-action-menu-footer--613a8e945a5665003a05113b.chromatic.com/?path=/story/components-actionmenu--with-footer

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
