### PR TITLE
feat(Checkbox): add indeterminate state and update old styles

### DIFF
--- a/packages/react-components/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/react-components/src/components/Checkbox/Checkbox.module.scss
@@ -40,13 +40,34 @@
       opacity: 0;
       z-index: 1;
       background-color: var(--content-invert-primary);
-      width: 24px;
-      height: 24px;
+      width: 16px;
+      height: 16px;
       content: '';
-      /* stylelint-disable */
+      /* stylelint-disable property-no-vendor-prefix */
       -webkit-mask: url('./check.svg') no-repeat 50% 50%;
       mask: url('./check.svg') no-repeat 50% 50%;
-      /* stylelint-enable */
+      /* stylelint-disable property-no-vendor-prefix */
+      -webkit-mask-size: contain;
+      mask-size: contain;
+    }
+
+    &:indeterminate {
+      border-color: var(--action-primary-default);
+      background-color: var(--action-primary-default);
+
+      &::after {
+        opacity: 1;
+        width: 10px;
+        height: 2px;
+        border-radius: 2px;
+        -webkit-mask: none;
+        mask: none;
+      }
+
+      &:hover {
+        border-color: var(--action-primary-hover);
+        background-color: var(--action-primary-hover);
+      }
     }
 
     &:hover {
@@ -58,8 +79,8 @@
     }
 
     &:checked {
-      border-color: var(--color-action-default);
-      background-color: var(--color-action-default);
+      border-color: var(--action-primary-default);
+      background-color: var(--action-primary-default);
 
       .checkbox__checkmark {
         opacity: 1;
@@ -67,8 +88,8 @@
     }
 
     &:checked:hover {
-      border-color: var(--action-primary-default);
-      background-color: var(--action-primary-default);
+      border-color: var(--action-primary-hover);
+      background-color: var(--action-primary-hover);
     }
 
     &:focus-visible {
@@ -96,7 +117,8 @@
         border-color: var(--border-basic-disabled);
         background-color: var(--surface-primary-disabled);
 
-        &:checked {
+        &:checked,
+        &:indeterminate {
           border-color: transparent;
           background-color: var(--action-primary-disabled);
         }

--- a/packages/react-components/src/components/Checkbox/Checkbox.module.scss
+++ b/packages/react-components/src/components/Checkbox/Checkbox.module.scss
@@ -43,10 +43,10 @@
       width: 16px;
       height: 16px;
       content: '';
-      /* stylelint-disable property-no-vendor-prefix */
+      /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-mask: url('./check.svg') no-repeat 50% 50%;
       mask: url('./check.svg') no-repeat 50% 50%;
-      /* stylelint-disable property-no-vendor-prefix */
+      /* stylelint-disable-next-line property-no-vendor-prefix */
       -webkit-mask-size: contain;
       mask-size: contain;
     }
@@ -57,9 +57,10 @@
 
       &::after {
         opacity: 1;
+        border-radius: 2px;
         width: 10px;
         height: 2px;
-        border-radius: 2px;
+        /* stylelint-disable-next-line property-no-vendor-prefix */
         -webkit-mask: none;
         mask: none;
       }

--- a/packages/react-components/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.stories.tsx
@@ -47,5 +47,74 @@ export const States = (): React.ReactElement => (
         Checkbox label
       </CheckboxComponent>
     </StoryDescriptor>
+    <StoryDescriptor title="Indeterminate">
+      <CheckboxComponent
+        indeterminate={true}
+        checked={false}
+        description="Enabled"
+      >
+        Checkbox label
+      </CheckboxComponent>
+      <CheckboxComponent
+        indeterminate={true}
+        checked={false}
+        description="Disabled"
+        disabled
+      >
+        Checkbox label
+      </CheckboxComponent>
+    </StoryDescriptor>
   </>
 );
+
+const plainOptions = ['Apple', 'Pear'];
+
+export const IndeterminateState = (): React.ReactElement => {
+  const [checkedList, setCheckedList] = React.useState<string[]>(['Apple']);
+
+  const checkAll = plainOptions.length === checkedList.length;
+  const indeterminate =
+    checkedList.length > 0 && checkedList.length < plainOptions.length;
+
+  const onCheckAllChange: CheckboxProps['onChange'] = (e) => {
+    const target = e.target as HTMLInputElement;
+    setCheckedList(target.checked ? plainOptions : []);
+  };
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    const newCheckedList = checkedList.includes(value)
+      ? checkedList.filter((item) => item !== value)
+      : [...checkedList, value];
+    setCheckedList(newCheckedList);
+  };
+
+  return (
+    <>
+      <CheckboxComponent
+        indeterminate={indeterminate}
+        onChange={onCheckAllChange}
+        checked={checkAll}
+      >
+        Check all
+      </CheckboxComponent>
+
+      <div style={{ display: 'flex', gap: '10px', marginTop: '10px' }}>
+        <CheckboxComponent
+          defaultValue="Apple"
+          checked={checkedList.includes('Apple')}
+          onChange={handleOnChange}
+        >
+          Apple
+        </CheckboxComponent>
+        <CheckboxComponent
+          defaultValue="Pear"
+          checked={checkedList.includes('Pear')}
+          onChange={handleOnChange}
+        >
+          Pear
+        </CheckboxComponent>
+      </div>
+    </>
+  );
+};

--- a/packages/react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.tsx
@@ -20,13 +20,25 @@ export interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
    * Set the checkbox description
    */
   description?: React.ReactNode;
+  /**
+   * Specify whether the checkbox should be in indeterminate state
+   */
+  indeterminate?: boolean;
 }
 
 const baseClass = 'checkbox';
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (
-    { checked, disabled, children, description, className, ...restInputProps },
+    {
+      checked,
+      indeterminate = false,
+      disabled,
+      children,
+      description,
+      className,
+      ...restInputProps
+    },
     ref
   ) => {
     return (
@@ -34,12 +46,22 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         className={cx(styles[baseClass], className, {
           [styles[`${baseClass}--selected`]]: checked,
           [styles[`${baseClass}--disabled`]]: disabled,
+          [styles[`${baseClass}--indeterminate`]]: indeterminate,
         })}
       >
         <label className={styles[`${baseClass}__label`]}>
           <input
             {...restInputProps}
-            ref={ref}
+            ref={(element) => {
+              if (element) {
+                element.indeterminate = indeterminate;
+                if (typeof ref === 'function') {
+                  ref(element);
+                } else if (ref) {
+                  ref.current = element;
+                }
+              }
+            }}
             checked={checked}
             disabled={disabled}
             className={styles[`${baseClass}__input`]}


### PR DESCRIPTION
Resolves: #1446 

## Description
- Added the `indeterminate` prop to the `Checkbox` component and updated the component to handle the indeterminate state.
- Additionally, adjusted the size of the checkbox check icon, and updated the deprecated color variables for consistency. 

Before:
<img width="215" alt="Screenshot 2025-01-20 at 11 53 41" src="https://github.com/user-attachments/assets/bb00fa15-0d36-4e0b-92b6-01c58ad38882" />

After:
<img width="244" alt="Screenshot 2025-01-20 at 11 52 41" src="https://github.com/user-attachments/assets/e8daab68-b02c-4604-a4c4-a3dd06152c29" />


Figma: https://www.figma.com/design/9FDwjR8lYvincseDkKypC4/%5BDS%5D-Component-Documentations?node-id=770-69276&p=f&m=dev 
## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1446--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for indeterminate checkbox state
	- Enhanced checkbox component with new visual states and styling

- **Documentation**
	- Updated Storybook examples to demonstrate indeterminate checkbox behavior

- **Style**
	- Refined checkbox styling for different states (checked, disabled, indeterminate)
	- Updated color variables for hover and disabled states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->