### PR TITLE
chore(release): bump version to v2.39.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.39.0",
+  "version": "2.39.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19224,10 +19224,10 @@
       }
     },
     "packages/example-react": {
-      "version": "2.39.0",
+      "version": "2.39.1",
       "dependencies": {
-        "@livechat/design-system-icons": "^2.39.0",
-        "@livechat/design-system-react-components": "^2.39.0",
+        "@livechat/design-system-icons": "^2.39.1",
+        "@livechat/design-system-react-components": "^2.39.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -19241,7 +19241,7 @@
     },
     "packages/icons": {
       "name": "@livechat/design-system-icons",
-      "version": "2.39.0",
+      "version": "2.39.1",
       "devDependencies": {
         "@svgr/cli": "^8.1.0",
         "glob": "^13.0.0",
@@ -19263,12 +19263,12 @@
     },
     "packages/react-components": {
       "name": "@livechat/design-system-react-components",
-      "version": "2.39.0",
+      "version": "2.39.1",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.25",
         "@livechat/data-utils": "^0.2.16",
-        "@livechat/design-system-icons": "^2.39.0",
+        "@livechat/design-system-icons": "^2.39.1",
         "clsx": "^1.1.1",
         "date-fns": "^2.28.0",
         "lodash.debounce": "^4.0.8",

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -1,15 +1,15 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "2.39.0",
+  "version": "2.39.1",
   "scripts": {
     "start": "vite --open",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@livechat/design-system-icons": "^2.39.0",
-    "@livechat/design-system-react-components": "^2.39.0",
+    "@livechat/design-system-icons": "^2.39.1",
+    "@livechat/design-system-react-components": "^2.39.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-icons",
-  "version": "2.39.0",
+  "version": "2.39.1",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-react-components",
-  "version": "2.39.0",
+  "version": "2.39.1",
   "description": "",
   "publishConfig": {
     "access": "public"
@@ -70,7 +70,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.25",
     "@livechat/data-utils": "^0.2.16",
-    "@livechat/design-system-icons": "^2.39.0",
+    "@livechat/design-system-icons": "^2.39.1",
     "clsx": "^1.1.1",
     "date-fns": "^2.28.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
## Description

Maintenance / security release (**v2.39.0 → v2.39.1**). Bundles the PRs merged since the last release. No changes to published component APIs or runtime behavior — dependency **overrides** and dev/build tooling only.

### Security — remaining Dependabot advisories resolved (#1748)

Raised the `overrides` floors (several were still pinned to vulnerable versions) so transitive dev/build dependencies resolve to patched releases. Result: `npm audit` → **0 vulnerabilities**.

| Package | Override → | Advisory |
|---|---|---|
| fast-uri | `^3.1.4` | GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6 |
| immutable | `^4.3.9` | GHSA-xvcm-6775-5m9r, GHSA-v56q-mh7h-f735 |
| axios | `^1.18.0` (added) | 5 advisories (alerts 461/463/466/479/480) |
| shell-quote | `^1.9.0` | GHSA-395f-4hp3-45gv |
| js-yaml | `^4.3.0` | GHSA-52cp-r559-cp3m |
| svgo | `^3.3.4` | GHSA-2p49-hgcm-8545 |
| brace-expansion | `5.0.8` | GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg |
| minimatch | `<3.1.4` → `3.1.4` | GHSA-23c5-xmqv-rm74 |
| ajv | `@6 ^6.14.0`, `@8 ^8.18.0` | GHSA-2g4f-4pwh-qvx6 |
| postcss | `^8.5.18` | GHSA-r28c-9q8g-f849 |

The last four (brace-expansion `mh99`, minimatch, ajv, postcss) were newer advisories not yet in the Dependabot list; cleared proactively to reach `audit = 0`.

### Tooling — lerna 8 → 9 (#1730)

Bumps `lerna` `^8.2.3` → `^9.0.7` (drops the transitive `uuid` dependency).

### Validation

`npm run build` ✓ · **517 tests pass** ✓ · CI (build + Chromatic UI tests) green on the source PRs · all patched versions verified aged past CI safe-chain's minimum-package-age gate.

## Storybook

<!--- Branch name will be inserted automatically -->
https://feature-undefined--613a8e945a5665003a05113b.chromatic.com

## Checklist

**Obligatory:**

- [ ] Self review (use this as your final check for proposed changes before requesting the review)
- [ ] Add correct label
- [ ] Assign pull request with the correct issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.39.1 across the design system packages.
  * Updated internal package references to use the matching 2.39.1 release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->