### PR TITLE
feat(Picker): support 'root' attribute

### DIFF
--- a/packages/react-components/src/components/Picker/Picker.tsx
+++ b/packages/react-components/src/components/Picker/Picker.tsx
@@ -39,6 +39,7 @@ export const Picker: React.FC<IPickerProps> = ({
   onSelect,
   placement,
   floatingStrategy,
+  root,
   useDismissHookProps,
   useClickHookProps,
   virtuosoProps,
@@ -149,7 +150,7 @@ export const Picker: React.FC<IPickerProps> = ({
       </PickerTrigger>
       <FloatingNode id={nodeId}>
         {isOpen && (
-          <FloatingPortal>
+          <FloatingPortal root={root}>
             <PickerList
               pickerType={type}
               options={items}

--- a/packages/react-components/src/components/Picker/types.ts
+++ b/packages/react-components/src/components/Picker/types.ts
@@ -1,6 +1,7 @@
 import { InputHTMLAttributes, ReactElement } from 'react';
 
 import {
+  FloatingPortalProps,
   Placement,
   Strategy,
   UseClickProps,
@@ -132,6 +133,10 @@ export interface IPickerProps extends ComponentCoreProps {
    * Floating strategy for the picker component from @floating-ui/react
    */
   floatingStrategy?: Strategy;
+  /**
+   * Root node the portal container from @floating-ui/react will be appended to
+   */
+  root?: FloatingPortalProps['root'];
   /**
    * Set the `floating-ui` useDismiss hook params if you need more control
    * https://floating-ui.com/docs/usedismiss


### PR DESCRIPTION
## Description
Adds support for `root` property of [FloatingPortal](https://floating-ui.com/docs/floatingportal#root) used in `Picker` component.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-picker-root--613a8e945a5665003a05113b.chromatic.com

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional `root` prop to the `Picker` component, allowing users to customize the portal's root element.
- **Enhancements**
	- Expanded configuration options for the `Picker` component with the addition of the `root` property in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->