### PR TITLE
fix(Tag): change element html tag to prevent button nesting errors

### DIFF
--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -117,11 +117,11 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
         )}
       </div>
       {onRemove && !disabled && (
-        <button
+        <span
           tabIndex={-1}
           title="Remove"
           onClick={onRemove}
-          type="button"
+          role="button"
           aria-label="Remove tag"
           className={cx(styles[`${baseClass}__remove`], {
             [styles[`${baseClass}__remove--hover`]]: isOnHoverCloseButton,
@@ -133,7 +133,7 @@ export const Tag: React.FC<React.PropsWithChildren<TagProps>> = ({
             size={closeIconSize}
             customColor={getIconCustomColor()}
           />
-        </button>
+        </span>
       )}
     </Text>
   );


### PR DESCRIPTION
<!--- Issue number will be inserted automatically -->
Resolves: #{issue-number}

## Description
Change HTML tag for close button in `Tag` component, to prevent button nesting errors in case, when component is rendered in the `Picker` with `multi-picker` mode.

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-1071--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
