### PR TITLE
fix(AppFrame): add fallback height for older browsers

### DIFF
--- a/packages/react-components/src/components/AppFrame/AppFrame.module.scss
+++ b/packages/react-components/src/components/AppFrame/AppFrame.module.scss
@@ -5,6 +5,7 @@ $base-class: 'app-frame';
   flex-direction: row;
   background-color: var(--navbar-background);
   width: 100%;
+  height: 100vh; // Fallback for older browsers that don't support dvh
   height: 100dvh;
   color: var(--content-invert-default);
 


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: n/a

## Description

The change adds a fallback height property for older browsers that do not support the `dvh` unit.

## Storybook

<!--- Branch name will be inserted automatically -->
https://613a8e945a5665003a05113b-cfcssuffqf.chromatic.com/?path=/docs/components-appframe--docs

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved layout styling by adding a fallback viewport height for older browsers while leveraging dynamic viewport height for modern browsers to ensure a consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->