### PR TITLE
fix(Tooltip): UI fixes

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/react-components/src/components/Tooltip/Tooltip.module.scss
@@ -1,11 +1,12 @@
 @import '../../utils/StackingContextLevel';
 
 $base-class: 'tooltip';
+$radius: var(--radius-3);
 
 .#{$base-class} {
   z-index: $stacking-context-level-tooltip;
   border: 1px solid var(--tooltip-border);
-  border-radius: var(--radius-3);
+  border-radius: $radius;
   box-shadow: var(--shadow-tooltip);
   background-color: var(--tooltip-background-basic);
   padding: var(--spacing-3);
@@ -13,35 +14,9 @@ $base-class: 'tooltip';
   color: var(--content-basic-primary);
   font-size: inherit;
 
-  &__arrow {
-    position: absolute;
-    border: 1px solid;
-    border-color: var(--tooltip-border) var(--tooltip-background-basic)
-      var(--tooltip-background-basic) var(--tooltip-border);
-    box-shadow: var(--shadow-tooltip-arrow);
-    background: var(--tooltip-background-basic);
-    width: 10px;
-    height: 10px;
-
-    &[aria-placement^='left'] {
-      left: calc(100% - 5px);
-      transform: rotate(135deg);
-    }
-
-    &[aria-placement^='right'] {
-      left: calc(0% - 5px);
-      transform: rotate(-45deg);
-    }
-
-    &[aria-placement^='bottom'] {
-      top: calc(0% - 5px);
-      transform: rotate(45deg);
-    }
-
-    &[aria-placement^='top'] {
-      top: calc(100% - 5px);
-      transform: rotate(-135deg);
-    }
+  &__content {
+    border-radius: $radius;
+    overflow: hidden;
   }
 
   &--invert {

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -16,6 +16,7 @@ import {
   useTransitionStyles,
   useTransitionStatus,
   safePolygon,
+  FloatingArrow,
 } from '@floating-ui/react';
 import cx from 'clsx';
 
@@ -103,7 +104,6 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
     refs,
     context,
     middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
-    placement: finalPlacement,
   } = useFloating({
     middleware: [
       offset({ mainAxis: offsetMainAxis }),
@@ -170,11 +170,17 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
           {...getFloatingProps()}
           data-status={status}
         >
-          <Text as="div">{children}</Text>
-          <div
+          <Text as="div" className={styles[`${baseClass}__content`]}>
+            {children}
+          </Text>
+          <FloatingArrow
             ref={arrowRef}
-            className={styles[`${baseClass}__arrow`]}
-            aria-placement={finalPlacement}
+            context={context}
+            stroke="var(--tooltip-border-for-svg)"
+            fill="var(--tooltip-background-basic)"
+            strokeWidth={1}
+            width={10}
+            height={5}
             style={{
               ...getArrowPositionStyles(
                 arrowOffsetY,

--- a/packages/react-components/src/foundations/design-token.ts
+++ b/packages/react-components/src/foundations/design-token.ts
@@ -352,6 +352,7 @@ export const DesignToken = {
   TooltipBackgroundBasic: '--tooltip-background-basic',
   TooltipBackgroundInvert: '--tooltip-background-invert',
   TooltipBorder: '--tooltip-border',
+  TooltipBorderForSvg: '--tooltip-border-for-svg',
   AnimatedGradientValue1: '--animated-gradient-value-1',
   AnimatedGradientValue2: '--animated-gradient-value-2',
   AnimatedGradientValue3: '--animated-gradient-value-3',

--- a/packages/react-components/src/stories/foundations/Color/data.ts
+++ b/packages/react-components/src/stories/foundations/Color/data.ts
@@ -1451,6 +1451,11 @@ export const ColorsData: Record<
     desc: '',
     deprecated: false,
   },
+  TooltipBorderForSvg: {
+    group: ColorGroup.BorderBasic,
+    desc: '',
+    deprecated: false,
+  },
   AnimatedGradientValue1: {
     group: ColorGroup.AnimationGradient,
     desc: 'Part of the gradient used for animation in Skeleton component',

--- a/packages/react-components/src/themes/dark.scss
+++ b/packages/react-components/src/themes/dark.scss
@@ -341,6 +341,7 @@ $surface-invert-primary: #e2e2e4;
   --tooltip-background-basic: #{$surface-secondary-default};
   --tooltip-background-invert: #{$surface-invert-primary};
   --tooltip-border: rgb(255 255 255 / 15%);
+  --tooltip-border-for-svg: #4c4c50;
   --animated-gradient-value-1: rgb(59 59 67 / 0%) 0.08%;
   --animated-gradient-value-2: #3b3b43 50.5%;
   --animated-gradient-value-3: rgb(59 59 67 / 0%) 99.89%;

--- a/packages/react-components/src/themes/legacy.scss
+++ b/packages/react-components/src/themes/legacy.scss
@@ -328,6 +328,7 @@ $decor-gray800: #29292f;
   --tooltip-background-basic: #fff;
   --tooltip-background-invert: #{$decor-gray800};
   --tooltip-border: transparent;
+  --tooltip-border-for-svg: transparent;
   --animated-gradient-value-1: rgb(226 226 228 / 0%) 0.08%;
   --animated-gradient-value-2: #e2e2e4 50.5%;
   --animated-gradient-value-3: rgb(226 226 228 / 0%) 99.89%;

--- a/packages/react-components/src/themes/light.scss
+++ b/packages/react-components/src/themes/light.scss
@@ -338,6 +338,7 @@ $decor-gray800: #29292f;
   --tooltip-background-basic: #fff;
   --tooltip-background-invert: #{$decor-gray800};
   --tooltip-border: transparent;
+  --tooltip-border-for-svg: transparent;
   --animated-gradient-value-1: rgb(226 226 228 / 0%) 0.08%;
   --animated-gradient-value-2: #e2e2e4 50.5%;
   --animated-gradient-value-3: rgb(226 226 228 / 0%) 99.89%;


### PR DESCRIPTION

Resolves: #965

## Description
Two fixes:
- inner container `overflow: hidden` to overflow content
- changed local arrow to `FloatingArrow` from `floating-ui`, added styles (created special `--tooltip-border-for-svg` token for arrow stroke)

## Storybook


https://feature-965--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
