### PR TITLE
fix(Picker): onClose, onOpen callbacks fixes

### DIFF
--- a/packages/react-components/src/components/Picker/Picker.spec.tsx
+++ b/packages/react-components/src/components/Picker/Picker.spec.tsx
@@ -12,7 +12,6 @@ import { DEFAULT_PICKER_OPTIONS } from './constants';
 import { Picker } from './Picker';
 import { PickerType, IPickerProps } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 window.HTMLElement.prototype.scrollIntoView = () => {};
 
 const defaultProps = {
@@ -58,9 +57,11 @@ describe('<Picker> component', () => {
 
   it('should call onSelect with selected item', () => {
     const onSelect = vi.fn();
+    const onClose = vi.fn();
     const { getByText } = renderComponent({
       ...defaultProps,
       onSelect,
+      onClose,
     });
 
     userEvent.click(getByText('Select option'));
@@ -71,22 +72,27 @@ describe('<Picker> component', () => {
         name: 'Option three',
       },
     ]);
+    expect(onClose).toHaveBeenCalledTimes(1); // it was visible, it should be closed after selection
   });
 
   it('should call onSelect with null after clearing the selection', () => {
     const onSelect = vi.fn();
+    const onClose = vi.fn();
     const { getByTestId } = renderComponent({
       ...defaultProps,
       selected: [{ key: 'three', name: 'Option three' }],
       onSelect,
+      onClose,
     });
 
     userEvent.click(getByTestId('picker-trigger__clear-icon'));
     expect(onSelect).toHaveBeenCalledWith(null);
+    expect(onClose).not.toHaveBeenCalled(); // because it was not visible
   });
 
   it('should call onSelect includes the currently selected options in multiselect mode', () => {
     const onSelect = vi.fn();
+    const onClose = vi.fn();
     const stepOneState = [{ key: 'two', name: 'Option two' }];
     const stepTwoState = [
       { key: 'two', name: 'Option two' },
@@ -101,26 +107,31 @@ describe('<Picker> component', () => {
       ...defaultProps,
       type: 'multi' as PickerType,
       onSelect,
+      onClose,
     };
     const { getByText, rerender } = renderComponent(props);
 
     userEvent.click(getByText('Select option'));
     userEvent.click(getByText('Option two'));
     expect(onSelect).toHaveBeenCalledWith(stepOneState);
+    expect(onClose).not.toHaveBeenCalled(); // because it is multiselect mode
 
     rerender(<Picker {...props} selected={stepOneState} />);
 
     userEvent.click(getByText('Option four'));
     expect(onSelect).toHaveBeenCalledWith(stepTwoState);
+    expect(onClose).not.toHaveBeenCalled(); // because it is multiselect mode
 
     rerender(<Picker {...props} selected={stepTwoState} />);
 
     userEvent.click(getByText('Option seven'));
     expect(onSelect).toHaveBeenCalledWith(stepThreeState);
+    expect(onClose).not.toHaveBeenCalled(); // because it is multiselect mode
   });
 
   it('should call onSelect with all correct elements in multiselect mode if "Select all" option is chosen', () => {
     const onSelect = vi.fn();
+    const onClose = vi.fn();
     const expectedResult = [
       { key: 'one', name: 'Option one' },
       { key: 'three', name: 'Option three' },
@@ -145,6 +156,7 @@ describe('<Picker> component', () => {
     userEvent.click(getByText('Select option'));
     userEvent.click(getByText('Select all'));
     expect(onSelect).toHaveBeenCalledWith(expectedResult);
+    expect(onClose).not.toHaveBeenCalled(); // because it is multiselect mode
   });
 
   it('should render given placeholder text if no item selected', () => {
@@ -195,24 +207,30 @@ describe('<Picker> component', () => {
   });
 
   it('should not open list if isVisible is set to false (controlled mode) after user click', () => {
+    const onOpen = vi.fn();
     const { queryByTestId, getByRole } = renderComponent({
       ...defaultProps,
       isVisible: false,
+      onOpen,
     });
 
     expect(queryByTestId('picker-list')).not.toBeInTheDocument();
     userEvent.click(getByRole('combobox'));
+    expect(onOpen).toHaveBeenCalledTimes(1);
     expect(queryByTestId('picker-list')).not.toBeInTheDocument();
   });
 
   it('should not close list if isVisible is set to true (controlled mode) after user click', () => {
+    const onClose = vi.fn();
     const { queryByTestId } = renderComponent({
       ...defaultProps,
       isVisible: true,
+      onClose,
     });
 
     expect(queryByTestId('picker-list')).toBeInTheDocument();
     userEvent.click(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
     expect(queryByTestId('picker-list')).toBeInTheDocument();
   });
 
@@ -226,9 +244,9 @@ describe('<Picker> component', () => {
     });
 
     userEvent.click(getByRole('combobox'));
-    expect(onOpen).toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalledTimes(1);
     userEvent.click(document.body);
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('should clear search input after selection if clearSearchAfterSelection is provided (multi-select mode)', () => {

--- a/packages/react-components/src/components/Picker/Picker.spec.tsx
+++ b/packages/react-components/src/components/Picker/Picker.spec.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_PICKER_OPTIONS } from './constants';
 import { Picker } from './Picker';
 import { PickerType, IPickerProps } from './types';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 window.HTMLElement.prototype.scrollIntoView = () => {};
 
 const defaultProps = {

--- a/packages/react-components/src/components/Picker/Picker.stories.tsx
+++ b/packages/react-components/src/components/Picker/Picker.stories.tsx
@@ -141,9 +141,9 @@ export const PickerWithMoreOptions = (): React.ReactElement => (
   </div>
 );
 
-const CustomPickerOption: React.FC = ({ children }) => (
-  <div className="custom-picker-option">{children}</div>
-);
+const CustomPickerOption: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => <div className="custom-picker-option">{children}</div>;
 
 export const PickerWithOptionsAsCustomElements = (): React.ReactElement => (
   <div style={{ ...commonWidth, marginBottom: 320 }}>

--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -49,14 +49,14 @@ export const Picker: React.FC<IPickerProps> = ({
   const isControlled = isVisible !== undefined;
   const isOpen = isControlled ? isVisible : open;
 
-  const handleVisibilityChange = (isOpen: boolean, event?: Event) => {
-    if (isOpen) {
-      onOpen?.(event);
+  const handleVisibilityChange = (newValue: boolean, event?: Event) => {
+    if (newValue) {
+      !isOpen && onOpen?.(event);
     } else {
-      onClose?.(event);
+      isOpen && onClose?.(event);
     }
 
-    !isControlled && setOpen(isOpen);
+    !isControlled && setOpen(newValue);
   };
 
   const {

--- a/packages/react-components/src/components/Picker/hooks/usePickerItems.ts
+++ b/packages/react-components/src/components/Picker/hooks/usePickerItems.ts
@@ -83,12 +83,12 @@ export const usePickerItems = ({
     }
 
     if (type === 'single') {
-      setOpen(false);
       setSelectedKeys(() => {
         item && onSelect([item]);
 
         return [key];
       });
+      setOpen(false);
     } else {
       if (key === SELECT_ALL_OPTION_KEY) {
         if (selectedKeys.length === getNormalizedItems(options).length) {
@@ -127,10 +127,10 @@ export const usePickerItems = ({
   const handleItemRemove = (itemKey: string) => handleSelect(itemKey);
 
   const handleClear = () => {
-    setOpen(false);
-    setSelectedKeys([]);
+    !isDataControlled && setSelectedKeys([]);
     onSelect(null);
     setSearchPhrase('');
+    setOpen(false);
   };
 
   return {


### PR DESCRIPTION
## Description

- Fixing callbacks execution ordering: onClose/onOpen callbacks will be executed after onSelect callback.
- Prevent onOpen/onClose callbacks from firing when the list is already opened/closed.


## Storybook

<!--- Issue number will be inserted automatically -->
https://feature-picker-callbacks-fixes--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add reviewers (`livechat/design-system`)
- [x] Add correct label
- [x] Assign pull request with the correct issue
