### PR TITLE
fix(Button): removing hardcoded testId from cloneElement in Button

### DIFF
--- a/packages/react-components/src/components/Button/Button.spec.tsx
+++ b/packages/react-components/src/components/Button/Button.spec.tsx
@@ -32,7 +32,7 @@ describe('<Button> component', () => {
 
   it('should show icon component when "icon" prop has been passed', () => {
     const { getByTestId } = renderButton({
-      icon: <Icon source={Icons.AddCircle} />,
+      icon: <Icon source={Icons.AddCircle} data-testid="button-icon" />,
     });
 
     expect(getByTestId('button-icon')).toBeVisible();

--- a/packages/react-components/src/components/Button/Button.tsx
+++ b/packages/react-components/src/components/Button/Button.tsx
@@ -119,7 +119,6 @@ export const Button = React.forwardRef<
             ),
             disabled,
             size: size === 'xcompact' ? 'small' : 'medium',
-            ['data-testid']: 'button-icon',
           })}
         <div className={styles[`${baseClass}__content`]}>{children}</div>
       </Component>


### PR DESCRIPTION
## Description
Removing testId from button's icon component as it will override consumer's testid

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-{issue-number}--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add reviewers (`livechat/design-system`)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue
