### PR TITLE
fix(UserGuide): fix sizing  for images and videos

### DIFF
--- a/packages/react-components/src/components/UserGuide/UserGuide.module.scss
+++ b/packages/react-components/src/components/UserGuide/UserGuide.module.scss
@@ -48,7 +48,7 @@ $animations: (
 
     transition-property: top, bottom, left, right;
     transition-timing-function: ease-in-out;
-    z-index: $stacking-context-level-tooltip;
+    z-index: $stacking-context-level-modal;
     opacity: 0;
     animation-duration: var(--transition-duration-moderate-2);
     animation-timing-function: ease-in-out;

--- a/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
@@ -548,6 +548,52 @@ UserGuideStepExample.parameters = {
   layout: 'centered',
 };
 
+export const UserGuideStepExampleWithImage = (): ReactElement => {
+  return (
+    <UserGuideStep
+      image={{
+        src: 'https://placehold.co/600x300',
+        alt: 'test image',
+      }}
+      aria-label="Navigation guide step"
+      header="This is navigation item"
+      text="Some text, maximum 210 characters. But can be divided into couple of message. More or less can be up to 4 lines. So let’s see how it looks like and let’s make it 4 lines. Ok, cool."
+      currentStep={1}
+      stepMax={9}
+      handleClickPrimary={() => {}}
+      handleCloseAction={() => {}}
+    />
+  );
+};
+UserGuideStepExampleWithImage.parameters = {
+  layout: 'centered',
+};
+
+export const UserGuideStepExampleWithVideo = (): ReactElement => {
+  return (
+    <UserGuideStep
+      video={{
+        src: 'https://cdn.livechat-static.com/api/file/lc/img/default/assets/copilot-popover.mp4',
+        playsInline: true,
+        autoPlay: true,
+        muted: true,
+        loop: true,
+        controls: true,
+      }}
+      aria-label="Navigation guide step"
+      header="This is navigation item"
+      text="Some text, maximum 210 characters. But can be divided into couple of message. More or less can be up to 4 lines. So let’s see how it looks like and let’s make it 4 lines. Ok, cool."
+      currentStep={1}
+      stepMax={9}
+      handleClickPrimary={() => {}}
+      handleCloseAction={() => {}}
+    />
+  );
+};
+UserGuideStepExampleWithVideo.parameters = {
+  layout: 'centered',
+};
+
 export const UserGuideBubbleStepExample = (): ReactElement => {
   return (
     <UserGuideBubbleStep

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.module.scss
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.module.scss
@@ -19,10 +19,17 @@ $base-class: 'user-guide-step';
     color: var(--content-basic-secondary);
   }
 
-  &__image-wrapper {
-    display: flex;
-    justify-content: center;
+  &__media-wrapper {
     margin-bottom: var(--spacing-4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__media {
+    max-height: 240px;
+    max-width: 100%;
+    border-radius: var(--radius-3);
   }
 
   &__footer {

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.tsx
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.tsx
@@ -46,24 +46,27 @@ export const UserGuideStep: FC<IUserGuideStepProps> = ({
         {header}
       </Text>
       {image && (
-        <div className={styles[`${baseClass}__image-wrapper`]}>
+        <div className={styles[`${baseClass}__media-wrapper`]}>
           <img
-            className={styles[`${baseClass}-image`]}
+            className={styles[`${baseClass}__media`]}
             src={image.src}
             alt={image.alt}
           />
         </div>
       )}
       {video && !image && (
-        <video
-          data-testid="user-guide-step-video"
-          src={video.src}
-          playsInline={video.playsInline}
-          autoPlay={video.autoPlay}
-          muted={video.muted}
-          loop={video.loop}
-          controls={video.controls}
-        />
+        <div className={styles[`${baseClass}__media-wrapper`]}>
+          <video
+            className={styles[`${baseClass}__media`]}
+            data-testid="user-guide-step-video"
+            src={video.src}
+            playsInline={video.playsInline}
+            autoPlay={video.autoPlay}
+            muted={video.muted}
+            loop={video.loop}
+            controls={video.controls}
+          />
+        </div>
       )}
       <Text
         id="user-guide-step-typed-text"


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: n/a

## Description
- Updated UserGuideStep to better handle sizes and layout for both image and video media
- Added consistent media styling with max height and border radius
- Added new story examples for UserGuideStep with image and video

Additionally:
- Adjusted z-index of overlay to use modal stacking context

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-fix-media-user-guide--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced user guide examples that showcase media-rich steps with both image and video demonstrations. These examples illustrate different approaches for presenting step-by-step guidance.

- **Style**
  - Refined the layering of floating elements for improved visibility.
  - Updated media presentation styling for better alignment, sizing, and overall consistency within the user guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->