### PR TITLE
fix(Picker): PickerList height initial value calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23096,9 +23096,9 @@
       }
     },
     "node_modules/react-virtuoso": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.6.2.tgz",
-      "integrity": "sha512-vvlqvzPif+MvBrJ09+hJJrVY0xJK9yran+A+/1iwY78k0YCVKsyoNPqoLxOxzYPggspNBNXqUXEcvckN29OxyQ==",
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.11.tgz",
+      "integrity": "sha512-Kdn9qEtQI2ulEuBMzW2BTkDsfijB05QUd6lpZ1K36oyA3k65Cz4lG4EKrh2pCfUafX4C2uMSZOwzMOhbrMOTFA==",
       "engines": {
         "node": ">=10"
       },
@@ -28100,7 +28100,7 @@
         "polished": "^4.1.3",
         "react-day-picker": "^7.4.10",
         "react-transition-group": "^4.4.2",
-        "react-virtuoso": "^4.6.2"
+        "react-virtuoso": "^4.7.11"
       },
       "devDependencies": {
         "@storybook/addon-a11y": "^7.6.8",
@@ -31345,7 +31345,7 @@
         "react-day-picker": "^7.4.10",
         "react-dom": "^17.0.2",
         "react-transition-group": "^4.4.2",
-        "react-virtuoso": "^4.6.2",
+        "react-virtuoso": "^4.7.11",
         "rollup-plugin-scss": "^4.0.0",
         "sass": "^1.49.9",
         "storybook": "^7.6.8",
@@ -45021,9 +45021,9 @@
       }
     },
     "react-virtuoso": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.6.2.tgz",
-      "integrity": "sha512-vvlqvzPif+MvBrJ09+hJJrVY0xJK9yran+A+/1iwY78k0YCVKsyoNPqoLxOxzYPggspNBNXqUXEcvckN29OxyQ==",
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.7.11.tgz",
+      "integrity": "sha512-Kdn9qEtQI2ulEuBMzW2BTkDsfijB05QUd6lpZ1K36oyA3k65Cz4lG4EKrh2pCfUafX4C2uMSZOwzMOhbrMOTFA==",
       "requires": {}
     },
     "read": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -83,6 +83,6 @@
     "polished": "^4.1.3",
     "react-day-picker": "^7.4.10",
     "react-transition-group": "^4.4.2",
-    "react-virtuoso": "^4.6.2"
+    "react-virtuoso": "^4.7.11"
   }
 }

--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -6,7 +6,7 @@ import cx from 'clsx';
 import { PickerList } from './components/PickerList';
 import { PickerTrigger } from './components/PickerTrigger';
 import { PickerTriggerBody } from './components/PickerTriggerBody';
-import { DEFAULT_LIST_HEIGHT } from './constants';
+import { DEFAULT_LIST_HEIGHT, MIN_LIST_HEIGHT } from './constants';
 import { useFloatingPicker } from './hooks/useFloatingPicker';
 import { usePickerItems } from './hooks/usePickerItems';
 import { IPickerProps } from './types';
@@ -17,6 +17,7 @@ export const Picker: React.FC<IPickerProps> = ({
   id,
   className,
   listClassName,
+  minListHeight = MIN_LIST_HEIGHT,
   maxListHeight = DEFAULT_LIST_HEIGHT,
   disabled,
   error,
@@ -94,6 +95,7 @@ export const Picker: React.FC<IPickerProps> = ({
     disabled,
     items,
     placement,
+    minListHeight,
     maxListHeight,
     floatingStrategy,
     useClickHookProps,

--- a/packages/react-components/src/components/Picker/components/PickerList.tsx
+++ b/packages/react-components/src/components/Picker/components/PickerList.tsx
@@ -56,7 +56,7 @@ export const PickerList: React.FC<IPickerListProps> = ({
   listClassName,
   virtuosoProps,
 }) => {
-  const [listHeight, setListHeight] = React.useState(maxHeight);
+  const [listHeight, setListHeight] = React.useState(0);
   const numberOfItems = options.length;
 
   const handleListHeightChange = React.useCallback(

--- a/packages/react-components/src/components/Picker/constants.ts
+++ b/packages/react-components/src/components/Picker/constants.ts
@@ -1,8 +1,7 @@
 import { DayMode } from '@livechat/design-system-icons';
 
-export const ITEM_ROW_HEIGHT = 35;
 export const ITEM_GAP_HEIGHT = 2;
-export const ITEM_HEIGHT = ITEM_ROW_HEIGHT + ITEM_GAP_HEIGHT;
+export const MIN_LIST_HEIGHT = 200;
 export const DEFAULT_LIST_HEIGHT = 400;
 
 export const DEFAULT_PICKER_OPTIONS = [

--- a/packages/react-components/src/components/Picker/hooks/useFloatingPicker.ts
+++ b/packages/react-components/src/components/Picker/hooks/useFloatingPicker.ts
@@ -34,6 +34,7 @@ interface UseFloatingPickerProps {
   useClickHookProps?: UseClickProps;
   useDismissHookProps?: UseDismissProps;
   openedOnInit: boolean;
+  minListHeight: number;
   maxListHeight: number;
   isOpen?: boolean;
   onVisibilityChange?: (open: boolean, event?: Event | undefined) => void;
@@ -67,6 +68,7 @@ export const useFloatingPicker = ({
   disabled,
   items,
   placement,
+  minListHeight,
   maxListHeight,
   floatingStrategy,
   useDismissHookProps,
@@ -96,7 +98,12 @@ export const useFloatingPicker = ({
         floatingSize({
           apply({ availableHeight, rects, elements }) {
             ReactDOM.flushSync(() => {
-              setMaxHeight(maxListHeight || availableHeight);
+              setMaxHeight(
+                Math.max(
+                  Math.min(maxListHeight, availableHeight),
+                  minListHeight
+                )
+              );
             });
             Object.assign(elements.floating.style, {
               width: `${rects.reference.width}px`,

--- a/packages/react-components/src/components/Picker/types.ts
+++ b/packages/react-components/src/components/Picker/types.ts
@@ -47,6 +47,10 @@ export interface IPickerProps extends ComponentCoreProps {
    */
   maxListHeight?: number;
   /**
+   * Specify the min height of the picker list
+   */
+  minListHeight?: number;
+  /**
    * Specify whether the picker should be disabled
    */
   disabled?: boolean;


### PR DESCRIPTION

Resolves: #1098

## Description

- Changing calculation logic for initial height of the list
- updating virtuoso version
- adding minListHeight prop

## Storybook


https://feature-1098--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
