### PR TITLE
fix(Tab): reverting role back to button

### DIFF
--- a/packages/react-components/src/components/Tab/Tab.spec.tsx
+++ b/packages/react-components/src/components/Tab/Tab.spec.tsx
@@ -11,31 +11,31 @@ describe('<Tab> component', () => {
   it('should allow for custom class', () => {
     const { getByRole } = renderComponent({ className: 'custom-class' });
 
-    expect(getByRole('tab')).toHaveClass('custom-class');
+    expect(getByRole('button')).toHaveClass('custom-class');
   });
 
   it('should render unselected Tab by default', () => {
     const { getByRole } = renderComponent({});
 
-    expect(getByRole('tab')).not.toHaveAttribute('aria-selected');
+    expect(getByRole('button')).not.toHaveAttribute('aria-selected');
   });
 
   it('should render selected Tab if isSelected is provided', () => {
     const { getByRole } = renderComponent({ isSelected: true });
 
-    expect(getByRole('tab')).toHaveAttribute('aria-selected', 'true');
+    expect(getByRole('button')).toHaveAttribute('aria-selected', 'true');
   });
 
   it('should render disabled Tab if disabled is provided', () => {
     const { getByRole } = renderComponent({ disabled: true });
 
-    expect(getByRole('tab')).toBeDisabled();
+    expect(getByRole('button')).toBeDisabled();
   });
 
   it('should render properly formatted counter', () => {
     const { getByRole } = renderComponent({ count: 1 });
 
-    expect(getByRole('tab')).toHaveTextContent('(1)');
+    expect(getByRole('button')).toHaveTextContent('(1)');
   });
 
   it('should render properly formatted counter as a badge', () => {
@@ -46,7 +46,7 @@ describe('<Tab> component', () => {
 
   it('should render with anchor element if href is provided', () => {
     const { getByRole } = renderComponent({ href: 'http://example.com' });
-    const link = getByRole('tab');
+    const link = getByRole('link');
 
     expect(link).toHaveTextContent('Hello');
     expect(link).toHaveAttribute('href', 'http://example.com');

--- a/packages/react-components/src/components/Tab/Tab.tsx
+++ b/packages/react-components/src/components/Tab/Tab.tsx
@@ -56,7 +56,6 @@ export const Tab: React.FC<React.PropsWithChildren<TabProps>> = ({
     <Text
       {...restProps}
       as={restProps.href ? 'a' : 'button'}
-      role="tab"
       aria-selected={isSelected}
       size="md"
       bold={isSelected}


### PR DESCRIPTION
## Description

Reverting Tab role change to avoid breaking of available tests in AA.
This change will be reintroduced in the new 2.0.0 version of the DS.

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-revert-tab-role-change--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
