### PR TITLE
feat(SegmentedControl): add support for icon-only buttons

### DIFF
--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -63,6 +63,6 @@ WithIcons.args = {
   buttons: [
     { id: 'one', icon: buttonIcon },
     { id: 'two', icon: buttonIcon2 },
-    { id: 'two', icon: buttonIcon3, disabled: true },
+    { id: 'three', icon: buttonIcon3, disabled: true },
   ],
 };

--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -7,6 +7,8 @@ import { SegmentedControl, SegmentedControlProps } from './SegmentedControl';
 
 const buttonSizes = ['compact', 'medium', 'large'];
 const buttonIcon = <Icon source={TablerIcons.AddCircle} />;
+const buttonIcon2 = <Icon source={TablerIcons.OpenInNew} />;
+const buttonIcon3 = <Icon source={TablerIcons.ContentCopy} />;
 
 export default {
   title: 'Components/Segmented Control',
@@ -51,4 +53,16 @@ Uncontrolled.args = {
     { id: 'fourth', label: 'fourth' },
   ],
   currentId: 'one',
+};
+
+export const WithIcons: StoryFn<SegmentedControlProps> = (
+  args: SegmentedControlProps
+) => <SegmentedControl {...args} />;
+
+WithIcons.args = {
+  buttons: [
+    { id: 'one', icon: buttonIcon },
+    { id: 'two', icon: buttonIcon2 },
+    { id: 'two', icon: buttonIcon3, disabled: true },
+  ],
 };

--- a/packages/react-components/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react-components/src/components/SegmentedControl/SegmentedControl.tsx
@@ -13,7 +13,7 @@ export type ButtonSize = 'compact' | 'medium' | 'large';
 
 type ButtonElement = {
   id: string;
-  label: string;
+  label?: string;
 } & Pick<ButtonProps, 'disabled' | 'loading' | 'icon'>;
 
 export interface SegmentedControlProps


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1502

## Description

* Updated the `ButtonElement` type to make the `label` property optional in `SegmentedControl.tsx` to add support for icon-only buttons

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1502--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Segmented Control demo showcasing icon-enhanced buttons, including a disabled button state.
	- Improved flexibility by allowing buttons to be configured without a label, streamlining setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->