### PR TITLE
feat(Picker): remain group headers in the list while filtering

### DIFF
--- a/packages/react-components/src/components/Picker/hooks/usePickerItems.ts
+++ b/packages/react-components/src/components/Picker/hooks/usePickerItems.ts
@@ -81,17 +81,27 @@ export const usePickerItems = ({
     let items = options;
 
     if (searchPhrase) {
-      items = items.filter((item) => {
-        if (item.groupHeader) {
-          return false;
-        }
+      items = items
+        .filter((item) => {
+          if (item.groupHeader) {
+            return true;
+          }
 
-        const search = searchPhrase.toLowerCase();
-        const itemName = item.name.toLowerCase();
-        const itemSecondaryText = item.secondaryText?.toLowerCase();
+          const search = searchPhrase.toLowerCase();
+          const itemName = item.name.toLowerCase();
+          const itemSecondaryText = item.secondaryText?.toLowerCase();
 
-        return itemName.includes(search) || itemSecondaryText?.includes(search);
-      });
+          return (
+            itemName.includes(search) || itemSecondaryText?.includes(search)
+          );
+        })
+        .filter(
+          (item, index, array) =>
+            !(
+              item.groupHeader &&
+              (array[index + 1]?.groupHeader || index === array.length - 1)
+            )
+        );
     }
 
     if (shouldShowSelectAll && items.length > 1) {


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: https://livechatinc.atlassian.net/browse/HD-4644

## Description

Make group headers visible in the option list while filtering with search phrase.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-HD-4644--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced item filtering in the Picker component to include `groupHeader` items in search results.
	- Improved logic to prevent consecutive `groupHeader` items from appearing in the results.

- **Bug Fixes**
	- Refined filtering process for better search accuracy and readability while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->