### PR TITLE
chore(release): bump version to v2.38.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.38.2",
+  "version": "2.38.3",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20231,10 +20231,10 @@
       }
     },
     "packages/example-react": {
-      "version": "2.38.2",
+      "version": "2.38.3",
       "dependencies": {
-        "@livechat/design-system-icons": "^2.38.2",
-        "@livechat/design-system-react-components": "^2.38.2",
+        "@livechat/design-system-icons": "^2.38.3",
+        "@livechat/design-system-react-components": "^2.38.3",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -20248,7 +20248,7 @@
     },
     "packages/icons": {
       "name": "@livechat/design-system-icons",
-      "version": "2.38.2",
+      "version": "2.38.3",
       "devDependencies": {
         "@svgr/cli": "^8.1.0",
         "glob": "^13.0.0",
@@ -20270,12 +20270,12 @@
     },
     "packages/react-components": {
       "name": "@livechat/design-system-react-components",
-      "version": "2.38.2",
+      "version": "2.38.3",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.25",
         "@livechat/data-utils": "^0.2.16",
-        "@livechat/design-system-icons": "^2.38.2",
+        "@livechat/design-system-icons": "^2.38.3",
         "clsx": "^1.1.1",
         "date-fns": "^2.28.0",
         "lodash.debounce": "^4.0.8",

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -1,15 +1,15 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "2.38.2",
+  "version": "2.38.3",
   "scripts": {
     "start": "vite --open",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@livechat/design-system-icons": "^2.38.2",
-    "@livechat/design-system-react-components": "^2.38.2",
+    "@livechat/design-system-icons": "^2.38.3",
+    "@livechat/design-system-react-components": "^2.38.3",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-icons",
-  "version": "2.38.2",
+  "version": "2.38.3",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-react-components",
-  "version": "2.38.2",
+  "version": "2.38.3",
   "description": "",
   "publishConfig": {
     "access": "public"
@@ -70,7 +70,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.25",
     "@livechat/data-utils": "^0.2.16",
-    "@livechat/design-system-icons": "^2.38.2",
+    "@livechat/design-system-icons": "^2.38.3",
     "clsx": "^1.1.1",
     "date-fns": "^2.28.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
<!--- Issue number will be inserted automatically if properly defined -->
Resolves: #{issue-number}

## Description

This pull request updates the version numbers for the design system packages and their dependencies across the monorepo to 2.38.3. This ensures consistency and prepares the packages for the new release.

Version and dependency updates:

* Bumped the version of `@livechat/design-system-icons` to 2.38.3 in its `package.json`.
* Bumped the version of `@livechat/design-system-react-components` to 2.38.3 in its `package.json` and updated its dependency on `@livechat/design-system-icons` to 2.38.3 [[1]](diffhunk://#diff-6adad24655c6ad668b62d38efb24e18aa0dbb3c97e4243fc83d43338bb96e6ecL3-R3) [[2]](diffhunk://#diff-6adad24655c6ad668b62d38efb24e18aa0dbb3c97e4243fc83d43338bb96e6ecL73-R73).
* Updated the version of the `example-react` package and its dependencies on both `@livechat/design-system-icons` and `@livechat/design-system-react-components` to 2.38.3.
* Updated the monorepo version in `lerna.json` to 2.38.3.


## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.38.3 with synchronized package and dependency versions across the design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->