### PR TITLE
feat(Accordion): new prop

### DIFF
--- a/packages/react-components/src/components/Accordion/Accordion.module.scss
+++ b/packages/react-components/src/components/Accordion/Accordion.module.scss
@@ -12,6 +12,7 @@ $base-class: 'accordion';
   background-color: var(--surface-secondary-default);
   width: 100%;
   min-height: 24px;
+  overflow: hidden;
 
   &:focus-visible {
     outline: 0;
@@ -101,6 +102,10 @@ $base-class: 'accordion';
 
       &--promo {
         padding: 0 var(--spacing-12) var(--spacing-6) var(--spacing-6);
+      }
+
+      &--full-width {
+        padding: 0;
       }
     }
   }

--- a/packages/react-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react-components/src/components/Accordion/Accordion.stories.tsx
@@ -120,6 +120,18 @@ export const Examples = (): React.ReactElement => {
           Default accordion content
         </Accordion>
       </StoryDescriptor>
+      <StoryDescriptor title="With full width content">
+        <Accordion label="Default" fullWidthContent>
+          <div className="multiline no-radius">
+            <p>{`Hello {{ticket.requesterName}},`}</p>
+            <p>
+              We haven't heard back from you for some time. If you need any
+              further help, please follow up on this email.
+            </p>
+            <p>Thank you.</p>
+          </div>
+        </Accordion>
+      </StoryDescriptor>
     </div>
   );
 };

--- a/packages/react-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react-components/src/components/Accordion/Accordion.stories.tsx
@@ -132,6 +132,11 @@ export const Examples = (): React.ReactElement => {
           </div>
         </Accordion>
       </StoryDescriptor>
+      <StoryDescriptor title="With hidden chevron icon">
+        <Accordion label="Default" hideChevron>
+          Default accordion content
+        </Accordion>
+      </StoryDescriptor>
     </div>
   );
 };

--- a/packages/react-components/src/components/Accordion/Accordion.tsx
+++ b/packages/react-components/src/components/Accordion/Accordion.tsx
@@ -25,6 +25,7 @@ const AccordionComponent: React.FC<IAccordionComponentProps> = ({
   label,
   multilineElement,
   openOnInit = false,
+  fullWidthContent,
   isOpen,
   isPromo,
   footer,
@@ -109,6 +110,8 @@ const AccordionComponent: React.FC<IAccordionComponentProps> = ({
                 className={cx(styles[`${baseClass}__content__inner`], {
                   [styles[`${baseClass}__content__inner--open`]]: isExpanded,
                   [styles[`${baseClass}__content__inner--promo`]]: isPromo,
+                  [styles[`${baseClass}__content__inner--full-width`]]:
+                    fullWidthContent,
                 })}
               >
                 {children}

--- a/packages/react-components/src/components/Accordion/Accordion.tsx
+++ b/packages/react-components/src/components/Accordion/Accordion.tsx
@@ -26,6 +26,7 @@ const AccordionComponent: React.FC<IAccordionComponentProps> = ({
   multilineElement,
   openOnInit = false,
   fullWidthContent,
+  hideChevron,
   isOpen,
   isPromo,
   footer,
@@ -84,13 +85,15 @@ const AccordionComponent: React.FC<IAccordionComponentProps> = ({
       onKeyDown={handleKeyDown}
       {...props}
     >
-      <Icon
-        source={ChevronDown}
-        className={cx(styles[`${baseClass}__chevron`], {
-          [styles[`${baseClass}__chevron--open`]]: isExpanded,
-          [styles[`${baseClass}__chevron--promo`]]: isPromo,
-        })}
-      />
+      {!hideChevron && (
+        <Icon
+          source={ChevronDown}
+          className={cx(styles[`${baseClass}__chevron`], {
+            [styles[`${baseClass}__chevron--open`]]: isExpanded,
+            [styles[`${baseClass}__chevron--promo`]]: isPromo,
+          })}
+        />
+      )}
       {buildHeader(isPromo)}
       {multilineElement && (
         <AccordionMultilineElement isExpanded={isExpanded}>

--- a/packages/react-components/src/components/Accordion/AccordionStories.css
+++ b/packages/react-components/src/components/Accordion/AccordionStories.css
@@ -30,6 +30,10 @@
   }
 }
 
+.multiline.no-radius {
+  border-radius: 0;
+}
+
 .accordion-promo-closed-heading {
   margin-bottom: 4px;
 }

--- a/packages/react-components/src/components/Accordion/types.ts
+++ b/packages/react-components/src/components/Accordion/types.ts
@@ -32,6 +32,10 @@ export interface IAccordionGlobalProps extends ComponentCoreProps {
    */
   isOpen?: boolean;
   /**
+   * Set to display the accordion content with full width
+   */
+  fullWidthContent?: boolean;
+  /**
    * Optional handler called on accordion close
    */
   onClose?: () => void;

--- a/packages/react-components/src/components/Accordion/types.ts
+++ b/packages/react-components/src/components/Accordion/types.ts
@@ -36,6 +36,10 @@ export interface IAccordionGlobalProps extends ComponentCoreProps {
    */
   fullWidthContent?: boolean;
   /**
+   * Set to hide the chevron icon
+   */
+  hideChevron?: boolean;
+  /**
    * Optional handler called on accordion close
    */
   onClose?: () => void;


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1604 

## Description
Added the `feature/1604` to remove the padding in accordion content.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1604--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The Accordion component now supports a full-width display option for its inner content, allowing for a layout without extra padding.
  - Users can hide the chevron icon for a cleaner look.

- **Style**
  - Enhanced overflow handling to maintain a clean presentation.
  - New styling ensures a consistent, square-corner appearance for elements with the `multiline` and `no-radius` classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->