### PR TITLE
feat(ProductSwitcher): remove target="_blank" from anchor tag

### DIFF
--- a/packages/example-react/src/main.tsx
+++ b/packages/example-react/src/main.tsx
@@ -3,7 +3,7 @@ import { Container, createRoot } from 'react-dom/client';
 
 import App from './App';
 
-import '@livechat/design-system-react-components/dist/style.css';
+import '@livechat/design-system-react-components/dist/design-system-react-components.css';
 
 const container = document.getElementById('root');
 const root = createRoot(container as Container);

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -16,7 +16,6 @@
 
 This package contains a library of reusable React components designed to be used in various projects. These components are the building blocks of our design system and can be easily integrated into your applications.
 
-
 ## Installation
 
 Run the following command using [npm](https://www.npmjs.com/) (or with you other favorite package manager, eg. [yarn](https://yarnpkg.com/)):
@@ -30,7 +29,7 @@ npm install @livechat/design-system-react-components @livechat/design-system-ico
 It is required to import the `CSS` directly into your project so it could be applied to components:
 
 ```js
-import '@livechat/design-system-react-components/dist/style.css';
+import '@livechat/design-system-react-components/dist/design-system-react-components.css
 ```
 
 You can import components directly from the npm package:
@@ -54,7 +53,6 @@ At this stage of the project we consider Storybook and Figma as parts of our doc
 
 [Storybook](https://design.livechat.com/) - includes design system foundations, describes components API and allows to familiarize with the thier capabilities
 [Figma](https://www.figma.com/file/2pFu80PXO5A2tfyrAGnx91/Product-Components) - it's not an official documentation from design perspective but we follow a simple rule of working in public
-
 
 ### Development
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -29,7 +29,7 @@ npm install @livechat/design-system-react-components @livechat/design-system-ico
 It is required to import the `CSS` directly into your project so it could be applied to components:
 
 ```js
-import '@livechat/design-system-react-components/dist/design-system-react-components.css
+import '@livechat/design-system-react-components/dist/design-system-react-components.css';
 ```
 
 You can import components directly from the npm package:

--- a/packages/react-components/src/components/ProductSwitcher/components/ProductRow/ProductRow.tsx
+++ b/packages/react-components/src/components/ProductSwitcher/components/ProductRow/ProductRow.tsx
@@ -46,7 +46,6 @@ export const ProductRow: FC<IProps> = ({
       {withDivider && <div className={styles[`${baseClass}__divider`]} />}
       <a
         href={url}
-        target="_blank"
         aria-label={`Go to ${name} product`}
         onClick={(event) => onClick(event, id)}
         className={cx(styles[baseClass], {


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1652

## Description

This pull request makes a small update to the `ProductRow` component. The change removes the `target="_blank"` attribute from the product link, so clicking the link will now open it in the same tab instead of a new one.

- Removed `target="_blank"` from the anchor tag in `ProductRow.tsx`, so product links no longer open in a new tab.

- Additionally, updated READ.ME after the last vite dependency upgrade  
https://v6.vite.dev/guide/migration#customize-css-output-file-name-in-library-mode

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1652--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Product Switcher links now open in the current tab/window for more predictable navigation.
  - Example app now loads an updated stylesheet, adjusting the app's styling import path.

- **Documentation**
  - Component docs updated with minor formatting tweaks and a revised example showing the new stylesheet import and wording adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->