### PR TITLE
fix(AppFrame): Fix several NavigationTopBar issues

### DIFF
--- a/packages/react-components/src/components/AppFrame/components/NavigationTopBar/NavigationTopBar.module.scss
+++ b/packages/react-components/src/components/AppFrame/components/NavigationTopBar/NavigationTopBar.module.scss
@@ -22,7 +22,7 @@ $mobile-breakpoint: 768px;
     align-items: center;
     justify-content: space-evenly;
     transition: all var(--transition-duration-moderate-1) ease-in-out;
-    border-radius: var(--radius-2);
+    border-radius: var(--radius-3);
     padding-right: 0;
     padding-left: var(--spacing-10);
     padding-block: 0;

--- a/packages/react-components/src/components/AppFrame/components/NavigationTopBar/NavigationTopBar.tsx
+++ b/packages/react-components/src/components/AppFrame/components/NavigationTopBar/NavigationTopBar.tsx
@@ -105,18 +105,14 @@ export const NavigationTopBarAlert: React.FC<ITopBarAlertProps> = ({
         {primaryCta && (
           <Button
             size="compact"
-            onClick={primaryCta.onClick}
             kind={isMobile ? secondaryCtaKind : primaryCtaKind}
+            {...primaryCta}
           >
             {primaryCta.label}
           </Button>
         )}
         {secondaryCta && (
-          <Button
-            size="compact"
-            onClick={secondaryCta.onClick}
-            kind={secondaryCtaKind}
-          >
+          <Button size="compact" kind={secondaryCtaKind} {...secondaryCta}>
             {secondaryCta.label}
           </Button>
         )}
@@ -144,21 +140,25 @@ export const NavigationTopBarAlert: React.FC<ITopBarAlertProps> = ({
     <>
       {isMounted && (
         <div
-          className={cx(styles[`${alertClass}__wrapper`], {
-            [styles[`${alertClass}__wrapper--open`]]: isOpen,
-          })}
+          className={cx(
+            styles[`${alertClass}__wrapper`],
+            {
+              [styles[`${alertClass}__wrapper--open`]]: isOpen,
+            },
+            'lc-dark-theme' // Alerts are forced into dark mode to maintain consistency of the colors
+          )}
           ref={alertRef}
           role="status"
         >
           <div
             data-testid="navigation-top-bar-alert"
             className={cx(
-              className,
               styles[alertClass],
               styles[`${alertClass}--${kind}`],
               {
                 [styles[`${alertClass}--open`]]: isOpen,
-              }
+              },
+              className
             )}
           >
             {Children}

--- a/packages/react-components/src/components/AppFrame/components/NavigationTopBar/types.ts
+++ b/packages/react-components/src/components/AppFrame/components/NavigationTopBar/types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { ButtonProps } from 'components/Button';
 import { ComponentCoreProps } from 'utils/types';
 
 export type NavigationTopBarKind = 'info' | 'success' | 'warning' | 'error';
@@ -23,6 +24,10 @@ export interface ITopBarTitleProps extends ComponentCoreProps {
   children: React.ReactNode;
 }
 
+type CTAProps = {
+  label: string;
+  onClick: () => void;
+} & Omit<ButtonProps, 'onClick' | 'children'>;
 export interface ITopBarAlertProps extends ComponentCoreProps {
   /**
    * Visual style of the alert. You can also use `className` to style the alert if you need to set a custom background color.
@@ -45,21 +50,15 @@ export interface ITopBarAlertProps extends ComponentCoreProps {
 
   /**
    * Primary CTA button. The button will be rendered if defined.
-   * Simple on purpose - if you need more complex buttons, you can use the `children` prop.
+   * Allows ButtonProps, but `children` is recommended for more complex use-cases.
    * */
-  primaryCta?: {
-    label: string;
-    onClick: () => void;
-  };
+  primaryCta?: CTAProps;
 
   /**
    * Secondary CTA button. The button will be rendered if defined.
-   * Simple on purpose - if you need more complex buttons, you can use the `children` prop.
+   * Allows ButtonProps, but `children` is recommended for more complex use-cases.
    * */
-  secondaryCta?: {
-    label: string;
-    onClick: () => void;
-  };
+  secondaryCta?: CTAProps;
 
   /**
    * Show or hide the alert, defaults to `true`. Changes to this prop are animated - the alert will enter and leave smoothly.


### PR DESCRIPTION
## Description
- styling no longer breaks when a className is added to the `.Alert` component
-  border radii fixed (6px -> 8px)
- the top bar is fixed to be in dark-mod

## Storybook

https://feature-navigation-top-bar-v2--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
