### PR TITLE
fix(useAnimations): flag to enable sleep wake scenarios

### DIFF
--- a/packages/react-components/src/components/AppFrame/components/NavigationTopBar/NavigationTopBar.tsx
+++ b/packages/react-components/src/components/AppFrame/components/NavigationTopBar/NavigationTopBar.tsx
@@ -101,6 +101,7 @@ export const NavigationTopBarAlert: React.FC<ITopBarAlertProps> = ({
   const { isMounted, isOpen } = useAnimations({
     isVisible,
     elementRef: alertRef,
+    includeSleepWakeScenario: true,
   });
   const handleResizeRef = React.useCallback(
     (node: NODE) =>

--- a/packages/react-components/src/hooks/useAnimations.ts
+++ b/packages/react-components/src/hooks/useAnimations.ts
@@ -1,8 +1,11 @@
 import * as React from 'react';
 
+import { useSleepWakeSync } from './useSleepWakeSync';
+
 interface UseAnimationsProps {
   isVisible: boolean;
   elementRef: React.RefObject<HTMLDivElement>;
+  includeSleepWakeScenario?: boolean;
 }
 
 interface IUseAnimations {
@@ -14,6 +17,7 @@ interface IUseAnimations {
 export const useAnimations = ({
   isVisible,
   elementRef,
+  includeSleepWakeScenario = false,
 }: UseAnimationsProps): IUseAnimations => {
   const [isMounted, setIsMounted] = React.useState(isVisible);
   const [isOpen, setIsOpen] = React.useState(isVisible);
@@ -55,26 +59,16 @@ export const useAnimations = ({
     }
   }, [shouldBeVisible]);
 
-  // Effect to listen for visibility changes (detecting sleep/wake scenarios)
-  React.useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        // Reset the animation state when returning to the visible state
-        setShouldBeVisible(isVisible);
-      }
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [isVisible]);
-
   // Synchronize shouldBeVisible with the isVisible prop
   React.useEffect(() => {
     setShouldBeVisible(isVisible);
   }, [isVisible]);
+
+  // Effect to listen for visibility changes (detecting sleep/wake scenarios)
+  useSleepWakeSync(
+    () => setShouldBeVisible(isVisible),
+    includeSleepWakeScenario
+  );
 
   return {
     isOpen,

--- a/packages/react-components/src/hooks/useSleepWakeSync.ts
+++ b/packages/react-components/src/hooks/useSleepWakeSync.ts
@@ -1,5 +1,10 @@
 import * as React from 'react';
 
+/**
+ * Syncs the wake event with the visibility change event.
+ * @param onWake The function to call when the wake event is triggered.
+ * @param enabled Whether the sync should be enabled.
+ */
 export const useSleepWakeSync = (onWake: () => void, enabled: boolean) => {
   React.useEffect(() => {
     const handleVisibilityChange = () => {

--- a/packages/react-components/src/hooks/useSleepWakeSync.ts
+++ b/packages/react-components/src/hooks/useSleepWakeSync.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+export const useSleepWakeSync = (onWake: () => void, enabled: boolean) => {
+  React.useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        onWake();
+      }
+    };
+
+    if (enabled) {
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    return () => {
+      if (enabled) {
+        document.removeEventListener(
+          'visibilitychange',
+          handleVisibilityChange
+        );
+      }
+    };
+  }, [onWake, enabled]);
+};


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #{issue-number}

## Description
The sleep/wake scenario in this hook, which was previously added as the fix for top bar alerts scenarios, caused incorrect state change for other components that don't use a controlled state when the user lefts the browser tab. This change adds a conditional flag to enable this feature and is currently used for the top bar notifications components only.
Also added the dedicated hook for that, as it could be improved in the future and brings more code consistency in the hooks.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-use-animations-fix--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [ ] Assign pull request with the correct issue
