### PR TITLE
docs(Popover, Tooltip): disable transitions in Chromatic tests

### DIFF
--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -79,7 +79,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
             onClick: () => setRadioButtonValue('two'),
           },
           {
-            key: 'three',
+            key: 'three1',
             withDivider: true,
             element: (
               <ListItem

--- a/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/react-components/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -79,7 +79,7 @@ export const KeepOpenOnItemClick = (): React.ReactElement => {
             onClick: () => setRadioButtonValue('two'),
           },
           {
-            key: 'three1',
+            key: 'three',
             withDivider: true,
             element: (
               <ListItem

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from '@livechat/design-system-icons';
 import { Meta, StoryFn } from '@storybook/react';
+import isChromatic from 'chromatic/isChromatic';
 
 import { Button } from '../Button';
 import { Icon } from '../Icon';
@@ -52,7 +53,7 @@ export default {
   parameters: {
     layout: 'centered',
     controls: { expanded: true },
-    chromatic: { delay: 600 },
+    // chromatic: { delay: 600 },
   },
   decorators: [
     (Story: StoryFn) => (
@@ -87,6 +88,9 @@ Default.args = {
   placement: 'bottom-start',
   isVisible: undefined,
   openedOnInit: true,
+  transitionOptions: {
+    duration: isChromatic() ? 0 : undefined,
+  },
 };
 
 CustomAnimation.args = {
@@ -94,7 +98,7 @@ CustomAnimation.args = {
   isVisible: undefined,
   openedOnInit: true,
   transitionOptions: {
-    duration: 500,
+    duration: isChromatic() ? 0 : 500,
     initial: {
       opacity: 0,
     },

--- a/packages/react-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/react-components/src/components/Popover/Popover.stories.tsx
@@ -53,7 +53,11 @@ export default {
   parameters: {
     layout: 'centered',
     controls: { expanded: true },
-    // chromatic: { delay: 600 },
+  },
+  args: {
+    transitionOptions: {
+      duration: isChromatic() ? 0 : undefined,
+    },
   },
   decorators: [
     (Story: StoryFn) => (
@@ -88,9 +92,6 @@ Default.args = {
   placement: 'bottom-start',
   isVisible: undefined,
   openedOnInit: true,
-  transitionOptions: {
-    duration: isChromatic() ? 0 : undefined,
-  },
 };
 
 CustomAnimation.args = {

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -48,9 +48,13 @@ export default {
       },
     },
   },
+  args: {
+    transitionOptions: {
+      duration: isChromatic() ? 0 : undefined,
+    },
+  },
   parameters: {
     controls: { expanded: true },
-    // chromatic: { delay: 300 },
   },
   subcomponents: {
     Info,
@@ -67,9 +71,6 @@ export const Default = (args: ITooltipProps): React.ReactElement => (
 );
 Default.args = {
   isVisible: true,
-  transitionOptions: {
-    duration: isChromatic() ? 0 : undefined,
-  },
 };
 Default.decorators = [
   (Story: StoryFn) => (
@@ -114,9 +115,6 @@ export const TooltipInfo = (args: ITooltipProps): React.ReactElement => (
 );
 TooltipInfo.args = {
   isVisible: true,
-  transitionOptions: {
-    duration: isChromatic() ? 0 : undefined,
-  },
 };
 TooltipInfo.decorators = [
   (Story: StoryFn) => (
@@ -150,9 +148,6 @@ export const TooltipInteractive = (args: ITooltipProps): React.ReactElement => (
 );
 TooltipInteractive.args = {
   isVisible: true,
-  transitionOptions: {
-    duration: isChromatic() ? 0 : undefined,
-  },
 };
 TooltipInteractive.decorators = [
   (Story: StoryFn) => (
@@ -180,9 +175,6 @@ export const TooltipReports = (args: ITooltipProps): React.ReactElement => (
 TooltipReports.args = {
   isVisible: true,
   fullSpaceContent: true,
-  transitionOptions: {
-    duration: isChromatic() ? 0 : undefined,
-  },
 };
 TooltipReports.decorators = [
   (Story: StoryFn) => (

--- a/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Meta, StoryFn } from '@storybook/react';
+import isChromatic from 'chromatic/isChromatic';
 
 import { StoryDescriptor } from '../../stories/components/StoryDescriptor';
 import { customHeightForChromatic } from '../../utils/chromatic-story-helpers';
@@ -49,7 +50,7 @@ export default {
   },
   parameters: {
     controls: { expanded: true },
-    chromatic: { delay: 300 },
+    // chromatic: { delay: 300 },
   },
   subcomponents: {
     Info,
@@ -66,6 +67,9 @@ export const Default = (args: ITooltipProps): React.ReactElement => (
 );
 Default.args = {
   isVisible: true,
+  transitionOptions: {
+    duration: isChromatic() ? 0 : undefined,
+  },
 };
 Default.decorators = [
   (Story: StoryFn) => (
@@ -110,6 +114,9 @@ export const TooltipInfo = (args: ITooltipProps): React.ReactElement => (
 );
 TooltipInfo.args = {
   isVisible: true,
+  transitionOptions: {
+    duration: isChromatic() ? 0 : undefined,
+  },
 };
 TooltipInfo.decorators = [
   (Story: StoryFn) => (
@@ -143,6 +150,9 @@ export const TooltipInteractive = (args: ITooltipProps): React.ReactElement => (
 );
 TooltipInteractive.args = {
   isVisible: true,
+  transitionOptions: {
+    duration: isChromatic() ? 0 : undefined,
+  },
 };
 TooltipInteractive.decorators = [
   (Story: StoryFn) => (
@@ -170,6 +180,9 @@ export const TooltipReports = (args: ITooltipProps): React.ReactElement => (
 TooltipReports.args = {
   isVisible: true,
   fullSpaceContent: true,
+  transitionOptions: {
+    duration: isChromatic() ? 0 : undefined,
+  },
 };
 TooltipReports.decorators = [
   (Story: StoryFn) => (


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: n/a

## Description

This pull request includes changes to the `Popover` and `Tooltip` component stories to try to improve their behavior in Chromatic testing environments by adjusting the transition duration of the animations to 0 in chromatic environment.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-fix-animations-in-chromatic--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
  - Enhanced popover transitions with adaptive animation duration, ensuring a smoother and more responsive visual experience across environments.  
  - Updated tooltip transitions now adjust their timing based on rendering conditions, providing seamless and consistent visual feedback during demos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->