### PR TITLE
feat(Typography): new semi-bold variant

### DIFF
--- a/packages/react-components/src/components/Typography/Text.tsx
+++ b/packages/react-components/src/components/Typography/Text.tsx
@@ -60,8 +60,8 @@ export const Text: React.FC<React.PropsWithChildren<IProps>> = ({
       className: cx(
         {
           [styles[`${baseClassPrefix}-${size}`]]: true,
-          [styles[`${baseClassPrefix}--semi-bold`]]: semiBold,
-          [styles[`${baseClassPrefix}--bold`]]: bold,
+          [styles[`${baseClassPrefix}--semi-bold`]]: semiBold && !bold,
+          [styles[`${baseClassPrefix}--bold`]]: bold && !semiBold,
           [styles[`${baseClassPrefix}--strike`]]: strike,
           [styles[`${baseClassPrefix}--underline`]]: underline,
           [styles[`${baseClassPrefix}--uppercase`]]: uppercase || caps,

--- a/packages/react-components/src/components/Typography/Text.tsx
+++ b/packages/react-components/src/components/Typography/Text.tsx
@@ -22,6 +22,8 @@ interface IProps extends React.HTMLAttributes<HTMLElement> {
   uppercase?: boolean;
   /** Optional prop to set the bold */
   bold?: boolean;
+  /** Optional prop to set the semi-bold */
+  semiBold?: boolean;
   /** Optional prop to set the underline */
   underline?: boolean;
   /** Optional prop to set the strike */
@@ -40,6 +42,7 @@ export const Text: React.FC<React.PropsWithChildren<IProps>> = ({
   caps = false,
   uppercase = false,
   bold = false,
+  semiBold = false,
   underline = false,
   strike = false,
   children,
@@ -57,6 +60,7 @@ export const Text: React.FC<React.PropsWithChildren<IProps>> = ({
       className: cx(
         {
           [styles[`${baseClassPrefix}-${size}`]]: true,
+          [styles[`${baseClassPrefix}--semi-bold`]]: semiBold,
           [styles[`${baseClassPrefix}--bold`]]: bold,
           [styles[`${baseClassPrefix}--strike`]]: strike,
           [styles[`${baseClassPrefix}--underline`]]: underline,

--- a/packages/react-components/src/components/Typography/Typography.module.scss
+++ b/packages/react-components/src/components/Typography/Typography.module.scss
@@ -162,6 +162,10 @@
 }
 
 .paragraph {
+  &--semi-bold {
+    font-weight: 500;
+  }
+
   &--bold {
     font-weight: 600;
   }

--- a/packages/react-components/src/stories/foundations/Typography/components/TextExamples.tsx
+++ b/packages/react-components/src/stories/foundations/Typography/components/TextExamples.tsx
@@ -12,6 +12,9 @@ export const TextExamples: React.FC = () => {
         <Text size={size} bold>
           Paragraph {size.toUpperCase()} with bold
         </Text>
+        <Text size={size} semiBold>
+          Paragraph {size.toUpperCase()} with semi-bold
+        </Text>
         <Text size={size} underline>
           Paragraph {size.toUpperCase()} with underline
         </Text>


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1419 

## Description
New `semiBold` props for `Text` component.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1419--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced an optional `semiBold` property for the `Text` component, allowing for semi-bold text styling.
	- Added a new `.paragraph--semi-bold` modifier in styles for enhanced typography options.
	- Updated `TextExamples` to showcase the new semi-bold text variant.

- **Bug Fixes**
	- No bug fixes were made in this release. 

- **Documentation**
	- No documentation updates were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->