### PR TITLE
chore(release): bump version to v2.38.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.38.1",
+  "version": "2.38.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20150,10 +20150,10 @@
       }
     },
     "packages/example-react": {
-      "version": "2.38.1",
+      "version": "2.38.2",
       "dependencies": {
-        "@livechat/design-system-icons": "^2.38.1",
-        "@livechat/design-system-react-components": "^2.38.1",
+        "@livechat/design-system-icons": "^2.38.2",
+        "@livechat/design-system-react-components": "^2.38.2",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -20167,7 +20167,7 @@
     },
     "packages/icons": {
       "name": "@livechat/design-system-icons",
-      "version": "2.38.1",
+      "version": "2.38.2",
       "devDependencies": {
         "@svgr/cli": "^8.1.0",
         "glob": "^13.0.0",
@@ -20189,12 +20189,12 @@
     },
     "packages/react-components": {
       "name": "@livechat/design-system-react-components",
-      "version": "2.38.1",
+      "version": "2.38.2",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.25",
         "@livechat/data-utils": "^0.2.16",
-        "@livechat/design-system-icons": "^2.38.1",
+        "@livechat/design-system-icons": "^2.38.2",
         "clsx": "^1.1.1",
         "date-fns": "^2.28.0",
         "lodash.debounce": "^4.0.8",

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -1,15 +1,15 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "2.38.1",
+  "version": "2.38.2",
   "scripts": {
     "start": "vite --open",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@livechat/design-system-icons": "^2.38.1",
-    "@livechat/design-system-react-components": "^2.38.1",
+    "@livechat/design-system-icons": "^2.38.2",
+    "@livechat/design-system-react-components": "^2.38.2",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-icons",
-  "version": "2.38.1",
+  "version": "2.38.2",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-react-components",
-  "version": "2.38.1",
+  "version": "2.38.2",
   "description": "",
   "publishConfig": {
     "access": "public"
@@ -70,7 +70,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.25",
     "@livechat/data-utils": "^0.2.16",
-    "@livechat/design-system-icons": "^2.38.1",
+    "@livechat/design-system-icons": "^2.38.2",
     "clsx": "^1.1.1",
     "date-fns": "^2.28.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
## Description

This pull request bumps the design system package versions from 2.38.1 to 2.38.2 in preparation for the next release.

### Version bumps

- `@livechat/design-system-icons`: 2.38.1 → 2.38.2
- `@livechat/design-system-react-components`: 2.38.1 → 2.38.2
- `@livechat/design-system-metrics`: unchanged (2.4.4 — no source changes since last release)
- `example-react` (private): 2.38.1 → 2.38.2 (workspace bookkeeping)

Determined by `lerna version --conventional-commits` (patch bump).

### What's included since v2.38.1

All security-focused dependency hardening — no consumer-facing API changes:

- `chore(deps): bump vitest to 4.1.7` to resolve critical UI server CVE (#1727)
- `chore(deps): update ip-address to ^10.1.1` to resolve XSS CVE (#1723)
- `chore(deps): update postcss to ^8.5.10` to resolve XSS CVE (#1722)
- `chore(deps): update brace-expansion to ^2.0.3` to resolve DoS CVE (#1724)
- `chore(deps): update uuid to ^11.1.1` to resolve buffer bounds CVE (#1725)
- `chore(deps): update tmp to ^0.2.6` to resolve path traversal CVE (#1721)
- `chore: add Aikido Safe Chain to CI workflows` (#1720)

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.38.2 with synchronized version updates across all packages, including icons, React components, and example applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->