### PR TITLE
fix(Tooltip): UI fixes for Interactive kind, arrow color fixes

### DIFF
--- a/packages/react-components/.storybook/preview-head.html
+++ b/packages/react-components/.storybook/preview-head.html
@@ -14,6 +14,14 @@
     padding: 10px 10px 10px 0;
   }
 
+  .story-container-dm-only-inverted {
+    padding: 10px 10px 10px 0;
+  }
+
+  .lc-dark-theme .story-container-dm-only-inverted {
+    background: var(--surface-invert-primary);
+  }
+
   .story-title {
     font-size: 14px;
     font-weight: 600;
@@ -21,6 +29,10 @@
   }
 
   .story-title-inverted {
+    color: var(--content-invert-default);
+  }
+
+  .lc-dark-theme .story-title-dm-only-inverted {
     color: var(--content-invert-default);
   }
 

--- a/packages/react-components/src/components/Button/Button.module.scss
+++ b/packages/react-components/src/components/Button/Button.module.scss
@@ -102,4 +102,12 @@ $base-class: 'btn';
   &--icon-only {
     @include icon.icon-only($base-class);
   }
+
+  &--primary-lock-black {
+    @include kind.primary-lock-black();
+  }
+
+  &--lock-black {
+    @include kind.lock-black();
+  }
 }

--- a/packages/react-components/src/components/Button/Button.module.scss
+++ b/packages/react-components/src/components/Button/Button.module.scss
@@ -103,11 +103,11 @@ $base-class: 'btn';
     @include icon.icon-only($base-class);
   }
 
-  &--primary-lock-black {
-    @include kind.primary-lock-black();
+  &--plain-lock-black {
+    @include kind.plain-lock-black();
   }
 
-  &--lock-black {
-    @include kind.lock-black();
+  &--text-lock-black {
+    @include kind.text-lock-black();
   }
 }

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -144,10 +144,16 @@ export const Sizes = (): React.ReactElement => {
       {kinds.map((kind) => {
         const kindName = kind.charAt(0).toUpperCase() + kind.slice(1);
         const isInverted = kind === 'link-inverted';
+        const isDmOnlyInverted =
+          kind === 'plain-lock-black' || kind === 'text-lock-black';
 
         return (
           <>
-            <StoryDescriptor title={`${kindName} kind`} inverted={isInverted}>
+            <StoryDescriptor
+              title={`${kindName} kind`}
+              inverted={isInverted}
+              dmOnlyInverted={isDmOnlyInverted}
+            >
               <div className="story-spacer">
                 {sizes.map((size) => {
                   const sizeName = size.charAt(0).toUpperCase() + size.slice(1);

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -32,8 +32,8 @@ const kinds: Array<ButtonKind> = [
   'float',
   'dotted',
   'high-contrast',
-  'primary-lock-black',
-  'lock-black',
+  'plain-lock-black',
+  'text-lock-black',
 ];
 const sizes: ButtonSize[] = ['xcompact', 'compact', 'medium', 'large'];
 
@@ -91,7 +91,7 @@ export const KindsAndStates = (): React.ReactElement => (
       const title = kind.charAt(0).toUpperCase() + kind.slice(1);
       const isInverted = kind === 'link-inverted';
       const isDmOnlyInverted =
-        kind === 'primary-lock-black' || kind === 'lock-black';
+        kind === 'plain-lock-black' || kind === 'text-lock-black';
 
       return (
         <>

--- a/packages/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/react-components/src/components/Button/Button.stories.tsx
@@ -32,6 +32,8 @@ const kinds: Array<ButtonKind> = [
   'float',
   'dotted',
   'high-contrast',
+  'primary-lock-black',
+  'lock-black',
 ];
 const sizes: ButtonSize[] = ['xcompact', 'compact', 'medium', 'large'];
 
@@ -88,10 +90,16 @@ export const KindsAndStates = (): React.ReactElement => (
     {kinds.map((kind) => {
       const title = kind.charAt(0).toUpperCase() + kind.slice(1);
       const isInverted = kind === 'link-inverted';
+      const isDmOnlyInverted =
+        kind === 'primary-lock-black' || kind === 'lock-black';
 
       return (
         <>
-          <StoryDescriptor title={title} inverted={isInverted}>
+          <StoryDescriptor
+            title={title}
+            inverted={isInverted}
+            dmOnlyInverted={isDmOnlyInverted}
+          >
             <Button kind={kind}>{title}</Button>
             <Button kind={kind} disabled>
               Disabled
@@ -100,7 +108,11 @@ export const KindsAndStates = (): React.ReactElement => (
               Loading
             </Button>
           </StoryDescriptor>
-          <StoryDescriptor title={`${title} with icon`} inverted={isInverted}>
+          <StoryDescriptor
+            title={`${title} with icon`}
+            inverted={isInverted}
+            dmOnlyInverted={isDmOnlyInverted}
+          >
             <Button kind={kind} icon={ExampleIcon}>
               {title}
             </Button>
@@ -114,6 +126,7 @@ export const KindsAndStates = (): React.ReactElement => (
           <StoryDescriptor
             title={`${title} with icon only`}
             inverted={isInverted}
+            dmOnlyInverted={isDmOnlyInverted}
           >
             <Button kind={kind} icon={ExampleIcon} />
             <Button kind={kind} icon={ExampleIcon} disabled />

--- a/packages/react-components/src/components/Button/styles/kind.scss
+++ b/packages/react-components/src/components/Button/styles/kind.scss
@@ -170,6 +170,7 @@
 }
 
 @mixin link-inverted() {
+  text-decoration: underline;
   color: var(--content-invert-primary);
 
   &:hover {

--- a/packages/react-components/src/components/Button/styles/kind.scss
+++ b/packages/react-components/src/components/Button/styles/kind.scss
@@ -270,37 +270,37 @@
   }
 }
 
-@mixin primary-lock-black() {
+@mixin plain-lock-black() {
   border-color: transparent;
-  background-color: var(--surface-locked-black);
+  background-color: var(--action-lock-default);
   color: var(--content-locked-white);
 
   &:hover {
-    background-color: var(--surface-locked-dark);
+    background-color: var(--action-lock-hover);
   }
 
   &[aria-disabled='true'] {
-    background-color: var(--action-high-contrast-disabled);
+    background-color: var(--action-lock-disabled);
   }
 }
 
-@mixin lock-black() {
+@mixin text-lock-black() {
   border: 0;
   background-color: transparent;
   padding: 0;
   height: auto;
   text-decoration: underline;
-  color: var(--content-locked-black);
+  color: var(--action-lock-default);
 
   &:hover {
-    color: var(--content-locked-black);
+    color: var(--action-lock-hover);
   }
 
   &:active {
-    color: var(--content-locked-black);
+    color: var(--action-lock-active);
   }
 
   &[aria-disabled='true'] {
-    color: var(--content-invert-disabled);
+    color: var(--action-lock-disabled);
   }
 }

--- a/packages/react-components/src/components/Button/styles/kind.scss
+++ b/packages/react-components/src/components/Button/styles/kind.scss
@@ -269,3 +269,38 @@
     background-color: var(--action-high-contrast-disabled);
   }
 }
+
+@mixin primary-lock-black() {
+  border-color: transparent;
+  background-color: var(--surface-locked-black);
+  color: var(--content-locked-white);
+
+  &:hover {
+    background-color: var(--surface-locked-dark);
+  }
+
+  &[aria-disabled='true'] {
+    background-color: var(--action-high-contrast-disabled);
+  }
+}
+
+@mixin lock-black() {
+  border: 0;
+  background-color: transparent;
+  padding: 0;
+  height: auto;
+  text-decoration: underline;
+  color: var(--content-locked-black);
+
+  &:hover {
+    color: var(--content-locked-black);
+  }
+
+  &:active {
+    color: var(--content-locked-black);
+  }
+
+  &[aria-disabled='true'] {
+    color: var(--content-invert-disabled);
+  }
+}

--- a/packages/react-components/src/components/Button/types.ts
+++ b/packages/react-components/src/components/Button/types.ts
@@ -12,7 +12,7 @@ export type ButtonKind =
   | 'float'
   | 'dotted'
   | 'high-contrast'
-  | 'primary-lock-black'
-  | 'lock-black';
+  | 'plain-lock-black'
+  | 'text-lock-black';
 
 export type ButtonSize = 'xcompact' | 'compact' | 'medium' | 'large';

--- a/packages/react-components/src/components/Button/types.ts
+++ b/packages/react-components/src/components/Button/types.ts
@@ -11,6 +11,8 @@ export type ButtonKind =
   | 'plain'
   | 'float'
   | 'dotted'
-  | 'high-contrast';
+  | 'high-contrast'
+  | 'primary-lock-black'
+  | 'lock-black';
 
 export type ButtonSize = 'xcompact' | 'compact' | 'medium' | 'large';

--- a/packages/react-components/src/components/Icon/Icon.module.scss
+++ b/packages/react-components/src/components/Icon/Icon.module.scss
@@ -134,5 +134,9 @@
     &--action-neutral {
       color: var(--action-neutral-disabled);
     }
+
+    &--lock-black {
+      color: var(--content-lock-black);
+    }
   }
 }

--- a/packages/react-components/src/components/Icon/Icon.tsx
+++ b/packages/react-components/src/components/Icon/Icon.tsx
@@ -22,7 +22,8 @@ export type IconKind =
   | 'action-negative'
   | 'action-positive'
   | 'action-warning'
-  | 'action-neutral';
+  | 'action-neutral'
+  | 'lock-black';
 
 const IconSizeMap: Record<IconSize, { width: number; height: number }> = {
   xsmall: {

--- a/packages/react-components/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/react-components/src/components/Tooltip/Tooltip.module.scss
@@ -107,10 +107,6 @@ $radius: var(--radius-3);
 
     &-secondary {
       margin-left: var(--spacing-4);
-
-      &-invert {
-        color: var(--content-invert-primary);
-      }
     }
 
     &--interactive {

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -13,6 +13,8 @@ import beautifulImage from './placeholder.png';
 import { Tooltip } from './Tooltip';
 import { ITooltipProps } from './types';
 
+const kinds: Array<ITooltipProps['kind']> = [undefined, 'invert', 'important'];
+
 export default {
   title: 'Components/Tooltip',
   component: Tooltip,
@@ -69,35 +71,24 @@ Default.decorators = [
 
 export const Kinds = (): React.ReactElement => (
   <>
-    <StoryDescriptor title="Default">
-      <Tooltip
-        placement="right"
-        isVisible
-        triggerRenderer={<Button>Trigger</Button>}
-      >
-        Simple text content
-      </Tooltip>
-    </StoryDescriptor>
-    <StoryDescriptor title="Invert">
-      <Tooltip
-        placement="right"
-        isVisible
-        kind="invert"
-        triggerRenderer={<Button>Trigger</Button>}
-      >
-        Simple text content
-      </Tooltip>
-    </StoryDescriptor>
-    <StoryDescriptor title="Important">
-      <Tooltip
-        placement="right"
-        isVisible
-        kind="important"
-        triggerRenderer={<Button>Trigger</Button>}
-      >
-        Simple text content
-      </Tooltip>
-    </StoryDescriptor>
+    {kinds.map((kind) => {
+      const title = kind
+        ? kind.charAt(0).toUpperCase() + kind.slice(1)
+        : 'Default';
+
+      return (
+        <StoryDescriptor title={title}>
+          <Tooltip
+            placement="right"
+            isVisible
+            kind={kind}
+            triggerRenderer={<Button>Trigger</Button>}
+          >
+            Simple text content
+          </Tooltip>
+        </StoryDescriptor>
+      );
+    })}
   </>
 );
 

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ComponentMeta, StoryFn } from '@storybook/react';
 
+import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
 import noop from '../../utils/noop';
 import { Button } from '../Button';
 
@@ -65,6 +66,40 @@ Default.decorators = [
     </div>
   ),
 ];
+
+export const Kinds = (): React.ReactElement => (
+  <>
+    <StoryDescriptor title="Default">
+      <Tooltip
+        placement="right"
+        isVisible
+        triggerRenderer={<Button>Trigger</Button>}
+      >
+        Simple text content
+      </Tooltip>
+    </StoryDescriptor>
+    <StoryDescriptor title="Invert">
+      <Tooltip
+        placement="right"
+        isVisible
+        kind="invert"
+        triggerRenderer={<Button>Trigger</Button>}
+      >
+        Simple text content
+      </Tooltip>
+    </StoryDescriptor>
+    <StoryDescriptor title="Important">
+      <Tooltip
+        placement="right"
+        isVisible
+        kind="important"
+        triggerRenderer={<Button>Trigger</Button>}
+      >
+        Simple text content
+      </Tooltip>
+    </StoryDescriptor>
+  </>
+);
 
 export const TooltipInfo = (args: ITooltipProps): React.ReactElement => (
   <Tooltip {...args} triggerRenderer={<Button>Trigger</Button>}>

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -102,6 +102,7 @@ export const Kinds = (): React.ReactElement => (
 export const TooltipInfo = (args: ITooltipProps): React.ReactElement => (
   <Tooltip {...args} triggerRenderer={<Button>Trigger</Button>}>
     <Info
+      theme={args.kind || args.theme}
       header="Header - concise and clear"
       text="Tooltip content is used to explain the details of elements or features."
       closeWithX
@@ -123,6 +124,7 @@ TooltipInfo.decorators = [
 export const TooltipInteractive = (args: ITooltipProps): React.ReactElement => (
   <Tooltip {...args} triggerRenderer={<Button>Trigger</Button>}>
     <Interactive
+      theme={args.kind || args.theme}
       header="Header - concise and clear"
       image={{
         src: beautifulImage,

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -25,6 +25,13 @@ export default {
     useDismissHookProps: {
       control: false,
     },
+    theme: {
+      options: ['invert', 'important', undefined],
+      control: {
+        type: 'select',
+        labels: 'Theme',
+      },
+    },
     kind: {
       options: ['invert', 'important', undefined],
       control: {

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -22,7 +22,7 @@ import cx from 'clsx';
 
 import { Text } from '../Typography';
 
-import { getArrowPositionStyles } from './helpers';
+import { getArrowPositionStyles, getArrowTokens } from './helpers';
 import { ITooltipProps } from './types';
 
 import styles from './Tooltip.module.scss';
@@ -176,8 +176,6 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
           <FloatingArrow
             ref={arrowRef}
             context={context}
-            stroke="var(--tooltip-border-for-svg)"
-            fill="var(--tooltip-background-basic)"
             strokeWidth={1}
             width={10}
             height={5}
@@ -189,6 +187,7 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
                 arrowX
               ),
             }}
+            {...getArrowTokens(tooltipStyle)}
           />
         </div>
       )}

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -171,7 +171,11 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
           data-status={status}
         >
           <Text as="div" className={styles[`${baseClass}__content`]}>
-            {children}
+            {React.isValidElement(children)
+              ? React.cloneElement(children as React.ReactElement, {
+                  theme: kind || theme,
+                })
+              : children}
           </Text>
           <FloatingArrow
             ref={arrowRef}

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -171,11 +171,7 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
           data-status={status}
         >
           <Text as="div" className={styles[`${baseClass}__content`]}>
-            {React.isValidElement(children)
-              ? React.cloneElement(children as React.ReactElement, {
-                  theme: kind || theme,
-                })
-              : children}
+            {children}
           </Text>
           <FloatingArrow
             ref={arrowRef}

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -39,6 +39,10 @@ export const Interactive: React.FC<{
       return 'secondary';
     }
 
+    if (theme === 'important') {
+      return 'primary-lock-black';
+    }
+
     return 'high-contrast';
   };
 
@@ -81,12 +85,17 @@ export const Interactive: React.FC<{
         >
           {primaryButton.label}
         </Button>
+        {/* // secondary button => if important = lock-black (like text) */}
         <Button
           className={cx(styles[`${baseClass}-footer-secondary`], {
             [styles[`${baseClass}-footer-secondary-invert`]]:
               theme === 'invert',
           })}
-          kind={secondaryButton.kind || 'text'}
+          kind={
+            secondaryButton.kind || theme === 'important'
+              ? 'lock-black'
+              : 'text'
+          }
           onClick={secondaryButton.handleClick}
         >
           {secondaryButton.label}

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -40,7 +40,7 @@ export const Interactive: React.FC<{
     }
 
     if (theme === 'important') {
-      return 'primary-lock-black';
+      return 'plain-lock-black';
     }
 
     return 'high-contrast';
@@ -85,7 +85,6 @@ export const Interactive: React.FC<{
         >
           {primaryButton.label}
         </Button>
-        {/* // secondary button => if important = lock-black (like text) */}
         <Button
           className={cx(styles[`${baseClass}-footer-secondary`], {
             [styles[`${baseClass}-footer-secondary-invert`]]:
@@ -93,7 +92,7 @@ export const Interactive: React.FC<{
           })}
           kind={
             secondaryButton.kind || theme === 'important'
-              ? 'lock-black'
+              ? 'text-lock-black'
               : 'text'
           }
           onClick={secondaryButton.handleClick}

--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -46,6 +46,18 @@ export const Interactive: React.FC<{
     return 'high-contrast';
   };
 
+  const getDefaultSecondaryButtonKind = (theme?: TooltipTheme) => {
+    if (theme === 'invert') {
+      return 'link-inverted';
+    }
+
+    if (theme === 'important') {
+      return 'text-lock-black';
+    }
+
+    return 'text';
+  };
+
   return (
     <div className={styles[`${baseClass}__interactive`]}>
       {closeWithX && (
@@ -86,15 +98,8 @@ export const Interactive: React.FC<{
           {primaryButton.label}
         </Button>
         <Button
-          className={cx(styles[`${baseClass}-footer-secondary`], {
-            [styles[`${baseClass}-footer-secondary-invert`]]:
-              theme === 'invert',
-          })}
-          kind={
-            secondaryButton.kind || theme === 'important'
-              ? 'text-lock-black'
-              : 'text'
-          }
+          className={cx(styles[`${baseClass}-footer-secondary`])}
+          kind={secondaryButton.kind || getDefaultSecondaryButtonKind(theme)}
           onClick={secondaryButton.handleClick}
         >
           {secondaryButton.label}

--- a/packages/react-components/src/components/Tooltip/helpers.ts
+++ b/packages/react-components/src/components/Tooltip/helpers.ts
@@ -41,3 +41,23 @@ export function getArrowPositionStyles(
 
   return;
 }
+
+export const getArrowTokens = (tooltipStyle: string | undefined) => {
+  switch (tooltipStyle) {
+    case 'invert':
+      return {
+        stroke: 'var(--tooltip-background-invert)',
+        fill: 'var(--tooltip-background-invert)',
+      };
+    case 'important':
+      return {
+        stroke: 'var(--surface-accent-emphasis-high-warning)',
+        fill: 'var(--surface-accent-emphasis-high-warning)',
+      };
+    default:
+      return {
+        stroke: 'var(--tooltip-border-for-svg)',
+        fill: 'var(--tooltip-background-basic)',
+      };
+  }
+};

--- a/packages/react-components/src/components/Tooltip/helpers.ts
+++ b/packages/react-components/src/components/Tooltip/helpers.ts
@@ -8,6 +8,8 @@ export function getIconType(theme: TooltipTheme): IconKind {
   switch (theme) {
     case 'invert':
       return 'inverted';
+    case 'important':
+      return 'lock-black';
     default:
       return 'primary';
   }

--- a/packages/react-components/src/foundations/design-token.ts
+++ b/packages/react-components/src/foundations/design-token.ts
@@ -358,6 +358,10 @@ export const DesignToken = {
   AnimatedGradientValue3: '--animated-gradient-value-3',
   ContentBasicInternalNote: '--content-basic-internal-note',
   ContentBasicBot: '--content-basic-bot',
+  ActionLockDefault: '--action-lock-default',
+  ActionLockHover: '--action-lock-hover',
+  ActionLockActive: '--action-lock-active',
+  ActionLockDisabled: '--action-lock-disabled',
 };
 
 export type DesignTokenKey = keyof typeof DesignToken;

--- a/packages/react-components/src/stories/components/StoryDescriptor.tsx
+++ b/packages/react-components/src/stories/components/StoryDescriptor.tsx
@@ -5,17 +5,26 @@ import cx from 'clsx';
 interface StoryDescriptorProps extends React.HTMLAttributes<HTMLDivElement> {
   title: string;
   inverted?: boolean;
+  dmOnlyInverted?: boolean;
   gap?: string;
 }
 
 export const StoryDescriptor: React.FC<
   React.PropsWithChildren<StoryDescriptorProps>
-> = ({ title, children, inverted, gap, ...props }) => (
+> = ({ title, children, inverted, gap, dmOnlyInverted, ...props }) => (
   <div
-    className={cx('story-container', { 'story-container-inverted': inverted })}
+    className={cx('story-container', {
+      'story-container-inverted': inverted,
+      'story-container-dm-only-inverted': dmOnlyInverted,
+    })}
     {...props}
   >
-    <div className={cx('story-title', { 'story-title-inverted': inverted })}>
+    <div
+      className={cx('story-title', {
+        'story-title-inverted': inverted,
+        'story-title-dm-only-inverted': dmOnlyInverted,
+      })}
+    >
       {title}
     </div>
     <div className="story-spacer" style={{ gap }}>

--- a/packages/react-components/src/stories/foundations/Color/Color.stories.mdx
+++ b/packages/react-components/src/stories/foundations/Color/Color.stories.mdx
@@ -214,6 +214,7 @@ Borders used on inverted surfaces
 - [Warning](#Warning)
 - [Neutral](#Neutral)
 - [High-Contrast](#High-Contrast)
+- [Lock](#Lock)
 
 Action colors refer to the colors used to prompt user action or interaction within a design.
 
@@ -250,6 +251,10 @@ Colors for neutral CTA’s surfaces, borders and content. Not primary interactiv
 ### High-Contrast <a id="High-Contrast" />
 
 <ColorTable data={getColorsByGroup(ColorGroup.ActionHighContrast)}></ColorTable>
+
+### Lock <a id="Lock" />
+
+<ColorTable data={getColorsByGroup(ColorGroup.ActionLock)}></ColorTable>
 
 ## Illustration <a id="Illustration" />
 

--- a/packages/react-components/src/stories/foundations/Color/data.ts
+++ b/packages/react-components/src/stories/foundations/Color/data.ts
@@ -111,6 +111,26 @@ export const ColorsData: Record<
     desc: 'Hover state for warning actions (tags)',
     deprecated: false,
   },
+  ActionLockDefault: {
+    group: ColorGroup.ActionLock,
+    desc: '',
+    deprecated: false,
+  },
+  ActionLockHover: {
+    group: ColorGroup.ActionLock,
+    desc: '',
+    deprecated: false,
+  },
+  ActionLockActive: {
+    group: ColorGroup.ActionLock,
+    desc: '',
+    deprecated: false,
+  },
+  ActionLockDisabled: {
+    group: ColorGroup.ActionLock,
+    desc: '',
+    deprecated: false,
+  },
   Background: {
     group: ColorGroup.Background,
     desc: 'Common background',

--- a/packages/react-components/src/stories/foundations/Color/types.ts
+++ b/packages/react-components/src/stories/foundations/Color/types.ts
@@ -30,6 +30,7 @@ export enum ColorGroup {
   ActionWarning,
   ActionNeutral,
   ActionHighContrast,
+  ActionLock,
   Illustration,
   Products,
   Decor,

--- a/packages/react-components/src/themes/dark.scss
+++ b/packages/react-components/src/themes/dark.scss
@@ -347,4 +347,8 @@ $surface-invert-primary: #e2e2e4;
   --animated-gradient-value-3: rgb(59 59 67 / 0%) 99.89%;
   --content-basic-internal-note: #efcf8d;
   --content-basic-bot: #f3e7fe;
+  --action-lock-default: #1B1B20;
+  --action-lock-hover: #131317;
+  --action-lock-active: #131317;
+  --action-lock-disabled:hsl(240deg 8% 12% / 20%);
 }

--- a/packages/react-components/src/themes/legacy.scss
+++ b/packages/react-components/src/themes/legacy.scss
@@ -334,4 +334,8 @@ $decor-gray800: #29292f;
   --animated-gradient-value-3: rgb(226 226 228 / 0%) 99.89%;
   --content-basic-internal-note: #3a310c;
   --content-basic-bot: #00003e;
+  --action-lock-default: #1B1B20;
+  --action-lock-hover: #131317;
+  --action-lock-active: #131317;
+  --action-lock-disabled:hsl(240deg 8% 12% / 20%);
 }

--- a/packages/react-components/src/themes/light.scss
+++ b/packages/react-components/src/themes/light.scss
@@ -344,4 +344,8 @@ $decor-gray800: #29292f;
   --animated-gradient-value-3: rgb(226 226 228 / 0%) 99.89%;
   --content-basic-internal-note: #3a310c;
   --content-basic-bot: #00003e;
+  --action-lock-default: #1B1B20;
+  --action-lock-hover: #131317;
+  --action-lock-active: #131317;
+  --action-lock-disabled:hsl(240deg 8% 12% / 20%);
 }


### PR DESCRIPTION
<!--- Issue number will be inserted automatically -->
Resolves: #{issue-number}

## Description
Correct color tokens for `FloatingArrow` in different tooltip kinds.
New story "Kinds" to show every possible tooltip kind.

Added new `Button` kinds (`plain-lock-black` and `text-lock-black`) to cover `Important` kind UI requirements.
Added new `Icon` kind (`lock-black`) to cover `Important` kind UI requirements.
Added new color tokens to cover new `Button` kinds requirements.

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-tooltip-arrow-color-fix--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
