### PR TITLE
feat(FormField): add boldLabel prop for InputPromo

### DIFF
--- a/packages/react-components/src/components/FormField/FormField.module.scss
+++ b/packages/react-components/src/components/FormField/FormField.module.scss
@@ -17,7 +17,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: flex-start;
-    margin-bottom: 4px;
+    margin-bottom: var(--spacing-1);
 
     label {
       margin-bottom: 0;

--- a/packages/react-components/src/components/FormField/FormField.stories.tsx
+++ b/packages/react-components/src/components/FormField/FormField.stories.tsx
@@ -2,7 +2,7 @@ import { Info } from '@livechat/design-system-icons';
 import { Meta, StoryFn } from '@storybook/react';
 
 import { Icon } from '../Icon';
-import { Input } from '../Input';
+import { Input, InputPromo } from '../Input';
 import { IInputProps } from '../Input/types';
 
 import { FormField as FormFieldComponent, FormFieldProps } from './FormField';
@@ -23,12 +23,20 @@ export default {
     labelRightNode: {
       control: false,
     },
+    parameters: {
+      controls: {
+        exclude: ['boldLabel'],
+      },
+    },
   },
 } as Meta<typeof FormFieldComponent>;
 
 const ExampleIcon = () => <Icon source={Info} />;
 const ExampleInput = ({ ...args }: IInputProps) => (
   <Input placeholder="Placeholder text" {...args} />
+);
+const ExampleInputPromo = ({ ...args }: IInputProps) => (
+  <InputPromo placeholder="Placeholder text" {...args} />
 );
 const LabelText = 'Email';
 const DescriptionText = 'Enter your email address';
@@ -91,5 +99,11 @@ export const WithInlineLabelAndLabelAdornment: StoryFn<FormFieldProps> = () => (
 export const TextFieldWithError: StoryFn<FormFieldProps> = () => (
   <FormFieldComponent labelText="Username" error="Username must be unique">
     <ExampleInput error />
+  </FormFieldComponent>
+);
+
+export const BoldLabelWithPromoInput: StoryFn<FormFieldProps> = () => (
+  <FormFieldComponent labelText="Username" boldLabel>
+    <ExampleInputPromo />
   </FormFieldComponent>
 );

--- a/packages/react-components/src/components/FormField/FormField.tsx
+++ b/packages/react-components/src/components/FormField/FormField.tsx
@@ -24,6 +24,10 @@ export interface FormFieldProps {
    */
   labelFor?: string;
   /**
+   * Makes the label text bold. Note: This prop should only be used together with PromoInput.
+   */
+  boldLabel?: boolean;
+  /**
    * The CSS class for field container
    */
   className?: string;
@@ -59,6 +63,7 @@ export const FormField: React.FC<React.PropsWithChildren<FormFieldProps>> = ({
   labelFor,
   children,
   labelRightNode,
+  boldLabel = false,
 }) => {
   const childrenRef = React.useRef<HTMLDivElement>(null);
   const [labelHeight, setLabelHeight] = React.useState('auto');
@@ -125,7 +130,7 @@ export const FormField: React.FC<React.PropsWithChildren<FormFieldProps>> = ({
                   className={styles[`${baseClass}__label-left-node`]}
                   htmlFor={labelFor}
                 >
-                  <Text as="span" size="sm">
+                  <Text as="span" size="sm" bold={boldLabel}>
                     {labelText}
                   </Text>
                 </label>


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1447 

## Description
This pull request includes changes to the `FormField` component and its associated stories to introduce a new `boldLabel` property to be used mainly for the `InputPromo` component. 

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1447--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an optional `boldLabel` prop to the `FormField` component for bold label rendering.
	- Introduced a new story demonstrating bold label functionality with promo input.

- **Bug Fixes**
	- Updated styles for the label to improve spacing with a variable margin.

- **Documentation**
	- Updated Storybook controls to exclude `boldLabel` control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->