### PR TITLE
feat(user-guide): add hideOverlay prop

### DIFF
--- a/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
@@ -43,6 +43,9 @@ export default {
     useDismissHookProps: {
       control: false,
     },
+    className: {
+      control: false,
+    },
     elementClassName: {
       control: false,
     },

--- a/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useReducer, useState } from 'react';
 
 import { Placement } from '@floating-ui/react';
 import * as Icons from '@livechat/design-system-icons';
-import { Meta } from '@storybook/react-vite';
+import { Meta, StoryFn } from '@storybook/react-vite';
 
 import exampleVideo from '../../assets/onboarding_final.mp4';
 import { AppFrame } from '../AppFrame';
@@ -28,7 +28,7 @@ import { Tooltip } from '../Tooltip';
 
 import { UserGuideBubbleStep, UserGuideStep } from './components';
 import { AppContent } from './stories-helpers';
-import { CursorTiming } from './types';
+import { CursorTiming, IUserGuide } from './types';
 import { UserGuide } from './UserGuide';
 
 import './UserGuideStories.css';
@@ -41,6 +41,35 @@ export default {
       control: false,
     },
     useDismissHookProps: {
+      control: false,
+    },
+    elementClassName: {
+      control: false,
+    },
+    cursorPosition: {
+      control: false,
+    },
+    cursorTiming: {
+      control: false,
+    },
+    parentElementName: {
+      control: false,
+    },
+    isVisible: {
+      control: false,
+    },
+    hideOverlay: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    zIndex: {
+      control: false,
+    },
+    isFirstStep: {
+      control: false,
+    },
+    isLastStep: {
       control: false,
     },
   },
@@ -84,7 +113,9 @@ const secondaryNavigationIcons = [
 const defaultImage =
   'https://cdn-labs.livechat-files.com/api/file/lc/img/100019504/df59da4b5b0cdb6030efb08787fd255d.jpg';
 
-export const Example = (): ReactElement => {
+export const Example: StoryFn<IUserGuide> = (
+  args: IUserGuide
+): ReactElement => {
   const [activeItem, setActiveItem] = useState('archives');
   const [activeSubItem, setActiveSubItem] = useState(0);
   const [topBarVisible] = useState(true);
@@ -371,6 +402,7 @@ export const Example = (): ReactElement => {
           elementClassName={state.elementClassName}
           isFirstStep={state.reference === 'first-step'}
           isLastStep={state.reference === 'last-step'}
+          hideOverlay={args.hideOverlay}
         >
           {state.reference === 'first-step' ? (
             <UserGuideBubbleStep

--- a/packages/react-components/src/components/UserGuide/UserGuide.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.tsx
@@ -23,6 +23,7 @@ export const UserGuide: FC<PropsWithChildren<IUserGuide>> = ({
   cursorTiming = 'fast2',
   parentElementName,
   isVisible = false,
+  hideOverlay = false,
   elementClassName,
   zIndex,
   isFirstStep,
@@ -135,7 +136,7 @@ export const UserGuide: FC<PropsWithChildren<IUserGuide>> = ({
       <div
         className={cx(styles[`${baseClass}__overlay`])}
         style={{
-          display: isVisible ? 'flex' : 'none',
+          display: isVisible && !hideOverlay ? 'flex' : 'none',
           zIndex: zIndex,
         }}
       >

--- a/packages/react-components/src/components/UserGuide/types.ts
+++ b/packages/react-components/src/components/UserGuide/types.ts
@@ -28,7 +28,7 @@ export interface IUserGuide {
    */
   isVisible?: boolean;
   /**
-   * The visibility of the overlay
+   * Set to true to hide the overlay
    */
   hideOverlay?: boolean;
   /**

--- a/packages/react-components/src/components/UserGuide/types.ts
+++ b/packages/react-components/src/components/UserGuide/types.ts
@@ -28,6 +28,10 @@ export interface IUserGuide {
    */
   isVisible?: boolean;
   /**
+   * The visibility of the overlay
+   */
+  hideOverlay?: boolean;
+  /**
    * The custom z-index value for the overlay
    */
   zIndex?: number;


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1645

## Description
Added option to hide the dimming overlay while keeping the `UserGuide` open.

## Storybook

<!--- Branch name will be inserted automatically -->
https://me-851--613a8e945a5665003a05113b.chromatic.com/

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UserGuide gains a new option to hide its overlay; when enabled the overlay is suppressed even if the guide is visible.
  * Default behavior unchanged — if the option isn’t used, overlays behave as before.
* **Documentation / Examples**
  * Story example updated to expose a hideOverlay control for interactive testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->