### PR TITLE
docs(Skeleton): add example of SkeletonText with custom width

### DIFF
--- a/packages/react-components/src/components/Skeleton/Skeleton.mdx
+++ b/packages/react-components/src/components/Skeleton/Skeleton.mdx
@@ -131,14 +131,22 @@ Is a component that is intended to wrap other `Skeleton` components, manage thei
 
 `SkeletonText` is a component designed to present a placeholder or loading state for text type content. Can be used on its own or with the `SkeletonWrapper` element that will also control the animation.
 
+The component uses `width: 100%` by default, but you can specify a custom width in pixels using the optional `width` prop.
+
 <Canvas withSource="none">
   <SkeletonWrapper animated>
+    {/* Default full width */}
+    <SkeletonText />
+    {/* Custom width in pixels */}
     <SkeletonText width={350} />
   </SkeletonWrapper>
 </Canvas>
 
 ```jsx
 <SkeletonWrapper animated>
+  {/* Default full width */}
+  <SkeletonText />
+  {/* Custom width in pixels */}
   <SkeletonText width={350} />
 </SkeletonWrapper>
 ```

--- a/packages/react-components/src/components/Skeleton/SkeletonText.stories.tsx
+++ b/packages/react-components/src/components/Skeleton/SkeletonText.stories.tsx
@@ -15,3 +15,11 @@ export const Text = (args: ISkeletonText): React.ReactElement => (
   />
 );
 Text.args = {};
+
+export const TextWithCustomWidth = (
+  args: ISkeletonText
+): React.ReactElement => <SkeletonText {...args} />;
+
+TextWithCustomWidth.args = {
+  width: 100,
+};


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1367

## Description

Added documentation for the `width` prop, which allows users to specify a custom width in pixels for the `SkeletonText` component.


## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1367--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the component guide with clear instructions on how the SkeletonText component displays by default and how it can be adjusted with a custom width.
- **New Features**
	- Added an interactive example to demonstrate the component’s custom width configuration for better clarity during implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->