### PR TITLE
feat(Icon): add layout-grid icons

### DIFF
--- a/packages/icons/svg/layout-grid-filled.svg
+++ b/packages/icons/svg/layout-grid-filled.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
+  <path d="M9 3a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-4a2 2 0 0 1 2 -2z"></path>
+  <path d="M19 3a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-4a2 2 0 0 1 2 -2z"></path>
+  <path d="M9 13a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-4a2 2 0 0 1 2 -2z"></path>
+  <path d="M19 13a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-4a2 2 0 0 1 -2 -2v-4a2 2 0 0 1 2 -2z"></path>
+</svg>

--- a/packages/icons/svg/layout-grid.svg
+++ b/packages/icons/svg/layout-grid.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round"
+  stroke-linejoin="round" width="24" height="24" stroke-width="2">
+  <path d="M4 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"></path>
+  <path d="M14 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"></path>
+  <path d="M4 14m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"></path>
+  <path d="M14 14m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"></path>
+</svg>

--- a/packages/react-components/src/components/Icon/IconsShowcase/constans.ts
+++ b/packages/react-components/src/components/Icon/IconsShowcase/constans.ts
@@ -291,6 +291,8 @@ export const IconsData: Record<IconName, IconGroup> = {
   KeyboardFilled: IconGroup.General,
   Keyboard: IconGroup.General,
   Language: IconGroup.General,
+  LayoutGrid: IconGroup.General,
+  LayoutGridFilled: IconGroup.General,
   Line: IconGroup.General,
   LineColored: IconGroup.General,
   LinkFilled: IconGroup.General,


### PR DESCRIPTION
## Description
Adds two icons, LayoutGrid and LayoutGridFilled

## Storybook

https://feature-icon-layout-grid--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added two new icons to the icon library:
		- LayoutGrid icon
		- LayoutGridFilled icon

<!-- end of auto-generated comment: release notes by coderabbit.ai -->