### PR TITLE
fix(Tooltip): adding triggerOnHover prop to allow enabling both handlers

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.spec.tsx
@@ -70,6 +70,7 @@ describe('<Tooltip> component', () => {
   it(`should show tooltip on trigger click and hide it on second click`, async () => {
     const { queryByRole, getByRole } = renderComponent({
       ...defaultProps,
+      triggerOnHover: false,
       triggerOnClick: true,
     });
     const button = getByRole('button');

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -53,6 +53,7 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
   hoverOnDelay,
   hoverOffDelay,
   triggerOnClick = false,
+  triggerOnHover = true,
   offsetMainAxis = 8,
   referenceElement,
   activationThreshold = 0,
@@ -131,7 +132,7 @@ export const Tooltip: React.FC<React.PropsWithChildren<ITooltipProps>> = ({
       open: getTransitionDelay(hoverOnDelay),
       close: getTransitionDelay(hoverOffDelay || hoverOutDelayTimeout),
     },
-    enabled: !triggerOnClick,
+    enabled: triggerOnHover,
     handleClose: closeOnTriggerBlur ? null : safePolygon(),
   });
   const focus = useFocus(context);

--- a/packages/react-components/src/components/Tooltip/types.ts
+++ b/packages/react-components/src/components/Tooltip/types.ts
@@ -97,6 +97,10 @@ export interface ITooltipProps {
    */
   triggerOnClick?: boolean;
   /**
+   * Set if you want to show tooltip after trigger hover if state is not managed
+   */
+  triggerOnHover?: boolean;
+  /**
    * Set the tooltip distance from the trigger
    */
   offsetMainAxis?: number;


### PR DESCRIPTION
<!--- Issue number will be inserted automatically -->
Resolves: [Slack Thread](https://text.slack.com/archives/CA945NPQR/p1719228311436989) 

## Description

Adding the `triggerOnHover` prop to allow enabling both (onHover and onClick) handlers simultaneously.

## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-tooltip-hover-click-fix--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
