### PR TITLE
docs(FormField): add example of character counter implementation

### DIFF
--- a/packages/react-components/src/components/FormField/FormField.mdx
+++ b/packages/react-components/src/components/FormField/FormField.mdx
@@ -113,6 +113,45 @@ To display error messages, use the `error` prop.
 
 <Canvas of={FormFieldStories.TextFieldWithError} sourceState="none" />
 
+### Example implementation with character counter
+
+To use FormField with character counter, you need to implement the counter component based on your inputs values and pass it to the `labelRightNode` prop.
+If you need to display the counter on the bottom of the FormField, you can pass the component to the `description` prop.
+
+```tsx
+  const [value, setValue] = React.useState('');
+  const maxLength = 5;
+  const characterCount = value.length;
+  const isExceeded = characterCount > maxLength;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  const CounterComponent = () => (
+      <Text
+        noMargin
+        size="sm"
+        customColor={
+          isExceeded
+            ? 'var(--content-basic-negative)'
+            : 'var(--content-basic-secondary)'
+        }
+      >
+        {characterCount}/{maxLength}
+      </Text>
+  );
+
+<FormField
+  labelText="Input with counter"
+  labelRightNode={<CounterComponent />}
+>
+  <Input type="text" placeholder="Enter your username" />
+</FormField>
+```
+
+<Canvas of={FormFieldStories.WithCharacterCounter} sourceState="none" />
+
 ## Component API <a id="ComponentAPI" />
 
 <ArgTypes of={FormFieldStories.Default} sort="requiredFirst" />

--- a/packages/react-components/src/components/FormField/FormField.stories.tsx
+++ b/packages/react-components/src/components/FormField/FormField.stories.tsx
@@ -225,37 +225,75 @@ export const BoldLabelWithPromoInput: StoryFn<FormFieldProps> = () => (
   </FormFieldComponent>
 );
 export const WithCharacterCounter = (): React.ReactElement => {
-  const [value, setValue] = React.useState('');
-  const maxLength = 5;
-  const characterCount = value.length;
-  const isExceeded = characterCount > maxLength;
+  const [value1, setValue1] = React.useState('');
+  const [value2, setValue2] = React.useState('');
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
+  const maxLength = 5;
+  const characterCount1 = value1.length;
+  const characterCount2 = value2.length;
+  const isExceeded1 = characterCount1 > maxLength;
+  const isExceeded2 = characterCount2 > maxLength;
+
+  const handleChange1 = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue1(e.target.value);
   };
 
-  const CounterComponent = () => (
+  const handleChange2 = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue2(e.target.value);
+  };
+
+  const CounterComponent1 = () => (
     <Text
       noMargin
       size="sm"
       customColor={
-        isExceeded
+        isExceeded1
           ? 'var(--content-basic-negative)'
           : 'var(--content-basic-secondary)'
       }
     >
-      {characterCount}/{maxLength}
+      {characterCount1}/{maxLength}
     </Text>
   );
 
+  const CounterComponent2 = () => (
+    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Text
+        noMargin
+        size="sm"
+        customColor={
+          isExceeded2
+            ? 'var(--content-basic-negative)'
+            : 'var(--content-basic-secondary)'
+        }
+      >
+        {characterCount2}/{maxLength}
+      </Text>
+    </div>
+  );
+
   return (
-    <FormFieldComponent labelRightNode={<CounterComponent />}>
-      <Input
-        value={value}
-        onChange={handleChange}
-        placeholder="Type something..."
-        error={isExceeded}
-      />
-    </FormFieldComponent>
+    <>
+      <StoryDescriptor title="Right aligned counter">
+        <FormFieldComponent labelRightNode={<CounterComponent1 />}>
+          <Input
+            value={value1}
+            onChange={handleChange1}
+            placeholder="Type something..."
+            error={isExceeded1}
+          />
+        </FormFieldComponent>
+      </StoryDescriptor>
+      <StoryDescriptor title="Bottom aligned counter">
+        <FormFieldComponent description={<CounterComponent2 />}>
+          <Input
+            value={value2}
+            onChange={handleChange2}
+            placeholder="Type something..."
+            error={isExceeded2}
+          />
+        </FormFieldComponent>
+      </StoryDescriptor>
+    </>
   );
 };

--- a/packages/react-components/src/components/FormField/FormField.stories.tsx
+++ b/packages/react-components/src/components/FormField/FormField.stories.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { Info } from '@livechat/design-system-icons';
 import { Meta, StoryFn } from '@storybook/react';
 
@@ -13,6 +15,7 @@ import { Picker } from '../Picker';
 import { RadioButton } from '../RadioButton';
 import { TagInput } from '../TagInput';
 import { Textarea } from '../Textarea';
+import { Text } from '../Typography';
 
 import { FormField as FormFieldComponent, FormFieldProps } from './FormField';
 
@@ -221,3 +224,38 @@ export const BoldLabelWithPromoInput: StoryFn<FormFieldProps> = () => (
     <ExampleInputPromo />
   </FormFieldComponent>
 );
+export const WithCharacterCounter = (): React.ReactElement => {
+  const [value, setValue] = React.useState('');
+  const maxLength = 5;
+  const characterCount = value.length;
+  const isExceeded = characterCount > maxLength;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  const CounterComponent = () => (
+    <Text
+      noMargin
+      size="sm"
+      customColor={
+        isExceeded
+          ? 'var(--content-basic-negative)'
+          : 'var(--content-basic-secondary)'
+      }
+    >
+      {characterCount}/{maxLength}
+    </Text>
+  );
+
+  return (
+    <FormFieldComponent labelRightNode={<CounterComponent />}>
+      <Input
+        value={value}
+        onChange={handleChange}
+        placeholder="Type something..."
+        error={isExceeded}
+      />
+    </FormFieldComponent>
+  );
+};


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1418

## Description

The changes include updates to the documentation and the storybook examples to demonstrate how to use the character counter with the `FormField` component.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1418--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation  
  - Enhanced FormField docs with an example that demonstrates how to integrate a character counter, providing clear visual guidance on managing input length.  

- New Features  
  - Introduced an interactive demo showcasing real-time character counting for form inputs, with dynamic visual feedback when limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->