### PR TITLE
chore(release): bump version to v2.39.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.39.1",
+  "version": "2.39.2",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19096,10 +19096,10 @@
       }
     },
     "packages/example-react": {
-      "version": "2.39.1",
+      "version": "2.39.2",
       "dependencies": {
-        "@livechat/design-system-icons": "^2.39.1",
-        "@livechat/design-system-react-components": "^2.39.1",
+        "@livechat/design-system-icons": "^2.39.2",
+        "@livechat/design-system-react-components": "^2.39.2",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
       },
@@ -19113,7 +19113,7 @@
     },
     "packages/icons": {
       "name": "@livechat/design-system-icons",
-      "version": "2.39.1",
+      "version": "2.39.2",
       "devDependencies": {
         "@svgr/cli": "^8.1.0",
         "glob": "^13.0.0",
@@ -19135,12 +19135,12 @@
     },
     "packages/react-components": {
       "name": "@livechat/design-system-react-components",
-      "version": "2.39.1",
+      "version": "2.39.2",
       "license": "ISC",
       "dependencies": {
         "@floating-ui/react": "^0.26.25",
         "@livechat/data-utils": "^0.2.16",
-        "@livechat/design-system-icons": "^2.39.1",
+        "@livechat/design-system-icons": "^2.39.2",
         "clsx": "^1.1.1",
         "date-fns": "^2.28.0",
         "lodash.debounce": "^4.0.8",

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -1,15 +1,15 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "2.39.1",
+  "version": "2.39.2",
   "scripts": {
     "start": "vite --open",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@livechat/design-system-icons": "^2.39.1",
-    "@livechat/design-system-react-components": "^2.39.1",
+    "@livechat/design-system-icons": "^2.39.2",
+    "@livechat/design-system-react-components": "^2.39.2",
     "react": "^18.3.0",
     "react-dom": "^18.3.0"
   },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-icons",
-  "version": "2.39.1",
+  "version": "2.39.2",
   "description": "",
   "publishConfig": {
     "access": "public"

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@livechat/design-system-react-components",
-  "version": "2.39.1",
+  "version": "2.39.2",
   "description": "",
   "publishConfig": {
     "access": "public"
@@ -70,7 +70,7 @@
   "dependencies": {
     "@floating-ui/react": "^0.26.25",
     "@livechat/data-utils": "^0.2.16",
-    "@livechat/design-system-icons": "^2.39.1",
+    "@livechat/design-system-icons": "^2.39.2",
     "clsx": "^1.1.1",
     "date-fns": "^2.28.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
## Summary

- prepare the `2.39.2` patch release after the AC-4477 security dependency updates
- bump `@livechat/design-system-icons` and `@livechat/design-system-react-components` from `2.39.1` to `2.39.2`
- update internal workspace dependency ranges and lockfile metadata

## Verification

- `npm run prepare-release`
  - lint passed
  - 517 tests passed
  - production builds passed
- `npm run deploy:dry-run`
  - `@livechat/design-system-icons@2.39.2`
  - `@livechat/design-system-react-components@2.39.2`

Related: [AC-4477](https://livechatinc.atlassian.net/browse/AC-4477)


[AC-4477]: https://livechatinc.atlassian.net/browse/AC-4477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ