### PR TITLE
feat(table): Add `customBackgroundColor` prop

### DIFF
--- a/packages/react-components/src/components/Table/Table.module.scss
+++ b/packages/react-components/src/components/Table/Table.module.scss
@@ -31,7 +31,7 @@ $base-class: 'table';
         transition: top 0.2s ease-in-out;
         z-index: 5;
         box-shadow: var(--shadow-fixed-bottom);
-        background-color: var(--background-01);
+        background-color: var(--custom-table-bg, var(--background-01));
       }
 
       &.#{$base-class}--has-selected thead {

--- a/packages/react-components/src/components/Table/Table.stories.tsx
+++ b/packages/react-components/src/components/Table/Table.stories.tsx
@@ -247,3 +247,165 @@ export const MultiSelect: StoryFn = () => {
     />
   );
 };
+
+export const WithCustomBackgroundColor: StoryFn = () => {
+  const [selectedRows, setSelectedRows] = React.useState<Set<string | number>>(
+    new Set()
+  );
+
+  const getRowId = (row: Data): string | number => row.id;
+  const data = generateData(4);
+
+  const Divider = () => (
+    <div
+      style={{
+        width: '1px',
+        height: '24px',
+        margin: '0 var(--spacing-4)',
+        backgroundColor: 'var(--border-invert-secondary)',
+      }}
+    />
+  );
+
+  const rowActions = (
+    <div
+      style={{ display: 'flex', gap: 'var(--spacing-2)', alignItems: 'center' }}
+    >
+      <ActionMenu
+        options={[
+          {
+            key: 'Action 1',
+            element: 'Action 1',
+          },
+          {
+            key: 'Action 2',
+            element: 'Action 2',
+          },
+        ]}
+        triggerRenderer={
+          <Button
+            style={{ paddingRight: '0' }}
+            kind="link-inverted"
+            size="compact"
+            iconPosition="right"
+            icon={<Icon source={ChevronDown} />}
+          >
+            Action Menu
+          </Button>
+        }
+      />
+      <Divider />
+      <Button
+        style={{ paddingLeft: '0' }}
+        icon={<Icon source={AddIcon} />}
+        kind="link-inverted"
+        size="compact"
+      >
+        Action 1
+      </Button>
+      <Divider />
+      <Button kind="secondary" size="compact">
+        Action 2
+      </Button>
+      <Button kind="secondary" size="compact">
+        Action 3
+      </Button>
+    </div>
+  );
+
+  return (
+    <>
+      <StoryDescriptor title="Default">
+        <div style={{ width: '100%' }}>
+          <Table
+            size="medium"
+            data={data}
+            columns={columns}
+            getRowId={getRowId}
+            customBackgroundColor="darkGray"
+          />
+        </div>
+      </StoryDescriptor>
+      <StoryDescriptor title="With row selection">
+        <div style={{ width: '100%' }}>
+          <Table
+            size="medium"
+            data={data}
+            columns={columns}
+            getRowId={getRowId}
+            selectable
+            selectedRows={selectedRows}
+            onSelectionChange={setSelectedRows}
+            rowActions={rowActions}
+            customBackgroundColor="darkGray"
+          />
+        </div>
+      </StoryDescriptor>
+      <StoryDescriptor title="With striped rows">
+        <div style={{ width: '100%' }}>
+          <Table
+            size="medium"
+            data={data}
+            columns={columns}
+            getRowId={getRowId}
+            stripped="rows"
+            customBackgroundColor="darkGray"
+          />
+        </div>
+      </StoryDescriptor>
+      <StoryDescriptor title="With striped columns">
+        <div style={{ width: '100%' }}>
+          <Table
+            size="medium"
+            data={data}
+            columns={columns}
+            getRowId={getRowId}
+            stripped="columns"
+            customBackgroundColor="darkGray"
+          />
+        </div>
+      </StoryDescriptor>
+      <StoryDescriptor title="With striped columns and other color">
+        <div style={{ width: '100%' }}>
+          <Table
+            size="medium"
+            data={data}
+            columns={columns}
+            getRowId={getRowId}
+            stripped="columns"
+            customBackgroundColor="aliceblue"
+          />
+        </div>
+      </StoryDescriptor>
+      <StoryDescriptor title="With pinned header" />
+      <StoryDescriptor
+        title=""
+        style={{ overflow: 'scroll', maxHeight: '200px' }}
+      >
+        <div style={{ width: '100%' }}>
+          <Table
+            size="large"
+            data={data}
+            columns={columns}
+            getRowId={getRowId}
+            pin="header"
+            customBackgroundColor="darkGray"
+          />
+        </div>
+      </StoryDescriptor>
+      <StoryDescriptor title="With pinned left column" />
+      <StoryDescriptor title="" style={{ overflow: 'scroll' }}>
+        <div style={{ width: '100%' }}>
+          <Table
+            size="medium"
+            data={dataForPinningExample}
+            columns={columnsForPinningExample}
+            getRowId={(row: DataForPinningExample) => row.userId}
+            pin="leftColumn"
+            customBackgroundColor="darkGray"
+          />
+        </div>
+      </StoryDescriptor>
+    </>
+  );
+};

--- a/packages/react-components/src/components/Table/Table.tsx
+++ b/packages/react-components/src/components/Table/Table.tsx
@@ -28,6 +28,7 @@ export const Table = <T,>({
   rowSelectionMessage,
   rowActions,
   testId,
+  customBackgroundColor,
 }: ITableProps<T>) => {
   const columnRefs = React.useRef<(HTMLTableCellElement | null)[]>([]);
   const [hoveredColumnIndex, setHoveredColumnIndex] = React.useState<
@@ -152,6 +153,12 @@ export const Table = <T,>({
     setColumnWidths(initialWidths);
   }, []);
 
+  const tableStyle = customBackgroundColor
+    ? ({
+        '--custom-table-bg': customBackgroundColor,
+      } as React.CSSProperties)
+    : {};
+
   return (
     <>
       {
@@ -182,6 +189,7 @@ export const Table = <T,>({
           styles[`${baseClass}--stripped_${stripped}`]
         )}
         data-testid={testId}
+        style={tableStyle}
       >
         <TableHeader
           columns={columns}

--- a/packages/react-components/src/components/Table/TableHeader.module.scss
+++ b/packages/react-components/src/components/Table/TableHeader.module.scss
@@ -5,7 +5,7 @@ $base-class: 'header';
 
 .#{$base-class} {
   border-bottom: 1px solid var(--border-basic-tertiary);
-  background-color: var(--background-01);
+  background-color: var(--custom-table-bg, var(--background-01));
   height: var(--spacing-12);
   line-height: var(--spacing-5);
   color: var(--content-basic-secondary);
@@ -27,7 +27,10 @@ $base-class: 'header';
 
     &--hoverDisabled {
       &:hover {
-        background-color: var(--background-01) !important;
+        background-color: var(
+          --custom-table-bg,
+          var(--background-01)
+        ) !important;
       }
     }
   }

--- a/packages/react-components/src/components/Table/TableRow.module.scss
+++ b/packages/react-components/src/components/Table/TableRow.module.scss
@@ -3,7 +3,7 @@ $table-class: 'table';
 
 .#{$base-class} {
   border-bottom: 1px solid var(--border-basic-tertiary);
-  background-color: var(--background-01);
+  background-color: var(--custom-table-bg, var(--background-01));
 
   &:not(.#{$table-class}__header):hover {
     background-color: var(--surface-primary-hover);

--- a/packages/react-components/src/components/Table/styles/pin.scss
+++ b/packages/react-components/src/components/Table/styles/pin.scss
@@ -6,13 +6,15 @@
       z-index: 5;
       box-shadow: var(--shadow-fixed-bottom);
     }
-  } @else if $type == 'leftColumn' {
+  }
+
+ @else if $type == 'leftColumn' {
     tr > td:first-child,
     th:first-child {
       position: sticky;
       left: 0;
       z-index: 5;
-      background-color: var(--background-01);
+      background-color: var(--custom-table-bg, var(--background-01));
     }
 
     tr:hover > td:first-child {
@@ -27,7 +29,7 @@
       bottom: 0;
       z-index: 5;
       box-shadow: var(--shadow-fixed-right);
-      background-color: var(--background-01);
+      background-color: var(--custom-table-bg, var(--background-01));
       width: 5px;
       content: '';
       clip-path: inset(0 -15px 0 0);
@@ -36,7 +38,9 @@
     tr:hover > td:first-child::after {
       background-color: var(--surface-primary-hover);
     }
-  } @else {
+  }
+
+ @else {
     @warn "Invalid pinned value: #{$type}. Supported values are 'header' and 'leftColumn'.";
   }
 }

--- a/packages/react-components/src/components/Table/types.ts
+++ b/packages/react-components/src/components/Table/types.ts
@@ -63,6 +63,12 @@ type BaseTableProps<T> = {
    * Sets the `data-testid` attribute, allowing the table to be easily selected in automated tests.
    */
   testId?: string;
+  /**
+   * Custom background color for table elements in their default state.
+   * When provided, all table elements will use this color as their background-color.
+   * Other states (hover, selected, etc.) will remain unchanged.
+   */
+  customBackgroundColor?: string;
 };
 
 type NonSelectableTableProps<T> = BaseTableProps<T> & {


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: https://github.com/livechat/design-system/issues/1654

## Description
Added option to table to enable setting custom background color. For hover, selected, etc. states, the background color remains the same.
Background color is sufficient for our usecase, decided against introducing a `className` prop.

Below is outdated, decided to change approach.
> We need to align Table styling of Omnichannel apps embedded in Text App - in particular `background-color` in Table component.
> To maintain the same bg color across all relevant table elements, `inherit` had to replace multiple `var(--background-01)` values and `var(--background-01)` was set as the single main bg color of the Table. This uncovered a sideeffect - if parent element of one of the table sub-elements doesn't explicitly have `background-color: inherit` defined (the `inherit` chain is broken in relation to Table's main `background-color`), the child element bg color would becine transparent.
> Based on that:
> - I've added `background-color: inherit` where I found it was missing,
> - tested in all storybook variants and didn't find anything breaking.
> 
> There still could be a case I haven't found which would cause visual regression with transparent background.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1654--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue
