### PR TITLE
fix(Popover): fix Popover visibility prop

### DIFF
--- a/packages/react-components/src/components/Popover/Popover.spec.tsx
+++ b/packages/react-components/src/components/Popover/Popover.spec.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { render, userEvent } from 'test-utils';
@@ -65,14 +66,18 @@ describe('<Popover> component', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('closes the popover when Escape key is pressed', () => {
+  it('closes the popover when Escape key is pressed', async () => {
     const { queryByRole } = renderComponent({
       ...defaultProps,
       openedOnInit: true,
     });
 
     userEvent.keyboard('[Escape]');
-    expect(queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Wait for close animation to finish
+    await waitFor(() => {
+      expect(queryByRole('dialog')).not.toBeInTheDocument();
+    });
   });
 
   it('should not close the popover when Escape key is pressed if closeOnEsc is set false', () => {

--- a/packages/react-components/src/components/Popover/Popover.tsx
+++ b/packages/react-components/src/components/Popover/Popover.tsx
@@ -103,7 +103,7 @@ export const Popover: React.FC<React.PropsWithChildren<IPopoverProps>> = ({
     }),
   } as UseTransitionStylesProps;
 
-  const { styles: transitionStyles } = useTransitionStyles(
+  const { isMounted, styles: transitionStyles } = useTransitionStyles(
     context,
     transitionOptions ? transitionOptions : defaultTransitionStyles
   );
@@ -121,7 +121,7 @@ export const Popover: React.FC<React.PropsWithChildren<IPopoverProps>> = ({
         {isTriggerAsFunction ? triggerRenderer() : triggerRenderer}
       </div>
       <FloatingNode id={nodeId}>
-        {currentlyVisible && (
+        {isMounted && (
           <FloatingFocusManager context={context} modal={false}>
             <div
               className={mergedClassNames}


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: n/a

## Description
After adding transitions to the popover element, its visibility should be managed using a different prop, `isMounted`, instead of `currentlyVisible`.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-fix-popover-transition-styles--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced popover rendering logic to improve component initialization and transition behavior.

- **Refactor**
	- Updated popover component to use mounted state for more precise rendering control.

- **Tests**
	- Improved reliability of popover tests by handling asynchronous close behavior and ensuring proper wait for animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->