### PR TITLE
chore: add explicit workflow permissions

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -4,6 +4,9 @@ on:
     types: [ opened, edited, synchronize ]
     branches:
       - main
+
+permissions: read-all
+
 jobs:
   check-for-cc:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,6 +7,9 @@ name: 'Chromatic'
 on: push
 
 # List of jobs
+
+permissions: read-all
+
 jobs:
   chromatic-deployment:
     # Operating System

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,9 @@ permissions: read-all
 
 jobs:
   chromatic-deployment:
+    permissions:
+      checks: write
+      statuses: write
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - release
 
+permissions: read-all
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ permissions: read-all
 
 jobs:
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Tests
 on: push
+
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -4,6 +4,9 @@ on:
     types: [opened]
     branches:
       - main
+
+permissions: read-all
+
 jobs:
   update-description:
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/update-pr-description.yml
+++ b/.github/workflows/update-pr-description.yml
@@ -10,6 +10,8 @@ permissions: read-all
 jobs:
   update-description:
     if: github.actor != 'dependabot[bot]'
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Update PR Description


### PR DESCRIPTION
## Workflow Permissions — automated PR

This PR adds explicit `permissions: read-all` to all workflow files that previously lacked a top-level permissions declaration.

> [!WARNING]
> **Some CI jobs may fail after merge** if they rely on write access that is now restricted by `permissions: read-all`. See the checklist below for how to identify and fix this before merging.

### What changed

Every workflow file that previously lacked a top-level `permissions:` declaration now has:

```yaml
permissions: read-all
```

added just before the `jobs:` block.

### Why

Without explicit permissions, workflow jobs inherit the repository or organisation default for GITHUB_TOKEN, which may be full write access. `permissions: read-all` makes all scopes explicitly read-only and eliminates reliance on that default.

### What to check before merging

Scan each workflow job for operations that need write access and add the corresponding permission at job level if missing:

| Operation | Permission needed |
|-----------|-------------------|
| Push commits / create tags | `contents: write` |
| Create / update releases | `contents: write` |
| Create or comment on PRs | `pull-requests: write` |
| Publish packages to GitHub Packages | `packages: write` |
| Write issues or comments | `issues: write` |
| Deploy to GitHub Pages | `pages: write` |
| Request OIDC token (cloud auth) | `id-token: write` |
| Upload to security dashboard | `security-events: write` |

Example — job that needs to push commits and open a PR:

```yaml
jobs:
  release:
    permissions:
      contents: write
      pull-requests: write
    steps:
      - ...
```

Full reference: [GitHub Actions permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

### Review checklist

- [ ] Scan each workflow job for write operations (see table above)
- [ ] Add job-level `permissions:` for any job needing write access
- [ ] Confirm CI is green after merge
- [ ] **Merge into `main`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized top-level workflow permission scopes across CI, tests, release, visual checks, and PR automation.
  * Expanded top-level permissions to ensure workflows run with consistent access.
  * Hardened release process by confining elevated write permissions to the release job and preserving job-specific write permissions where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->