### PR TITLE
build(deps): override smol-toml to 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16548,10 +16548,11 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
       },

--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
     "react-scanner": {
       "picomatch": "4.0.4"
     },
+    "nx": {
+      "smol-toml": "1.7.1"
+    },
     "@microsoft/api-extractor": "7.58.2",
     "vite-plugin-dts": {
       "@microsoft/api-extractor": {


### PR DESCRIPTION
## Summary

- override the vulnerable transitive `smol-toml@1.6.1` used by Nx with patched `1.7.1`
- scope the override to Nx instead of applying it repository-wide
- resolve the High-severity Dependabot alert tracked in [AC-4477](https://livechatinc.atlassian.net/browse/AC-4477)

Nx currently hard-pins `smol-toml@1.6.1`. The latest compatible Nx 22 release, as well as Nx 23.2.1, still uses that vulnerable version, so a parent-package bump cannot resolve the alert yet.

Dependabot alert: https://github.com/livechat/design-system/security/dependabot/507

## Validation

- `npm explain smol-toml` resolves `1.7.1` through the scoped override
- `npm audit` reports 0 High and 0 Critical vulnerabilities
- `npm test`
- `npm run build`
- commit hooks and TypeScript type-check

[AC-4477]: https://livechatinc.atlassian.net/browse/AC-4477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ