### PR TITLE
fix(FieldField): replace Info icon with Error icon

### DIFF
--- a/packages/react-components/src/components/FieldError/FieldError.tsx
+++ b/packages/react-components/src/components/FieldError/FieldError.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Info } from '@livechat/design-system-icons';
+import { Error } from '@livechat/design-system-icons';
 import cx from 'clsx';
 
 import { Icon } from '../Icon';
@@ -22,7 +22,7 @@ export const FieldError: React.FC<React.PropsWithChildren<FieldErrorProps>> = ({
   return (
     <Text as="span" size="sm" {...props} className={mergedClassNames}>
       <Icon
-        source={Info}
+        source={Error}
         className={styles[`${baseClass}__icon`]}
         size="small"
       />


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1520

## Description

Updated the icon used to represent errors in FormField, switching from an informational icon to an error-specific icon.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1520--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the error notification display to feature a more appropriate error icon for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->