### PR TITLE
fix(ActionBar): changing start to flex-start values

### DIFF
--- a/packages/react-components/src/components/ActionBar/ActionBar.module.scss
+++ b/packages/react-components/src/components/ActionBar/ActionBar.module.scss
@@ -138,7 +138,7 @@ $base-class: 'action-bar';
 
     &__trigger-vertical {
       display: flex;
-      align-items: start;
+      align-items: flex-start;
     }
   }
 

--- a/packages/react-components/src/components/Icon/IconsShowcase/style.scss
+++ b/packages/react-components/src/components/Icon/IconsShowcase/style.scss
@@ -3,7 +3,7 @@
   flex-wrap: wrap;
   gap: 8px;
   align-self: stretch;
-  justify-content: start;
+  justify-content: flex-start;
   padding: var(--spacing-0);
 }
 


### PR DESCRIPTION

Resolves: #1192

## Description
Fixing mixed support error for CSS `start` values.

## Storybook


https://feature-1192--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
