### PR TITLE
fix(ActionMenu): change opacity to color token for disabled item

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.module.scss
@@ -115,7 +115,7 @@ $base-class: 'action-menu';
       }
 
       &--disabled {
-        opacity: 0.45;
+        color: var(--content-basic-disabled);
 
         &:hover {
           background: none;


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1309 

## Description
Added color token for a disabled button to show disabled state. Removed the `opacity` prop, which will solve the problem of displaying tooltips for disabled elements.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1309--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue
