### PR TITLE
feat(ProductSwitcher): update ChatBot and HelpDesk display names to ChatBot.com and HelpDesk.com

### DIFF
--- a/packages/react-components/src/components/ProductSwitcher/constants.ts
+++ b/packages/react-components/src/components/ProductSwitcher/constants.ts
@@ -25,7 +25,7 @@ export const ProductSwitcherProducts: ProductOption[] = [
   },
   {
     id: 'chatbot',
-    name: 'ChatBot',
+    name: 'ChatBot.com',
     icon: ChatBotMono,
     backgroundColors: {
       main: 'var(--products-chatbot)',
@@ -36,7 +36,7 @@ export const ProductSwitcherProducts: ProductOption[] = [
   },
   {
     id: 'helpdesk',
-    name: 'HelpDesk',
+    name: 'HelpDesk.com',
     icon: HelpDeskMono,
     backgroundColors: {
       main: 'var(--products-helpdesk)',


### PR DESCRIPTION
Resolves: GRT-542

## Description

Updates the display names shown in the Product Switcher from `ChatBot` / `HelpDesk` to `ChatBot.com` / `HelpDesk.com`, matching the current product branding.

This is scoped to the display label only (`ProductOption.name`, a plain `string`). It intentionally does **not** touch the `ProductName` type, `SSOProductIdMap`, or the `product` field in the redirect-data constants — those are used as identifiers compared against `installedProducts` data supplied by consuming apps, and renaming them would be a breaking change requiring coordinated backend updates. That can be handled as a separate, deliberate change if/when needed.

## Storybook

https://feature-GRT-542--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [x] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated product names in the product switcher to display “ChatBot.com” and “HelpDesk.com.”


<!-- end of auto-generated comment: release notes by coderabbit.ai -->