### PR TITLE
Typo in ModalHeader interface

### DIFF
--- a/packages/react-components/src/components/Modal/components/ModalHeader.tsx
+++ b/packages/react-components/src/components/Modal/components/ModalHeader.tsx
@@ -30,7 +30,7 @@ export interface ModalHeaderProps {
   /**
    * Define class name for container
    */
-  className?: 'string';
+  className?: string;
 }
 
 export const ModalHeader: React.FC<ModalHeaderProps> = ({


### PR DESCRIPTION
<!--- Issue number will be inserted automatically -->
Resolves: #1090

## Description

Fixes typo that prevents setting custom className to ModalHeader component 

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-1090--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add reviewers (`livechat/design-system`)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue
