### PR TITLE
feat(Interactive): allow all Button props in tooltip button, make secondButton optional

### DIFF
--- a/packages/react-components/src/components/Tooltip/components/Interactive.tsx
+++ b/packages/react-components/src/components/Tooltip/components/Interactive.tsx
@@ -80,18 +80,26 @@ export const Interactive: React.FC<ITooltipInteractiveProps> = ({
         )}
       >
         <Button
+          {...primaryButton}
           kind={primaryButton.kind || getDefaultPrimaryButtonKind(theme)}
           onClick={primaryButton.handleClick}
         >
           {primaryButton.label}
         </Button>
-        <Button
-          className={cx(styles[`${baseClass}-footer-secondary`])}
-          kind={secondaryButton.kind || getDefaultSecondaryButtonKind(theme)}
-          onClick={secondaryButton.handleClick}
-        >
-          {secondaryButton.label}
-        </Button>
+
+        {secondaryButton && (
+          <Button
+            {...secondaryButton}
+            className={cx(
+              styles[`${baseClass}-footer-secondary`],
+              secondaryButton.className
+            )}
+            kind={secondaryButton.kind || getDefaultSecondaryButtonKind(theme)}
+            onClick={secondaryButton.handleClick}
+          >
+            {secondaryButton.label}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/packages/react-components/src/components/Tooltip/types.ts
+++ b/packages/react-components/src/components/Tooltip/types.ts
@@ -8,15 +8,14 @@ import {
   UseClickProps,
 } from '@floating-ui/react';
 
-import { ButtonKind } from '../Button';
+import { ButtonProps } from '../Button';
 
 export type TooltipTheme = 'invert' | 'important' | undefined;
 
 export type TooltipButton = {
   handleClick: () => void;
   label: string;
-  kind?: ButtonKind;
-};
+} & Omit<ButtonProps, 'onClick'>;
 
 export interface ITooltipProps {
   /**
@@ -201,5 +200,5 @@ export interface ITooltipInteractiveProps {
   /**
    * The Interactive tooltip secondary button props
    */
-  secondaryButton: TooltipButton;
+  secondaryButton?: TooltipButton;
 }


### PR DESCRIPTION
Resolves: #1189 

## Description

This improvement allows more flexibility when using the component:
- The secondary button is now optional
- You can provide all of the props that `Button` has.

For example: before, you couldn't provide an Icon to complement the button - now you can.
Note: existing `Interactive` usage should **not** break or change in any way - this is an API extension and isn't supposed to break current uses of the component

## Storybook

https://feature-1189-tooltip-interactive--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
