### PR TITLE
fix(AppFrame): auto open/close side menu if child element is active

### DIFF
--- a/packages/react-components/src/components/AppFrame/components/NavigationItem/NavigationItem.module.scss
+++ b/packages/react-components/src/components/AppFrame/components/NavigationItem/NavigationItem.module.scss
@@ -38,7 +38,7 @@ $base-class: 'navigation-item';
       color: var(--content-locked-white);
 
       span {
-        transform: scale(1.1);
+        transform: scale(1);
       }
     }
 
@@ -48,7 +48,7 @@ $base-class: 'navigation-item';
       box-shadow: var(--focus-ring-inner);
 
       span {
-        transform: scale(1.1);
+        transform: scale(1);
       }
     }
 
@@ -57,7 +57,7 @@ $base-class: 'navigation-item';
     }
 
     span {
-      transform: scale(1);
+      transform: scale(0.9);
       transition: all var(--transition-duration-fast-1) ease-in-out;
       width: 24px;
       height: 24px;

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
@@ -4,7 +4,12 @@ import { SideNavigationGroup } from './SideNavigationGroup';
 import { ISideNavigationGroupProps } from './types';
 
 const defaultProps = {
-  children: <div>Side navigation group content</div>,
+  children: (
+    <>
+      <li>Option 1</li>
+      <li>Option 2</li>
+    </>
+  ),
 };
 
 const renderComponent = (props: ISideNavigationGroupProps) => {
@@ -24,7 +29,8 @@ describe('<SideNavigationGroup> component', () => {
   it('should render children', () => {
     const { getByText } = renderComponent(defaultProps);
 
-    expect(getByText('Side navigation group content')).toBeInTheDocument();
+    expect(getByText('Option 1')).toBeInTheDocument();
+    expect(getByText('Option 2')).toBeInTheDocument();
   });
 
   it('should render label as provided element', () => {
@@ -94,18 +100,5 @@ describe('<SideNavigationGroup> component', () => {
 
     userEvent.hover(getByText('Side navigation label'));
     expect(onItemHover).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not render children if isCollapsible is set true and isOpen is false', async () => {
-    const { queryByText } = renderComponent({
-      ...defaultProps,
-      isCollapsible: true,
-    });
-
-    await waitFor(() => {
-      expect(
-        queryByText('Side navigation group content')
-      ).not.toBeInTheDocument();
-    });
   });
 });

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
@@ -96,14 +96,16 @@ describe('<SideNavigationGroup> component', () => {
     expect(onItemHover).toHaveBeenCalledTimes(1);
   });
 
-  it('should not render children if isCollapsible is set true and isOpen is false', () => {
+  it('should not render children if isCollapsible is set true and isOpen is false', async () => {
     const { queryByText } = renderComponent({
       ...defaultProps,
       isCollapsible: true,
     });
 
-    expect(
-      queryByText('Side navigation group content')
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        queryByText('Side navigation group content')
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
@@ -101,4 +101,34 @@ describe('<SideNavigationGroup> component', () => {
     userEvent.hover(getByText('Side navigation label'));
     expect(onItemHover).toHaveBeenCalledTimes(1);
   });
+
+  it('should not render children if isCollapsible is set true and there is no active option', async () => {
+    const { queryByText } = renderComponent({
+      ...defaultProps,
+      isCollapsible: true,
+    });
+
+    await waitFor(() => {
+      expect(queryByText('Option 1')).not.toBeInTheDocument();
+      expect(queryByText('Option 2')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should render children if isCollapsible is set true and there is active option', async () => {
+    const { queryByText } = renderComponent({
+      ...defaultProps,
+      isCollapsible: true,
+      children: (
+        <>
+          <li data-active="true">Option 1</li>
+          <li>Option 2</li>
+        </>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(queryByText('Option 1')).toBeInTheDocument();
+      expect(queryByText('Option 2')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
@@ -32,7 +32,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   const hadActiveListElementsRef = React.useRef(false);
   const listWrapperRef = React.useRef<HTMLDivElement>(null);
   const { isOpen, isMounted, setShouldBeVisible } = useAnimations({
-    isVisible: !isCollapsible || shouldOpenOnInit,
+    isVisible: isCollapsible || shouldOpenOnInit,
     elementRef: listWrapperRef,
   });
   const localRightNode =
@@ -40,6 +40,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   const localLabel = typeof label === 'function' ? label(isOpen) : label;
 
   const openList = (): void => setShouldBeVisible(true);
+  const closeList = (): void => setShouldBeVisible(false);
 
   const toggle = (): void => {
     if (!isCollapsible) return;
@@ -63,6 +64,10 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   React.useEffect(() => {
     if (!shouldOpenOnActive) {
       return;
+    }
+
+    if (!hasActiveElements) {
+      closeList();
     }
 
     if (!hadActiveListElementsRef.current && hasActiveElements) {

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
@@ -32,7 +32,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   const hadActiveListElementsRef = React.useRef(false);
   const listWrapperRef = React.useRef<HTMLDivElement>(null);
   const { isOpen, isMounted, setShouldBeVisible } = useAnimations({
-    isVisible: isCollapsible || shouldOpenOnInit,
+    isVisible: !isCollapsible || shouldOpenOnInit,
     elementRef: listWrapperRef,
   });
   const localRightNode =
@@ -66,7 +66,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
       return;
     }
 
-    if (!hasActiveElements) {
+    if (!hasActiveElements && isCollapsible) {
       closeList();
     }
 

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
@@ -25,21 +25,22 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   onItemHover,
   shouldOpenOnInit = false,
 }) => {
+  const [initialMount, setInitialMount] = React.useState<boolean>(true);
   const [hasActiveElements, setHasActiveElements] =
     React.useState<boolean>(false);
   const [listHeight, setListHeight] = React.useState<number>(0);
   const hadActiveListElementsRef = React.useRef(false);
   const listWrapperRef = React.useRef<HTMLDivElement>(null);
   const { isOpen, isMounted, setShouldBeVisible } = useAnimations({
-    isVisible: true,
+    isVisible: !isCollapsible || shouldOpenOnInit,
     elementRef: listWrapperRef,
   });
   const localRightNode =
     typeof rightNode === 'function' ? rightNode(isOpen) : rightNode;
   const localLabel = typeof label === 'function' ? label(isOpen) : label;
+  const shouldRenderList = initialMount ? initialMount : isMounted;
 
   const openList = (): void => setShouldBeVisible(true);
-  const closeList = (): void => setShouldBeVisible(false);
 
   const toggle = (): void => {
     if (!isCollapsible) return;
@@ -58,19 +59,16 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
 
     const newListHeight = (listElements?.length || 0) * SINGLE_ELEMENT_SIZE;
     setListHeight(newListHeight);
+    setInitialMount(false);
   };
 
   React.useEffect(() => {
-    if (!hasActiveElements && isCollapsible && !shouldOpenOnInit) {
-      closeList();
-    }
-
     if (!hadActiveListElementsRef.current && hasActiveElements) {
       openList();
     }
 
     hadActiveListElementsRef.current = hasActiveElements;
-  }, [hasActiveElements]);
+  }, [hasActiveElements, hadActiveListElementsRef.current, shouldOpenOnInit]);
 
   return (
     <div data-testid="side-navigation-group" className={styles[baseClass]}>
@@ -115,7 +113,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
         ])}
         style={{ maxHeight: isOpen ? listHeight : 0 }}
       >
-        {isMounted && (
+        {shouldRenderList && (
           <ul
             className={cx(styles[`${baseClass}__list`], className)}
             ref={onSetListNode}

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
@@ -24,7 +24,6 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   isCollapsible,
   onItemHover,
   shouldOpenOnInit = false,
-  shouldOpenOnActive = false,
 }) => {
   const [hasActiveElements, setHasActiveElements] =
     React.useState<boolean>(false);
@@ -32,7 +31,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   const hadActiveListElementsRef = React.useRef(false);
   const listWrapperRef = React.useRef<HTMLDivElement>(null);
   const { isOpen, isMounted, setShouldBeVisible } = useAnimations({
-    isVisible: !isCollapsible || shouldOpenOnInit,
+    isVisible: true,
     elementRef: listWrapperRef,
   });
   const localRightNode =
@@ -62,11 +61,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   };
 
   React.useEffect(() => {
-    if (!shouldOpenOnActive) {
-      return;
-    }
-
-    if (!hasActiveElements && isCollapsible) {
+    if (!hasActiveElements && isCollapsible && !shouldOpenOnInit) {
       closeList();
     }
 
@@ -75,7 +70,7 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
     }
 
     hadActiveListElementsRef.current = hasActiveElements;
-  }, [hasActiveElements, shouldOpenOnActive]);
+  }, [hasActiveElements]);
 
   return (
     <div data-testid="side-navigation-group" className={styles[baseClass]}>

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/types.ts
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/types.ts
@@ -27,8 +27,4 @@ export interface ISideNavigationGroupProps extends ComponentCoreProps {
    * Specify whether the list should be open on the first render
    */
   shouldOpenOnInit?: boolean;
-  /**
-   * Specify whether the list should be open if an item within the group is active
-   */
-  shouldOpenOnActive?: boolean;
 }


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #{issue-number}

## Description
Our `SideNavigationGroup` logic should open the menu if a child item is selected. With our approach with unmounting the hidden elements, the logic cannot find the active element, so the side menu stay closed with selected item inside.
With this change, we keep the menu open initially to give the logic the possibility to find the active elements, and if there is no active element, then the menu is closed.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-app-frame-side-nav-fix--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
