### PR TITLE
feat(Picker): add avatar variations to Picker component

### DIFF
--- a/packages/react-components/src/components/Picker/Picker.stories.tsx
+++ b/packages/react-components/src/components/Picker/Picker.stories.tsx
@@ -348,3 +348,75 @@ export const SearchBehavior = (): React.ReactElement => (
     </StoryDescriptor>
   </div>
 );
+
+const AVATAR_OPTIONS = {
+  NO_AVATARS: [
+    { key: '1', name: 'Option One' },
+    { key: '2', name: 'Option Two' },
+    { key: '3', name: 'Option Three' },
+  ] as IPickerListItem[],
+  WITH_AVATARS: [
+    {
+      key: '1',
+      name: 'John Smith',
+      avatarSrc: 'text',
+      avatar: { src: image, type: 'image' },
+    },
+    {
+      key: '2',
+      name: 'Jane Doe',
+      avatar: { src: image, type: 'image' },
+    },
+    {
+      key: '3',
+      name: 'Bob Wilson',
+      avatar: { src: image, type: 'image' },
+    },
+  ] as IPickerListItem[],
+  DEFAULT_AVATARS: [
+    { key: '1', name: 'John Smith', avatar: { type: 'text' } },
+    { key: '2', name: 'Jane Doe', avatar: { type: 'text' } },
+    { key: '3', name: 'Bob Wilson', avatar: { type: 'text' } },
+  ] as IPickerListItem[],
+  MIXED_AVATARS: [
+    {
+      key: '1',
+      name: 'John Smith',
+      avatar: { src: image, type: 'image' },
+    },
+    { key: '2', name: 'Jane Doe', avatar: { type: 'text' } },
+    { key: '3', name: 'Bob Wilson', avatar: { type: 'text' } },
+    {
+      key: '4',
+      name: 'Alice Brown',
+      avatar: { src: image, type: 'image' },
+    },
+  ] as IPickerListItem[],
+};
+
+export const AvatarVariations = (): React.ReactElement => (
+  <div style={{ ...commonWidth, marginBottom: 320 }}>
+    <StoryDescriptor title="No avatars">
+      <PickerComponent
+        options={AVATAR_OPTIONS.NO_AVATARS}
+        onSelect={noop}
+        openedOnInit
+      />
+    </StoryDescriptor>
+
+    <StoryDescriptor title="With custom avatars">
+      <PickerComponent options={AVATAR_OPTIONS.WITH_AVATARS} onSelect={noop} />
+    </StoryDescriptor>
+
+    <StoryDescriptor title="With default avatars">
+      <PickerComponent
+        options={AVATAR_OPTIONS.DEFAULT_AVATARS}
+        onSelect={noop}
+      />
+    </StoryDescriptor>
+
+    <StoryDescriptor title="Mixed avatars">
+      <PickerComponent options={AVATAR_OPTIONS.MIXED_AVATARS} onSelect={noop} />
+    </StoryDescriptor>
+  </div>
+);

--- a/packages/react-components/src/components/Picker/Picker.stories.tsx
+++ b/packages/react-components/src/components/Picker/Picker.stories.tsx
@@ -359,7 +359,6 @@ const AVATAR_OPTIONS = {
     {
       key: '1',
       name: 'John Smith',
-      avatarSrc: 'text',
       avatar: { src: image, type: 'image' },
     },
     {

--- a/packages/react-components/src/components/Picker/components/PickerListItem.tsx
+++ b/packages/react-components/src/components/Picker/components/PickerListItem.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Check } from '@livechat/design-system-icons';
 import cx from 'clsx';
 
+import { Avatar } from '../../Avatar';
 import { Checkbox } from '../../Checkbox';
 import { Icon } from '../../Icon';
 import { Heading, Text } from '../../Typography';
@@ -60,11 +61,14 @@ export const PickerListItem: React.FC<IPickerListItemProps> = ({
             source={item.icon}
           />
         )}
-        {item.avatarSrc && (
-          <img
-            className={cx(styles[`${itemClassName}__avatar`])}
-            src={item.avatarSrc}
+        {(item.avatar || item.avatarSrc) && (
+          <Avatar
+            className={styles[`${itemClassName}__avatar`]}
+            src={item.avatar?.src || item.avatarSrc}
+            type={item.avatar?.type || (item.avatarSrc ? 'image' : 'text')}
+            text={item.name}
             alt={item.name}
+            size="xxsmall"
           />
         )}
         <div className={styles[`${itemClassName}__label-container`]}>

--- a/packages/react-components/src/components/Picker/components/PickerListItem.tsx
+++ b/packages/react-components/src/components/Picker/components/PickerListItem.tsx
@@ -46,6 +46,9 @@ export const PickerListItem: React.FC<IPickerListItemProps> = ({
       );
     }
 
+    const getAvatarType = (item: IPickerListItem) =>
+      item.avatar?.type || (item.avatarSrc ? 'image' : 'text');
+
     return (
       <>
         {item.showCheckbox && (
@@ -65,7 +68,7 @@ export const PickerListItem: React.FC<IPickerListItemProps> = ({
           <Avatar
             className={styles[`${itemClassName}__avatar`]}
             src={item.avatar?.src || item.avatarSrc}
-            type={item.avatar?.type || (item.avatarSrc ? 'image' : 'text')}
+            type={getAvatarType(item)}
             text={item.name}
             alt={item.name}
             size="xxsmall"

--- a/packages/react-components/src/components/Picker/types.ts
+++ b/packages/react-components/src/components/Picker/types.ts
@@ -11,6 +11,7 @@ import { VirtuosoProps } from 'react-virtuoso';
 
 import { Size } from '../../utils';
 import { ComponentCoreProps } from '../../utils/types';
+import { AvatarType } from '../Avatar/types';
 import { IconSource } from '../Icon';
 import { TagProps } from '../Tag';
 
@@ -24,7 +25,14 @@ export interface IPickerListItem {
   groupHeader?: boolean;
   disabled?: boolean;
   icon?: IconSource;
+  /**
+   * @deprecated Use avatar object instead
+   */
   avatarSrc?: string;
+  avatar?: {
+    src?: string;
+    type: AvatarType;
+  } | null;
   secondaryText?: string;
   showCheckbox?: boolean;
   selectedTagOptions?: TagProps;


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1349

## Description

This pull request includes changes to the `Picker` component in the `react-components` package, focusing on enhancing the avatar handling functionality. The most important changes include adding new avatar variations in the stories, updating the `PickerListItem` component to use the `Avatar` component, and deprecating the `avatarSrc` property in favor of a new `avatar` object.

Enhancements to avatar handling:

* Updated the `PickerListItem` component to use the `Avatar` component instead of directly using `avatarSrc`. This lets the user to choose what type of Avatar to render.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1349--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive demonstration showcasing four distinct avatar variations—no avatars, custom avatars, default avatars, and mixed options—for the Picker component.
- **Enhancements**
  - Refined avatar display to support both image and text-based representations, providing a more consistent and flexible visual experience for users.
  - Updated interface to include a structured representation for avatar data, enhancing clarity and flexibility in handling avatar information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->