### PR TITLE
feat(UserGuideStep): Extend `UserGuideStep` with prop to customize CTA

### DIFF
--- a/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
@@ -644,7 +644,7 @@ export const UserGuideStepExampleWithCustomCTA = (): ReactElement => {
       header="This is navigation item"
       text="Some text, maximum 210 characters. But can be divided into couple of message. More or less can be up to 4 lines. So let's see how it looks like and let's make it 4 lines. Ok, cool."
       currentStep={1}
-      stepMax={1}
+      stepMax={9}
       cta="Custom CTA"
       handleClickPrimary={() => {}}
       handleCloseAction={() => {}}

--- a/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
@@ -645,7 +645,7 @@ export const UserGuideStepExampleWithCustomCTA = (): ReactElement => {
       text="Some text, maximum 210 characters. But can be divided into couple of message. More or less can be up to 4 lines. So let's see how it looks like and let's make it 4 lines. Ok, cool."
       currentStep={1}
       stepMax={9}
-      cta="Custom CTA"
+      customCta="Custom CTA"
       handleClickPrimary={() => {}}
       handleCloseAction={() => {}}
     />

--- a/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
+++ b/packages/react-components/src/components/UserGuide/UserGuide.stories.tsx
@@ -637,6 +637,24 @@ UserGuideStepExampleWithVideo.parameters = {
   layout: 'centered',
 };
 
+export const UserGuideStepExampleWithCustomCTA = (): ReactElement => {
+  return (
+    <UserGuideStep
+      aria-label="Navigation guide step"
+      header="This is navigation item"
+      text="Some text, maximum 210 characters. But can be divided into couple of message. More or less can be up to 4 lines. So let's see how it looks like and let's make it 4 lines. Ok, cool."
+      currentStep={1}
+      stepMax={1}
+      cta="Custom CTA"
+      handleClickPrimary={() => {}}
+      handleCloseAction={() => {}}
+    />
+  );
+};
+UserGuideStepExampleWithCustomCTA.parameters = {
+  layout: 'centered',
+};
+
 export const UserGuideBubbleStepExample = (): ReactElement => {
   return (
     <UserGuideBubbleStep

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.spec.tsx
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.spec.tsx
@@ -74,4 +74,13 @@ describe('<UserGuideStep> component', () => {
 
     expect(getByRole('button', { name: 'Finish' })).toBeInTheDocument();
   });
+
+  it('should render custom cta when provided', () => {
+    const { getByRole } = renderComponent({
+      ...DEFAULT_PROPS,
+      cta: 'Custom CTA',
+    });
+
+    expect(getByRole('button', { name: 'Custom CTA' })).toBeInTheDocument();
+  });
 });

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.spec.tsx
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.spec.tsx
@@ -78,7 +78,7 @@ describe('<UserGuideStep> component', () => {
   it('should render custom cta when provided', () => {
     const { getByRole } = renderComponent({
       ...DEFAULT_PROPS,
-      cta: 'Custom CTA',
+      customCta: 'Custom CTA',
     });
 
     expect(getByRole('button', { name: 'Custom CTA' })).toBeInTheDocument();

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.tsx
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.tsx
@@ -17,6 +17,7 @@ const baseClass = 'user-guide-step';
 export const UserGuideStep: FC<IUserGuideStepProps> = ({
   header,
   text,
+  cta,
   image,
   video,
   currentStep,
@@ -92,7 +93,7 @@ export const UserGuideStep: FC<IUserGuideStepProps> = ({
             onClick={handleClickPrimary}
             className={styles[`${baseClass}__footer__button-primary`]}
           >
-            {currentStep === stepMax ? 'Finish' : 'Next'}
+            {cta || (currentStep === stepMax ? 'Finish' : 'Next')}
           </Button>
           <span>
             {handleCloseAction && (

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.tsx
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/UserGuideStep.tsx
@@ -17,7 +17,7 @@ const baseClass = 'user-guide-step';
 export const UserGuideStep: FC<IUserGuideStepProps> = ({
   header,
   text,
-  cta,
+  customCta,
   image,
   video,
   currentStep,
@@ -93,7 +93,7 @@ export const UserGuideStep: FC<IUserGuideStepProps> = ({
             onClick={handleClickPrimary}
             className={styles[`${baseClass}__footer__button-primary`]}
           >
-            {cta || (currentStep === stepMax ? 'Finish' : 'Next')}
+            {customCta || (currentStep === stepMax ? 'Finish' : 'Next')}
           </Button>
           <span>
             {handleCloseAction && (

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/types.ts
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/types.ts
@@ -10,6 +10,10 @@ export interface IUserGuideStepProps {
    */
   text: string;
   /**
+   * The cta of the step
+   */
+  cta?: string;
+  /**
    * Set to enable typing animation for the text
    */
   typingAnimation?: boolean;

--- a/packages/react-components/src/components/UserGuide/components/UserGuideStep/types.ts
+++ b/packages/react-components/src/components/UserGuide/components/UserGuideStep/types.ts
@@ -10,9 +10,9 @@ export interface IUserGuideStepProps {
    */
   text: string;
   /**
-   * The cta of the step
+   * The custom button cta of the step
    */
-  cta?: string;
+  customCta?: string;
   /**
    * Set to enable typing animation for the text
    */


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #1656 

## Description
Added `cta` prop to `UserGuideStep` component, test, story.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-1656--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [x] Add correct label
- [x] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User guide steps now support customizable Call-to-Action button labels; displays provided text or falls back to "Next" / "Finish" based on step position.
  * Added an example story demonstrating a step configured with a custom CTA.

* **Tests**
  * Added a test that verifies a custom CTA label renders when supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->