### PR TITLE
fix(ProductSwitcher): lock in dark mode; add textUrl Prop

### DIFF
--- a/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.stories.tsx
+++ b/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.stories.tsx
@@ -66,7 +66,7 @@ export const Default: Story = {
     });
 
     return (
-      <div className="lc-dark-theme" style={{ display: 'flex', height: 500 }}>
+      <div style={{ display: 'flex', height: 500 }}>
         <ProductSwitcher {...props} productOptions={products} />
       </div>
     );

--- a/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.tsx
+++ b/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.tsx
@@ -16,6 +16,7 @@ import {
   useTransitionStyles,
 } from '@floating-ui/react';
 import { TextLogoFull } from '@livechat/design-system-icons';
+import cx from 'clsx';
 
 import { Icon } from '../Icon';
 import { Tooltip } from '../Tooltip';
@@ -37,6 +38,7 @@ export const ProductSwitcher: FC<ProductSwitcherProps> = ({
   onOpen,
   onClose,
   onSelect,
+  textURL = 'https://www.text.com',
 }) => {
   const [isOpen, setIsOpen] = React.useState(openedOnInit);
   const [isTooltipOpen, setIsTooltipOpen] = useState<boolean | undefined>(
@@ -145,7 +147,10 @@ export const ProductSwitcher: FC<ProductSwitcherProps> = ({
           {...getFloatingProps()}
         >
           {isMounted && (
-            <div className={styles[baseClass]} style={transitionStyles}>
+            <div
+              className={cx('lc-dark-theme', styles[baseClass])}
+              style={transitionStyles}
+            >
               <div className={styles[`${baseClass}__content`]}>
                 {productOptions.map((product) => (
                   <ProductRow
@@ -158,7 +163,7 @@ export const ProductSwitcher: FC<ProductSwitcherProps> = ({
               </div>
               <div className={styles[`${baseClass}__footer`]}>
                 <a
-                  href="https://www.text.com"
+                  href={textURL}
                   target="_blank"
                   className={styles[`${baseClass}__footer-link`]}
                   onClick={() => handleVisibilityChange(false)}

--- a/packages/react-components/src/components/ProductSwitcher/types.ts
+++ b/packages/react-components/src/components/ProductSwitcher/types.ts
@@ -23,6 +23,7 @@ export type ProductName =
 export interface ProductSwitcherProps {
   mainProductId: ProductId;
   productOptions: ProductOption[];
+  textURL?: string;
   openedOnInit?: boolean;
   isVisible?: boolean;
   onOpen?: (event?: Event) => void;


### PR DESCRIPTION
## Description
Adding textURL prop and locking switcher in dark mode.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-switcher-tweaks--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue
