### PR TITLE
chore(release): bump version to v2.38.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.37.1",
+  "version": "2.38.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19699,10 +19699,10 @@
       }
     },
     "packages/example-react": {
-      "version": "2.37.1",
+      "version": "2.38.0",
       "dependencies": {
-        "@livechat/design-system-icons": "^2.37.1",
-        "@livechat/design-system-react-components": "^2.37.1",
+        "@livechat/design-system-icons": "^2.38.0",
+        "@livechat/design-system-react-components": "^2.38.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -19716,7 +19716,7 @@
     },
     "packages/icons": {
       "name": "@livechat/design-system-icons",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "devDependencies": {
         "@svgr/cli": "^8.1.0",
         "glob": "^13.0.0",
@@ -19738,12 +19738,12 @@
     },
     "packages/react-components": {
       "name": "@livechat/design-system-react-components",
-      "version": "2.37.1",
+      "version": "2.38.0",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.25",
         "@livechat/data-utils": "^0.2.16",
-        "@livechat/design-system-icons": "^2.37.1",
+        "@livechat/design-system-icons": "^2.38.0",
         "clsx": "^1.1.1",
         "date-fns": "^2.28.0",
         "lodash.debounce": "^4.0.8",

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -1,15 +1,15 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "2.37.1",
+  "version": "2.38.0",
   "scripts": {
     "start": "vite --open",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@livechat/design-system-icons": "^2.37.1",
-    "@livechat/design-system-react-components": "^2.37.1",
+    "@livechat/design-system-icons": "^2.38.0",
+    "@livechat/design-system-react-components": "^2.38.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-icons",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-react-components",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "description": "",
   "publishConfig": {
     "access": "public"
@@ -70,7 +70,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.25",
     "@livechat/data-utils": "^0.2.16",
-    "@livechat/design-system-icons": "^2.37.1",
+    "@livechat/design-system-icons": "^2.38.0",
     "clsx": "^1.1.1",
     "date-fns": "^2.28.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #{issue-number}

## Description
This pull request updates the version of the design system packages and their dependencies from 2.37.1 to 2.38.0 across the repository. These changes ensure consistency and allow projects to use the latest features and fixes from the design system.

Version updates:

* Bumped the version of the monorepo in `lerna.json` from 2.37.1 to 2.38.0.
* Updated the version of `@livechat/design-system-icons` and `@livechat/design-system-react-components` in `example-react/package.json` to 2.38.0.
* Updated the version of `@livechat/design-system-icons` in `react-components/package.json` to 2.38.0.
* Bumped the version of `@livechat/design-system-icons` package to 2.38.0 in its own `package.json`.
* Bumped the version of `@livechat/design-system-react-components` package to 2.38.0 in its own `package.json`.
## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-undefined--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 2.38.0 released: All design system packages, React components library, and icon packages updated to version 2.38.0
  * Dependencies synchronized: Package dependencies across the monorepo updated to align with the latest release version, ensuring consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->