### PR TITLE
fix(AppFrame): side menu group auto open logic update and some fixes

### DIFF
--- a/packages/react-components/src/components/AppFrame/AppFrame.stories.tsx
+++ b/packages/react-components/src/components/AppFrame/AppFrame.stories.tsx
@@ -136,7 +136,7 @@ export const Default = (): React.ReactElement => {
       navigation={
         <Navigation>
           <NavigationGroup scrollable>
-            <li className="lc-dark-theme product-switcher-height">
+            <li className="product-switcher-height">
               <ProductSwitcher
                 mainProductId="livechat"
                 productOptions={products}

--- a/packages/react-components/src/components/AppFrame/components/NavigationItem/NavigationItem.module.scss
+++ b/packages/react-components/src/components/AppFrame/components/NavigationItem/NavigationItem.module.scss
@@ -22,7 +22,7 @@ $base-class: 'navigation-item';
     align-items: center;
     justify-content: center;
     transition: all var(--transition-duration-fast-1) ease-in-out;
-    opacity: 0.7;
+    opacity: 0.6;
     border-radius: var(--radius-3);
     width: 42px;
     height: 42px;
@@ -53,7 +53,7 @@ $base-class: 'navigation-item';
     }
 
     &--disabled {
-      opacity: 0.4;
+      opacity: 0.3;
     }
 
     span {

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.spec.tsx
@@ -1,25 +1,24 @@
 import { render, userEvent, vi, waitFor } from 'test-utils';
 
+import { SideNavigationItem } from '../SideNavigationItem/SideNavigationItem';
+
 import { SideNavigationGroup } from './SideNavigationGroup';
 import { ISideNavigationGroupProps } from './types';
 
-const defaultProps = {
-  children: (
-    <>
-      <li>Option 1</li>
-      <li>Option 2</li>
-    </>
-  ),
-};
-
-const renderComponent = (props: ISideNavigationGroupProps) => {
-  return render(<SideNavigationGroup {...props} />);
+const renderComponent = (
+  props: Omit<ISideNavigationGroupProps, 'children'>
+) => {
+  return render(
+    <SideNavigationGroup {...props}>
+      <SideNavigationItem label="Option 1" onClick={vi.fn()} />
+      <SideNavigationItem label="Option 2" onClick={vi.fn()} />
+    </SideNavigationGroup>
+  );
 };
 
 describe('<SideNavigationGroup> component', () => {
   it('should allow for custom class', () => {
     const { getByRole } = renderComponent({
-      ...defaultProps,
       className: 'custom-class',
     });
 
@@ -27,7 +26,7 @@ describe('<SideNavigationGroup> component', () => {
   });
 
   it('should render children', () => {
-    const { getByText } = renderComponent(defaultProps);
+    const { getByText } = renderComponent({});
 
     expect(getByText('Option 1')).toBeInTheDocument();
     expect(getByText('Option 2')).toBeInTheDocument();
@@ -35,7 +34,6 @@ describe('<SideNavigationGroup> component', () => {
 
   it('should render label as provided element', () => {
     const { getByText } = renderComponent({
-      ...defaultProps,
       label: <div>Side navigation label</div>,
     });
 
@@ -47,7 +45,6 @@ describe('<SideNavigationGroup> component', () => {
       <div data-testid="toggle">{isOpen ? 'Opened label' : 'Closed label'}</div>
     );
     const { getByTestId } = renderComponent({
-      ...defaultProps,
       isCollapsible: true,
       label: handleLabel,
     });
@@ -63,7 +60,6 @@ describe('<SideNavigationGroup> component', () => {
 
   it('should render rightNode as provided element if isCollapsible is set true', () => {
     const { getByText } = renderComponent({
-      ...defaultProps,
       isCollapsible: true,
       rightNode: <div>Right node</div>,
     });
@@ -76,7 +72,6 @@ describe('<SideNavigationGroup> component', () => {
       <div data-testid="toggle">{isOpen ? 'Opened node' : 'Closed node'}</div>
     );
     const { getByTestId } = renderComponent({
-      ...defaultProps,
       isCollapsible: true,
       rightNode: handleRightNode,
     });
@@ -93,7 +88,6 @@ describe('<SideNavigationGroup> component', () => {
   it('should call onItemHover when provided if user hovers the label', () => {
     const onItemHover = vi.fn();
     const { getByText } = renderComponent({
-      ...defaultProps,
       label: <div>Side navigation label</div>,
       onItemHover,
     });
@@ -104,7 +98,6 @@ describe('<SideNavigationGroup> component', () => {
 
   it('should not render children if isCollapsible is set true and there is no active option', async () => {
     const { queryByText } = renderComponent({
-      ...defaultProps,
       isCollapsible: true,
     });
 
@@ -115,16 +108,12 @@ describe('<SideNavigationGroup> component', () => {
   });
 
   it('should render children if isCollapsible is set true and there is active option', async () => {
-    const { queryByText } = renderComponent({
-      ...defaultProps,
-      isCollapsible: true,
-      children: (
-        <>
-          <li data-active="true">Option 1</li>
-          <li>Option 2</li>
-        </>
-      ),
-    });
+    const { queryByText } = render(
+      <SideNavigationGroup>
+        <SideNavigationItem label="Option 1" onClick={vi.fn()} isActive />
+        <SideNavigationItem label="Option 2" onClick={vi.fn()} />
+      </SideNavigationGroup>
+    );
 
     await waitFor(() => {
       expect(queryByText('Option 1')).toBeInTheDocument();

--- a/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
+++ b/packages/react-components/src/components/AppFrame/components/SideNavigationGroup/SideNavigationGroup.tsx
@@ -25,7 +25,6 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   onItemHover,
   shouldOpenOnInit = false,
 }) => {
-  const [initialMount, setInitialMount] = React.useState<boolean>(true);
   const [hasActiveElements, setHasActiveElements] =
     React.useState<boolean>(false);
   const [listHeight, setListHeight] = React.useState<number>(0);
@@ -38,7 +37,6 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
   const localRightNode =
     typeof rightNode === 'function' ? rightNode(isOpen) : rightNode;
   const localLabel = typeof label === 'function' ? label(isOpen) : label;
-  const shouldRenderList = initialMount ? initialMount : isMounted;
 
   const openList = (): void => setShouldBeVisible(true);
 
@@ -47,20 +45,21 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
     setShouldBeVisible((prev) => !prev);
   };
 
-  const onSetListNode = (node: HTMLUListElement): void => {
-    const listElements = node?.getElementsByTagName('li');
+  React.useEffect(() => {
+    if (!children || !isCollapsible) {
+      return;
+    }
+
+    const listElements = children as React.ReactElement[];
     const hasListActiveElements = listElements?.length
-      ? [...listElements].some(
-          (el) => el.getAttribute('data-active') === 'true'
-        )
+      ? [...listElements].some((el) => el.props.isActive === true)
       : false;
 
     setHasActiveElements(hasListActiveElements);
 
     const newListHeight = (listElements?.length || 0) * SINGLE_ELEMENT_SIZE;
     setListHeight(newListHeight);
-    setInitialMount(false);
-  };
+  }, [children]);
 
   React.useEffect(() => {
     if (!hadActiveListElementsRef.current && hasActiveElements) {
@@ -111,13 +110,12 @@ export const SideNavigationGroup: React.FC<ISideNavigationGroupProps> = ({
             [styles[`${baseClass}__list-wrapper--expanded`]]: isOpen,
           },
         ])}
-        style={{ maxHeight: isOpen ? listHeight : 0 }}
+        style={
+          isCollapsible ? { maxHeight: isOpen ? listHeight : 0 } : undefined
+        }
       >
-        {shouldRenderList && (
-          <ul
-            className={cx(styles[`${baseClass}__list`], className)}
-            ref={onSetListNode}
-          >
+        {isMounted && (
+          <ul className={cx(styles[`${baseClass}__list`], className)}>
             {children}
           </ul>
         )}

--- a/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.module.scss
+++ b/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.module.scss
@@ -4,7 +4,7 @@ $base-class: 'product-switcher';
 .#{$base-class} {
   gap: 16px;
   z-index: $stacking-context-level-popover;
-  border-radius: var(--radius-3);
+  border-radius: var(--radius-4);
   box-shadow: var(--shadow-pop-over);
   background-color: var(--popover-background);
   padding: var(--spacing-3);
@@ -47,5 +47,6 @@ $base-class: 'product-switcher';
 
   &__tooltip {
     z-index: initial;
+    pointer-events: none;
   }
 }

--- a/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.tsx
+++ b/packages/react-components/src/components/ProductSwitcher/ProductSwitcher.tsx
@@ -18,7 +18,6 @@ import {
 import { TextLogoFull } from '@livechat/design-system-icons';
 import cx from 'clsx';
 
-import { ThemeClassName } from '../../providers';
 import { Icon } from '../Icon';
 import { Tooltip } from '../Tooltip';
 import { Text } from '../Typography';
@@ -127,7 +126,7 @@ export const ProductSwitcher: FC<ProductSwitcherProps> = ({
           arrowOffsetY={2}
           offsetMainAxis={10}
           hoverOnDelay={400}
-          className={cx(styles[`${baseClass}__tooltip`], ThemeClassName.Light)}
+          className={cx(styles[`${baseClass}__tooltip`])}
           placement="right"
           floatingStrategy="fixed"
           kind="invert"
@@ -140,6 +139,7 @@ export const ProductSwitcher: FC<ProductSwitcherProps> = ({
               notificationCount={combinedNotificationCount}
             />
           }
+          closeOnTriggerBlur
         >
           Switch product
         </Tooltip>
@@ -161,6 +161,7 @@ export const ProductSwitcher: FC<ProductSwitcherProps> = ({
               <div className={styles[`${baseClass}__content`]}>
                 {productOptions.map((product) => (
                   <ProductRow
+                    isDarkMode={isDarkMode}
                     key={product.id}
                     isActive={product.id === mainProductId}
                     product={product}

--- a/packages/react-components/src/components/ProductSwitcher/components/ProductRow/ProductRow.module.scss
+++ b/packages/react-components/src/components/ProductSwitcher/components/ProductRow/ProductRow.module.scss
@@ -66,4 +66,8 @@ $base-class: 'product-row';
     max-width: unset;
     text-wrap: nowrap;
   }
+
+  &__tooltip-dark-shadow {
+    box-shadow: 0 1px 10px 0 rgb(66 77 87 / 30%);
+  }
 }

--- a/packages/react-components/src/components/ProductSwitcher/components/ProductRow/ProductRow.tsx
+++ b/packages/react-components/src/components/ProductSwitcher/components/ProductRow/ProductRow.tsx
@@ -16,6 +16,7 @@ type IProps = {
   onClick: (event: MouseEvent, id: ProductId) => void;
   product: ProductOption;
   isActive?: boolean;
+  isDarkMode: boolean;
 };
 
 const baseClass = 'product-row';
@@ -38,6 +39,7 @@ export const ProductRow: FC<IProps> = ({
   },
   onClick,
   isActive = false,
+  isDarkMode,
 }) => {
   return (
     <>
@@ -65,6 +67,9 @@ export const ProductRow: FC<IProps> = ({
             {name}
             {expired && (
               <Tooltip
+                className={cx({
+                  [styles[`${baseClass}__tooltip-dark-shadow`]]: isDarkMode,
+                })}
                 triggerRenderer={
                   <Icon
                     source={Info}
@@ -78,7 +83,9 @@ export const ProductRow: FC<IProps> = ({
             )}
             {typeof trialDaysLeft !== 'undefined' && (
               <Tooltip
-                className={styles[`${baseClass}__trial-tooltip`]}
+                className={cx(styles[`${baseClass}__trial-tooltip`], {
+                  [styles[`${baseClass}__tooltip-dark-shadow`]]: isDarkMode,
+                })}
                 triggerRenderer={
                   <Icon
                     source={Info}


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #{issue-number}

## Description
`ProductSwitcher`:
- radius changes
- tooltip shadow changes
- fixed bug with main tooltip

`AppFrame`:
- UI changes
- new logic responsible for auto opening side menu if any element is active

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-{branch-name}--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue
