### PR TITLE
docs(RangeDatePickerV2): remove WithInitialSelectedOption story

### DIFF
--- a/packages/react-components/src/components/RangeDatePickerV2/RangeDatePickerV2.stories.tsx
+++ b/packages/react-components/src/components/RangeDatePickerV2/RangeDatePickerV2.stories.tsx
@@ -26,8 +26,3 @@ WithInitialDates.args = {
   initialFromDate: new Date('2025-01-20'),
   initialToDate: new Date('2025-02-06'),
 };
-
-export const WithInitialSelectedOption: StoryFn = StoryTemplate.bind({});
-WithInitialSelectedOption.args = {
-  initialSelectedOptionId: 'last7days',
-};


### PR DESCRIPTION


<!--- Issue number will be inserted automatically if properly defined -->
Resolves: n/a

## Description
This pull request includes a change to the RangePicker stories, by removing the `WithInitialSelectedOption` story that was breaking Chromatic visual tests and was not needed.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-fix-range-picker-chromatic--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified Storybook examples for the RangeDatePickerV2 component by removing an initial selected option story.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->