### PR TITLE
fix(Table): overwrite table width for chromatic consistent screenshots

### DIFF
--- a/packages/react-components/src/components/Table/Table.stories.module.scss
+++ b/packages/react-components/src/components/Table/Table.stories.module.scss
@@ -1,0 +1,3 @@
+.table-width-chromatic {
+  width: 1000px;
+}

--- a/packages/react-components/src/components/Table/Table.stories.tsx
+++ b/packages/react-components/src/components/Table/Table.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Meta, StoryFn } from '@storybook/react';
+import isChromatic from 'chromatic/isChromatic';
 import cx from 'clsx';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
@@ -15,10 +16,20 @@ import { Table } from './Table';
 import { Column, Data, DataForPinningExample } from './types';
 
 import styles from './Table.module.scss';
+import storyStyles from './Table.stories.module.scss';
 
 export default {
   title: 'Components/Table',
   component: Table,
+  decorators: [
+    (Story: StoryFn) => (
+      <div
+        className={cx(isChromatic() && storyStyles['table-width-chromatic'])}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 } as Meta<typeof Table>;
 
 const actionBarClass = 'action-bar';


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: n/a

## Description
This PR fixes issues with inconsistent Chromatic screenshots caused by the Table component auto width. A wrapper was added around the stories in Chromatic to set a fixed width, making the screenshots consistent and reliable.

Self-tested multiple, consecutive Chromatic builds and verified the changes using the updated package in the AA app to ensure everything works as expected.
Link to an example of a working build: https://www.chromatic.com/build?appId=613a8e945a5665003a05113b&number=4077 

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-fix-chromatic-table--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Added a new CSS class for Chromatic visual testing
	- Enhanced Storybook component presentation with conditional styling

- **Chores**
	- Updated Storybook configuration for improved visual testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->